### PR TITLE
fix: ACM asian detection

### DIFF
--- a/src/trackers/ACM.py
+++ b/src/trackers/ACM.py
@@ -259,9 +259,9 @@ class ACM:
         ``origin_country`` is not available — co-productions with Asian studios
         (e.g. a US show filmed with a Japanese partner) should not qualify.
         """
-        origin_codes: list[str] = meta.get("origin_country", []) or []
+        origin_codes = [c.strip().upper() for c in (meta.get("origin_country", []) or []) if isinstance(c, str) and c.strip()]
         if origin_codes:
-            return any(code.upper() in self.ASIAN_COUNTRIES for code in origin_codes)
+            return any(code in self.ASIAN_COUNTRIES for code in origin_codes)
 
         # Fallback: origin_country not provided — check production_countries
         production_countries: list[dict[str, str]] = meta.get("production_countries", []) or []

--- a/tests/test_acm.py
+++ b/tests/test_acm.py
@@ -137,3 +137,18 @@ class TestCheckAsianOrigin:
         acm = ACM(_config())
         meta = _meta(origin_country=["jp"])
         assert acm.check_asian_origin(meta) is True
+
+    def test_empty_strings_in_origin_fallback(self):
+        """origin_country with only empty/blank strings should fall back to production_countries."""
+        acm = ACM(_config())
+        meta = _meta(
+            origin_country=["", "  ", None],
+            production_countries=[{"iso_3166_1": "KR", "name": "South Korea"}],
+        )
+        assert acm.check_asian_origin(meta) is True
+
+    def test_empty_strings_in_origin_no_fallback(self):
+        """origin_country with only empty strings and no production data should reject."""
+        acm = ACM(_config())
+        meta = _meta(origin_country=["", None], production_countries=[])
+        assert acm.check_asian_origin(meta) is False


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Asian origin detection: the system now prioritizes the declared origin country and only falls back to production countries when origin is missing, reducing misclassification of co-productions.

* **Tests**
  * Added comprehensive unit tests validating origin detection across origin country values, production country fallbacks, mixed-origin cases, empty/None data, and case-insensitive country codes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->