### PR TITLE
fix(A4K): check bitrate independently of Encoded_Library_Settings 

### DIFF
--- a/src/trackers/A4K.py
+++ b/src/trackers/A4K.py
@@ -75,33 +75,33 @@ class A4K(UNIT3D):
         # check bitrate requirements for A4K uploads, but only if it's not a disc upload since discs can have variable bitrates and A4K doesn't specify bitrate requirements for disc uploads
         if not meta["is_disc"] and meta["type"] in ["ENCODE", "WEBDL"]:
             tracks = meta.get("mediainfo", {}).get("media", {}).get("track", [])
-            for track in tracks:
-                if track.get("@type") == "Video":
-                    bit_rate = track.get("BitRate")
-                    if bit_rate:
-                        try:
-                            bit_rate_num = int(bit_rate)
-                        except (ValueError, TypeError):
-                            bit_rate_num = None
+            video_track = next((t for t in tracks if t.get("@type") == "Video"), None)
+            if video_track is None:
+                console.print(f"[bold red]Could not determine video bitrate from mediainfo for {self.tracker} upload.[/bold red]")
+                console.print("[yellow]Bitrate must be above 15000 kbps for movies and 10000 kbps for TV shows.[/yellow]")
+                if not meta.get("unattended", False) or meta.get("unattended_confirm", False):
+                    if not cli_ui.ask_yes_no("Do you want to upload anyway?", default=False):
+                        return False
+                else:
+                    return False
+            else:
+                bit_rate = video_track.get("BitRate")
+                if bit_rate:
+                    try:
+                        bit_rate_num = int(bit_rate)
+                    except (ValueError, TypeError):
+                        bit_rate_num = None
 
-                        if bit_rate_num is not None:
-                            bit_rate_kbps = bit_rate_num / 1000
-                            if meta.get("category") == "MOVIE" and bit_rate_kbps < 15000:
-                                if not meta.get("unattended", False):
-                                    console.print(f"Video bitrate too low: {bit_rate_kbps:.0f} kbps for A4K movie uploads.")
-                                return False
-                            elif meta.get("category") == "TV" and bit_rate_kbps < 10000:
-                                if not meta.get("unattended", False):
-                                    console.print(f"Video bitrate too low: {bit_rate_kbps:.0f} kbps for A4K TV uploads.")
-                                return False
-                        else:
-                            console.print(f"[bold red]Could not determine video bitrate from mediainfo for {self.tracker} upload.[/bold red]")
-                            console.print("[yellow]Bitrate must be above 15000 kbps for movies and 10000 kbps for TV shows.[/yellow]")
-                            if not meta.get("unattended", False) or meta.get("unattended_confirm", False):
-                                if not cli_ui.ask_yes_no("Do you want to upload anyway?", default=False):
-                                    return False
-                            else:
-                                return False
+                    if bit_rate_num is not None:
+                        bit_rate_kbps = bit_rate_num / 1000
+                        if meta.get("category") == "MOVIE" and bit_rate_kbps < 15000:
+                            if not meta.get("unattended", False):
+                                console.print(f"Video bitrate too low: {bit_rate_kbps:.0f} kbps for A4K movie uploads.")
+                            return False
+                        elif meta.get("category") == "TV" and bit_rate_kbps < 10000:
+                            if not meta.get("unattended", False):
+                                console.print(f"Video bitrate too low: {bit_rate_kbps:.0f} kbps for A4K TV uploads.")
+                            return False
                     else:
                         console.print(f"[bold red]Could not determine video bitrate from mediainfo for {self.tracker} upload.[/bold red]")
                         console.print("[yellow]Bitrate must be above 15000 kbps for movies and 10000 kbps for TV shows.[/yellow]")
@@ -110,6 +110,14 @@ class A4K(UNIT3D):
                                 return False
                         else:
                             return False
+                else:
+                    console.print(f"[bold red]Could not determine video bitrate from mediainfo for {self.tracker} upload.[/bold red]")
+                    console.print("[yellow]Bitrate must be above 15000 kbps for movies and 10000 kbps for TV shows.[/yellow]")
+                    if not meta.get("unattended", False) or meta.get("unattended_confirm", False):
+                        if not cli_ui.ask_yes_no("Do you want to upload anyway?", default=False):
+                            return False
+                    else:
+                        return False
 
         return should_continue
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Streamlined bitrate validation by reading the primary video track bitrate directly.
  * Enforced thresholds: movies require ≥15,000 kbps, TV require ≥10,000 kbps.
  * Improved handling when bitrate is missing or unparsable: clearer diagnostics, interactive prompts for upload decisions, and safe failure for non-interactive (unattended) checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->