### PR TITLE
[TOS] Check bitrate of video

### DIFF
--- a/src/trackers/TOS.py
+++ b/src/trackers/TOS.py
@@ -361,100 +361,101 @@ class TOS(FrenchTrackerMixin, UNIT3D):
             console.print(f"[red]{self.tracker}: Scene release detected but no NFO file found. TOS requires NFO files for Scene releases.[/red]")
             return False
 
-        # Check minimum bitrate requirement
-        x264req = { 
-            "720p" : {
-              "WEBDL" : 3000,
-              "ENCODE" : 4000 
+        # ── Minimum bitrate requirements (kbps) per codec / resolution / type ──
+        # Anime has lower thresholds per TOS rules.
+        is_anime = bool(meta.get("anime", False))
+
+        bitrate_minimums: dict[str, dict[str, dict[str, int]]] = {
+            "x264": {
+                "720p": {"WEBDL": 3000, "ENCODE": 4000},
+                "1080p": {"WEBDL": 5000, "ENCODE": 8000},
+                "2160p": {"WEBDL": 10000, "ENCODE": 16000},
             },
-            "1080p" : {
-              "WEBDL" : 5000,
-              "ENCODE" : 8000
+            "x265": {
+                "720p": {"WEBDL": 2000, "ENCODE": 3000},
+                "1080p": {"WEBDL": 3500, "ENCODE": 6000},
+                "2160p": {"WEBDL": 8000, "ENCODE": 12000},
             },
-            "2160p" : {
-              "WEBDL" : 10000,
-              "ENCODE" : 16000,
+            "AV1": {
+                "720p": {"WEBDL": 2000, "ENCODE": 2400},
+                "1080p": {"WEBDL": 3000, "ENCODE": 4000},
+                "2160p": {"WEBDL": 5000, "ENCODE": 8000},
             },
-        }
-        x265req = { 
-            "720p" : {
-              "WEBDL" : 2000,
-              "ENCODE" : 3000 
-            },
-            "1080p" : {
-              "WEBDL" : 3500,
-              "ENCODE" : 6000
-            },
-            "2160p" : {
-              "WEBDL" : 8000,
-              "ENCODE" : 12000,
-            }
-        }
-        AV1req = { 
-            "720p" : {
-              "WEBDL" : 2000,
-              "ENCODE" : 2400 
-            },
-            "1080p" : {
-              "WEBDL" : 3000,
-              "ENCODE" : 4000
-            },
-            "2160p" : {
-              "WEBDL" : 5000,
-              "ENCODE" : 8000,
-            }
         }
 
-        if not meta["is_disc"] and meta["type"] in ["ENCODE", "WEBDL"]:
-            bitrateError= False
-            tracks = meta.get("mediainfo", {}).get("media", {}).get("track", [])
-            video_track = next((t for t in tracks if t.get("@type") == "Video"), None)
-            if video_track is None:
-                console.print(f"[bold red]Could not determine video bitrate from mediainfo for {self.tracker} upload.[/bold red]")
-                bitrateError = True
+        anime_minimums: dict[str, dict[str, dict[str, int]]] = {
+            "x264": {
+                "720p": {"WEBDL": 1800, "ENCODE": 2300},
+                "1080p": {"WEBDL": 3000, "ENCODE": 5000},
+                "2160p": {"WEBDL": 6000, "ENCODE": 10000},
+            },
+            "x265": {
+                "720p": {"WEBDL": 1200, "ENCODE": 1800},
+                "1080p": {"WEBDL": 2000, "ENCODE": 3500},
+                "2160p": {"WEBDL": 4000, "ENCODE": 8000},
+            },
+            "AV1": {
+                "720p": {"WEBDL": 1200, "ENCODE": 1500},
+                "1080p": {"WEBDL": 1500, "ENCODE": 2000},
+                "2160p": {"WEBDL": 3000, "ENCODE": 4000},
+            },
+        }
+
+        # Map video_codec values to our table keys
+        codec_map: dict[str, str] = {
+            "H264": "x264",
+            "x264": "x264",
+            "AVC": "x264",
+            "H265": "x265",
+            "x265": "x265",
+            "HEVC": "x265",
+            "AV1": "AV1",
+        }
+
+        bitrate_error = False
+        thresholds_table = anime_minimums if is_anime else bitrate_minimums
+
+        if not meta.get("is_disc") and meta.get("type") in ("ENCODE", "WEBDL"):
+            resolution = meta.get("resolution", "")
+            release_type = meta.get("type", "")
+            video_codec = meta.get("video_codec", "")
+            codec_key = codec_map.get(video_codec)
+
+            if not codec_key:
+                if meta.get("debug"):
+                    console.print(f"[dim]{self.tracker}: No bitrate rules for codec '{video_codec}' — skipping check.[/dim]")
+            elif resolution not in thresholds_table.get(codec_key, {}):
+                if meta.get("debug"):
+                    console.print(f"[dim]{self.tracker}: No bitrate rules for {codec_key} at {resolution} — skipping check.[/dim]")
             else:
-                bit_rate = video_track.get("BitRate")
-                if bit_rate:
-                    try:
-                        bit_rate_num = int(bit_rate)
-                    except (ValueError, TypeError):
-                        bit_rate_num = None
-
-                    if bit_rate_num is not None:
-                        bit_rate_kbps = bit_rate_num / 1000
-                        if meta["video_codec"] in ["H264", "x264", "AVC"]:
-                            if x264req[meta["resolution"]][meta["type"]] > bit_rate_kbps:
-                                minBitrate = x264req[meta["resolution"]][meta["type"]]
-                                console.print(f"[bold red]Video bitrate too low: {bit_rate_kbps:.0f} kbps for x264.[/bold red]")
-                                console.print(f"[bold yellow]Must be > { minBitrate } kbps for { meta["resolution"] }[/bold yellow]")
-                                console.print(f"Except for Anime : 2300/5000/- (BluRay) and 1800/3000/6000 (WEBDL) (720/10808/2160p)")
-                                bitrateError = True
-                        if meta["video_codec"] in ["H265", "x265", "HEVC"]:
-                            if x265req[meta["resolution"]][meta["type"]] > bit_rate_kbps:
-                                minBitrate = x265req[meta["resolution"]][meta["type"]]
-                                console.print(f"[bold red]Video bitrate too low: {bit_rate_kbps:.0f} kbps for x265.[/bold red]")
-                                console.print(f"[bold yellow]Must be > { minBitrate } kbps for { meta["resolution"] }[/bold yellow]")
-                                console.print(f"Except for Anime : 1800/3500/8000 (BluRay) and 1200/2000/4000 (WEBDL) (720/10808/2160p)")
-                                bitrateError = True
-                        if meta["video_codec"] == "AV1":
-                            if AV1req[meta["resolution"]][meta["type"]] > bit_rate_kbps:
-                                minBitrate = AV1req[meta["resolution"]][meta["type"]]
-                                console.print(f"[bold red]Video bitrate too low: {bit_rate_kbps:.0f} kbps for AV1.[/bold red]")
-                                console.print(f"[bold yellow]Must be > { minBitrate } kbps for { meta["resolution"] }[/bold yellow]")
-                                console.print(f"Except for Anime : 10 bits mandatory (BluRay) and 1200/1500/3000 (WEBDL) (720/10808/2160p)")
-                                bitrateError = True
-                    else:
-                        console.print(f"[bold red]Could not determine video bitrate from mediainfo for {self.tracker} upload.[/bold red]")
-                        bitrateError = True
-                else:
+                min_kbps = thresholds_table[codec_key][resolution][release_type]
+                tracks = meta.get("mediainfo", {}).get("media", {}).get("track", [])
+                video_track = next((t for t in tracks if t.get("@type") == "Video"), None)
+                if video_track is None:
                     console.print(f"[bold red]Could not determine video bitrate from mediainfo for {self.tracker} upload.[/bold red]")
-                    bitrateError = True
-        if (bitrateError):
-            if not meta.get("unattended", False):
-                return cli_ui.ask_yes_no("Do you want to upload anyway?", default=False)
-            else:
+                    bitrate_error = True
+                else:
+                    raw_br = video_track.get("BitRate")
+                    try:
+                        bit_rate_kbps = int(raw_br) / 1000 if raw_br else None
+                    except (ValueError, TypeError):
+                        bit_rate_kbps = None
+
+                    if bit_rate_kbps is None:
+                        console.print(f"[bold red]Could not determine video bitrate from mediainfo for {self.tracker} upload.[/bold red]")
+                        bitrate_error = True
+                    elif bit_rate_kbps < min_kbps:
+                        label = f"{codec_key} (anime)" if is_anime else codec_key
+                        console.print(f"[bold red]{self.tracker}: Video bitrate too low: {bit_rate_kbps:.0f} kbps for {label}.[/bold red]")
+                        console.print(f"[bold yellow]Must be >= {min_kbps} kbps for {resolution}.[/bold yellow]")
+                        bitrate_error = True
+
+        if bitrate_error:
+            if meta.get("unattended", False):
                 return False
-        return True 
+            return cli_ui.ask_yes_no("Do you want to upload anyway?", default=False)
+
+        return True
 
     async def _build_audio_string(self, meta):
         """Build the language tag following French tracker conventions.


### PR DESCRIPTION
TOS requires a minimum bitrate depending on the video codec. I added a comparison with or without validation of the upload (especially if it's ANIME, where a lower bitrate is accepted).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime bitrate validation for video uploads with codec- and resolution-specific thresholds (x264/x265/AV1 across 720p/1080p/2160p).
  * Uploads with missing or below-threshold bitrate now prompt users to confirm or abort; unattended uploads follow a fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->