### PR TITLE
fix(C411): update MULTI.VFQ tag mapping from 4 to 5

### DIFF
--- a/src/trackers/C411.py
+++ b/src/trackers/C411.py
@@ -585,7 +585,7 @@ class C411(FrenchTrackerMixin):
         tag_map: dict[str, int] = {
             "MULTI.VF2": 422,
             "MULTI.VFF": 4,
-            "MULTI.VFQ": 4,
+            "MULTI.VFQ": 5,
             "MULTI.VOF": 4,
             "MULTI.TRUEFRENCH": 4,
             "MULTI": 4,


### PR DESCRIPTION
Description:
 Summary
- Corrected `MULTI.VFQ` tag mapping from `4` to `5` in C411 tracker
 Explanation
Based on the language ID mappings:
| ID | Language |
|----|----------|
| 4 | Multi (Français inclus) |
| **5** | **Multi (Québecois inclus)** |
`VFQ` (Québecois French) should map to ID **5** (Multi with Québecois included), not ID 4 (Multi with French included).
This fix ensures proper categorization of Quebec French releases in the tracker

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated language option mapping configuration to improve accuracy with language selection handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->