### PR TITLE
feat: add HDF (HD-Forever) tracker support

### DIFF
--- a/data/example-config.py
+++ b/data/example-config.py
@@ -364,7 +364,7 @@ config = {
 
     "TRACKERS": {
         # Which trackers do you want to upload to?
-        # Available tracker: A4K, ACM, AITHER, ANT, AR, ASC, AZ, BHD, BHDTV, BJS, BLU, BT, C411, CBR, CZ, DC, DP, DT, EMUW, FF, FL, FNP, FRIKI, GPW, HDB, HDS, HDT, HHD, HUNO, IHD, IS, ITT, LCD, LDU, LST, LT, LUME, MTV, NBL, OE, OTW, PHD, PT, PTER, PTP, PTS, PTT, R4E, RAS, RF, RTF, SAM, SHRI, SN, SP, SPD, STC, THR, TIK, TL, TLZ, TORR9, TOS, TTG, TTR, TVC, ULCX, UTP, YOINK, YUS
+        # Available tracker: A4K, ACM, AITHER, ANT, AR, ASC, AZ, BHD, BHDTV, BJS, BLU, BT, C411, CBR, CZ, DC, DP, DT, EMUW, FF, FL, FNP, FRIKI, GPW, HDB, HDF, HDS, HDT, HHD, HUNO, IHD, IS, ITT, LCD, LDU, LST, LT, LUME, MTV, NBL, OE, OTW, PHD, PT, PTER, PTP, PTS, PTT, R4E, RAS, RF, RTF, SAM, SHRI, SN, SP, SPD, STC, THR, TIK, TL, TLZ, TORR9, TOS, TTG, TTR, TVC, ULCX, UTP, YOINK, YUS
         # Only add the trackers you want to upload to on a regular basis
         "default_trackers": "",
 
@@ -602,6 +602,18 @@ config = {
             # Mon profil > Réglages > Passkey
             "announce_url": "https://generation-free.org/announce/PasskeyHere",
             "anon": False,
+        },
+        "HDF": {
+            # Instead of using the tracker acronym for folder name when sym/hard linking, you can use a custom name
+            "link_dir_name": "",
+            # hdf.world — HD-Forever (French private tracker, cookie-based)
+            # Export cookies from https://hdf.world/ using a browser extension (e.g. "cookies.txt" for Firefox).
+            # Cookies must be in Netscape format and saved to data/cookies/HDF.txt
+            # Your personal announce URL is on hdf.world/upload.php (labelled "Votre annonce URL personnelle")
+            "announce_url": "https://hdf.world/announce.php?passkey=<PASSKEY>",
+            "anon": False,
+            # Include screenshots in the upload description (default: False)
+            "include_screenshots": False,
         },
         "GPW": {
             "link_dir_name": "",

--- a/src/trackers/HDF.py
+++ b/src/trackers/HDF.py
@@ -1,0 +1,762 @@
+# Upload Assistant © 2025 Audionut & wastaken7 — Licensed under UAPL v1.0
+"""
+hdf.world — HD-Forever (French private tracker, cookie-based HTML form upload)
+
+Upload endpoint:  POST https://hdf.world/upload.php
+Authentication:   Session cookies (Netscape cookie file)
+Content-Type:     multipart/form-data
+
+The tracker uses a classic PHP upload form with TMDB integration.
+"""
+
+import contextlib
+import os
+import platform
+import re
+from datetime import datetime
+from typing import Any, Optional, Union
+
+import aiofiles
+import httpx
+from bs4 import BeautifulSoup, Tag
+
+from src.console import console
+from src.cookie_auth import CookieAuthUploader, CookieValidator
+from src.nfo_generator import SceneNfoGenerator
+from src.tmdb import TmdbManager
+from src.trackers.FRENCH import FrenchTrackerMixin
+
+Meta = dict[str, Any]
+Config = dict[str, Any]
+
+FRENCH_MONTHS: list[str] = [
+    "",
+    "janvier",
+    "février",
+    "mars",
+    "avril",
+    "mai",
+    "juin",
+    "juillet",
+    "août",
+    "septembre",
+    "octobre",
+    "novembre",
+    "décembre",
+]
+
+# ── Banned groups (from HDF rules) ────────────────────────────────────
+_BANNED_GROUPS: list[str] = [
+    "EXTREME",
+    "RARBG",
+    "FGT",
+    "HDMIDIMADRIDI",
+    "Foxhound",
+    "HDSpace",
+    "FL3ER",
+    "SUNS3T",
+    "WoLFHD",
+]
+
+
+class HDF(FrenchTrackerMixin):
+    """HD-Forever (hdf.world) — French private tracker with cookie-based auth."""
+
+    def __init__(self, config: Config) -> None:
+        self.config: Config = config
+        self.cookie_validator = CookieValidator(config)
+        self.cookie_auth_uploader = CookieAuthUploader(config)
+        self.tracker: str = "HDF"
+        self.source_flag: str = "HDF"
+        self.base_url: str = "https://hdf.world"
+        self.upload_url: str = f"{self.base_url}/upload.php"
+        self.torrent_url: str = f"{self.base_url}/details.php?id="
+        self.banned_groups: list[str] = _BANNED_GROUPS
+        self.tmdb_manager = TmdbManager(config)
+        self.session = httpx.AsyncClient(
+            headers={"User-Agent": f"Upload Assistant/2.3 ({platform.system()} {platform.release()})"},
+            timeout=30,
+        )
+
+    # ── FrenchTrackerMixin overrides ──────────────────────────────────
+
+    # HDF naming examples: "The.Box.2009.MULTi.VFi.1080p.BluRay.REMUX.AVC.DTS-HD.MA.5.1-HDForever"
+    # HDF wants streaming service in name: "The.Box.2009.MULTi.VFi.1080p.AMZN.WEB-DL.H264.DDP.5.1-HDForever"
+    INCLUDE_SERVICE_IN_NAME: bool = True
+
+    # HDF uses "WEB-DL" (not "WEB") per their naming rules
+    WEB_LABEL: str = "WEB-DL"
+
+    # ──────────────────────────────────────────────────────────
+    #  Authentication
+    # ──────────────────────────────────────────────────────────
+
+    async def validate_credentials(self, meta: Meta) -> bool:
+        cookies = await self.cookie_validator.load_session_cookies(meta, self.tracker)
+        self.session.cookies.clear()
+        if cookies is not None:
+            self.session.cookies.update(cookies)
+        return await self.cookie_validator.cookie_validation(
+            meta=meta,
+            tracker=self.tracker,
+            test_url=self.upload_url,
+            error_text="login.php",
+        )
+
+    # ──────────────────────────────────────────────────────────
+    #  Category mapping
+    # ──────────────────────────────────────────────────────────
+
+    # HDF categories (from upload form dropdown — IDs reverse-engineered):
+    # 1 = Films
+    # 2 = Films d'animation
+    # 3 = Séries
+    # 4 = Séries d'animation
+    # 5 = Documentaires
+    # 6 = Spectacles
+    # 7 = Concerts
+
+    async def get_category_id(self, meta: Meta) -> int:
+        category = str(meta.get("category", "")).upper()
+        genres = str(meta.get("genres", "")).lower()
+        keywords = str(meta.get("keywords", "")).lower()
+        is_anime = bool(meta.get("anime"))
+
+        if "documentary" in genres or "documentary" in keywords:
+            if category == "TV":
+                return 5  # Documentaires (series)
+            return 5  # Documentaires
+
+        if "music" in genres or "concert" in keywords:
+            return 7  # Concerts
+
+        if is_anime:
+            if category == "TV":
+                return 4  # Séries d'animation
+            return 2  # Films d'animation
+
+        if category == "TV":
+            return 3  # Séries
+
+        return 1  # Films (default)
+
+    # ──────────────────────────────────────────────────────────
+    #  Codec mapping
+    # ──────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _get_codec_id(meta: Meta) -> str:
+        """Map video codec to HDF form value."""
+        codec = str(meta.get("video_codec", "")).upper()
+        encode = str(meta.get("video_encode", "")).upper()
+
+        if "AV1" in encode or "AV1" in codec:
+            return "AV1"
+        if "HEVC" in codec or "H265" in encode or "X265" in encode or "H.265" in encode:
+            return "x265"
+        if "AVC" in codec or "H264" in encode or "X264" in encode or "H.264" in encode:
+            return "x264"
+        return ""
+
+    # ──────────────────────────────────────────────────────────
+    #  Resolution mapping
+    # ──────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _get_resolution_id(meta: Meta) -> str:
+        """Map resolution to HDF form value."""
+        resolution = str(meta.get("resolution", ""))
+        if "2160" in resolution:
+            return "2160p"
+        if "1080" in resolution:
+            return "1080p"
+        if "720" in resolution:
+            return "720p"
+        return resolution
+
+    # ──────────────────────────────────────────────────────────
+    #  Type de fichier (file type) mapping
+    # ──────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _get_file_type(meta: Meta) -> str:
+        """Map release type to HDF file type form value."""
+        release_type = str(meta.get("type", "")).upper()
+        is_disc = str(meta.get("is_disc", ""))
+
+        if is_disc == "BDMV" or release_type == "DISC":
+            return "FULL"
+        if release_type == "REMUX":
+            return "REMUX"
+        if release_type in ("WEBDL", "WEBRIP"):
+            return "WEB-DL"
+        if release_type == "ENCODE":
+            return "ENCODE"
+        return ""
+
+    # ──────────────────────────────────────────────────────────
+    #  Language checkboxes
+    # ──────────────────────────────────────────────────────────
+
+    def _compute_language_flags(self, meta: Meta, audio_tag: str) -> dict[str, bool]:
+        """Determine which language checkboxes to tick based on the audio tag."""
+        flags: dict[str, bool] = {
+            "VFI": False,
+            "VFF": False,
+            "VFQ": False,
+            "VO": False,
+            "VOF": False,
+            "VOQ": False,
+            "VF": False,
+            "MULTi": False,
+            "subtitles": False,
+            "muet": False,
+        }
+
+        tag = audio_tag.upper()
+
+        # MULTi variants
+        if "MULTI" in tag:
+            flags["MULTi"] = True
+            if "VFF" in tag or "VF2" in tag:
+                flags["VFF"] = True
+            if "VFQ" in tag:
+                flags["VFQ"] = True
+            if "VFI" in tag:
+                flags["VFI"] = True
+        elif "VOF" in tag:
+            flags["VOF"] = True
+        elif "VFF" in tag or "TRUEFRENCH" in tag:
+            flags["VFF"] = True
+        elif "VFQ" in tag:
+            flags["VFQ"] = True
+        elif "VFI" in tag:
+            flags["VFI"] = True
+        elif "VOSTFR" in tag:
+            flags["VO"] = True
+            flags["subtitles"] = True
+        elif "MUET" in tag:
+            flags["muet"] = True
+        elif "VO" in tag:
+            flags["VO"] = True
+
+        # Check for French subtitles presence
+        if self._has_french_subs(meta):
+            flags["subtitles"] = True
+
+        return flags
+
+    # ──────────────────────────────────────────────────────────
+    #  Versions (editions / special flags)
+    # ──────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _get_versions(meta: Meta) -> list[str]:
+        """Determine version flags to tick on HDF form.
+
+        HDF versions: Remaster, Director's Cut, Version Longue, UnCut,
+        UnRated, 2in1, Source Netflix/Amazon/AppleTV/Canal+/Disney+,
+        Criterion, Custom/HYBRiD, HDR, HDR10+, Dolby Vision, IMAX, Bonus
+        """
+        versions: list[str] = []
+        edition = str(meta.get("edition", "")).lower()
+
+        if "remaster" in edition:
+            versions.append("Remaster")
+        if "director" in edition:
+            versions.append("Director's Cut")
+        if "extended" in edition or "version longue" in edition:
+            versions.append("Version Longue")
+        if "uncut" in edition:
+            versions.append("UnCut")
+        if "unrated" in edition:
+            versions.append("UnRated")
+        if "2in1" in edition or "2 in 1" in edition:
+            versions.append("2in1")
+        if "criterion" in edition:
+            versions.append("Criterion")
+        if "hybrid" in edition or "custom" in edition:
+            versions.append("Custom / HYBRiD")
+        if "imax" in edition:
+            versions.append("IMAX")
+
+        # Streaming source
+        service = str(meta.get("service", "")).upper()
+        service_map = {
+            "NF": "Source Netflix",
+            "NETFLIX": "Source Netflix",
+            "AMZN": "Source Amazon",
+            "AMAZON": "Source Amazon",
+            "ATVP": "Source AppleTV",
+            "APTV": "Source AppleTV",
+            "CNLP": "Source Canal+",
+            "CANAL+": "Source Canal+",
+            "DSNP": "Source Disney+",
+            "DISNEY+": "Source Disney+",
+        }
+        if service in service_map:
+            versions.append(service_map[service])
+
+        # HDR flags
+        hdr = str(meta.get("hdr", "")).upper()
+        if "HDR10+" in hdr:
+            versions.append("HDR10+")
+        elif "HDR" in hdr:
+            versions.append("HDR")
+        if "DV" in hdr:
+            versions.append("Dolby Vision")
+
+        return versions
+
+    # ──────────────────────────────────────────────────────────
+    #  Description builder
+    # ──────────────────────────────────────────────────────────
+
+    async def _build_description(self, meta: Meta) -> str:
+        """Build BBCode description for HDF, matching the site's presentation style.
+
+        Structure: [center] wrapped, French TMDB data (credits, overview),
+        flag emojis for audio/subtitles, technical info.
+        """
+        C = "#3d85c6"  # accent colour
+        TC = "#ea9999"  # tagline colour
+        parts: list[str] = []
+
+        # ── Fetch French TMDB data ──
+        fr_data: dict[str, Any] = {}
+        with contextlib.suppress(Exception):
+            fr_data = await self.tmdb_manager.get_tmdb_localized_data(meta, data_type="main", language="fr", append_to_response="credits") or {}
+
+        fr_title = str(fr_data.get("title", "") or meta.get("title", "")).strip()
+        fr_overview = str(fr_data.get("overview", "")).strip()
+        year = meta.get("year", "")
+        tagline = str(fr_data.get("tagline", "")).strip()
+
+        # Full-size poster (w500)
+        poster = meta.get("poster", "") or ""
+        if "image.tmdb.org/t/p/" in poster:
+            poster = re.sub(r"/t/p/[^/]+/", "/t/p/w500/", poster)
+
+        # MI text for technical parsing
+        mi_text = await self._get_mediainfo_text(meta)
+
+        # ── Open [center] ──
+        parts.append("[center]")
+
+        # ── Title block ──
+        parts.append(f"[b][color={C}][size=28]{fr_title} ({year})[/size][/color][/b]")
+        parts.append("")
+
+        # ── Poster ──
+        if poster:
+            parts.append(f"[img]{poster}[/img]")
+            parts.append("")
+
+        # ── Tagline ──
+        if tagline:
+            parts.append(f'[color={TC}][i][b]"{tagline}"[/b][/i][/color]')
+            parts.append("")
+
+        # ══════════════════════════════════════════════════════
+        #  Informations
+        # ══════════════════════════════════════════════════════
+        parts.append(f"[b][color={C}][size=18]━━━ Informations ━━━[/size][/color][/b]")
+
+        # Original title
+        original_title = str(meta.get("original_title", "") or meta.get("title", "")).strip()
+        if original_title and original_title != fr_title:
+            parts.append(f"[b][color={C}]Titre original :[/color][/b] [i]{original_title}[/i]")
+
+        # Country
+        countries = fr_data.get("production_countries", meta.get("production_countries", []))
+        if countries and isinstance(countries, list):
+            names = [c.get("name", "") for c in countries if isinstance(c, dict) and c.get("name")]
+            if names:
+                parts.append(f"[b][color={C}]Pays :[/color][/b] [i]{', '.join(names)}[/i]")
+
+        # Genres
+        genres_list = fr_data.get("genres", [])
+        if genres_list and isinstance(genres_list, list):
+            genre_names = [g["name"] for g in genres_list if isinstance(g, dict) and g.get("name")]
+            if genre_names:
+                parts.append(f"[b][color={C}]Genres :[/color][/b] [i]{', '.join(genre_names)}[/i]")
+
+        # Release date (French formatted)
+        release_date = str(fr_data.get("release_date", "") or meta.get("release_date", "") or meta.get("first_air_date", "")).strip()
+        if release_date:
+            parts.append(f"[b][color={C}]Date de sortie :[/color][/b] [i]{self._format_french_date(release_date)}[/i]")
+        elif year:
+            parts.append(f"[b][color={C}]Date de sortie :[/color][/b] [i]{year}[/i]")
+
+        # Runtime
+        runtime = fr_data.get("runtime") or meta.get("runtime", 0)
+        if runtime:
+            h, m = divmod(int(runtime), 60)
+            dur = f"{h}h{m:02d}" if h > 0 else f"{m}min"
+            parts.append(f"[b][color={C}]Durée :[/color][/b] [i]{dur}[/i]")
+
+        # Credits
+        credits = fr_data.get("credits", {})
+        crew = credits.get("crew", []) if isinstance(credits, dict) else []
+        cast = credits.get("cast", []) if isinstance(credits, dict) else []
+
+        directors = [p["name"] for p in crew if isinstance(p, dict) and p.get("job") == "Director" and p.get("name")]
+        if not directors:
+            meta_dirs = meta.get("tmdb_directors", [])
+            if isinstance(meta_dirs, list):
+                directors = [d.get("name", d) if isinstance(d, dict) else str(d) for d in meta_dirs]
+        if directors:
+            label = "Réalisateur" if len(directors) == 1 else "Réalisateurs"
+            parts.append(f"[b][color={C}]{label} :[/color][/b] [i]{', '.join(directors)}[/i]")
+
+        actors = [p["name"] for p in cast[:5] if isinstance(p, dict) and p.get("name")]
+        if actors:
+            parts.append(f"[b][color={C}]Acteurs :[/color][/b] [i]{', '.join(actors)}[/i]")
+
+        # Rating
+        vote_avg = fr_data.get("vote_average") or meta.get("vote_average")
+        vote_count = fr_data.get("vote_count") or meta.get("vote_count")
+        if vote_avg and vote_count:
+            parts.append(f"[b][color={C}]Note :[/color][/b] [i]{vote_avg}/10 ({vote_count} votes)[/i]")
+
+        # External links
+        ext_links: list[str] = []
+        imdb_id = meta.get("imdb_id", 0)
+        if imdb_id and int(imdb_id) > 0:
+            ext_links.append(f"[url=https://www.imdb.com/title/tt{str(imdb_id).zfill(7)}/]IMDb[/url]")
+        tmdb_id_val = meta.get("tmdb", "")
+        if tmdb_id_val:
+            tmdb_cat = "movie" if meta.get("category", "").upper() != "TV" else "tv"
+            ext_links.append(f"[url=https://www.themoviedb.org/{tmdb_cat}/{tmdb_id_val}]TMDB[/url]")
+        if ext_links:
+            parts.append("")
+            parts.append(" │ ".join(ext_links))
+
+        parts.append("")
+
+        # ══════════════════════════════════════════════════════
+        #  Synopsis
+        # ══════════════════════════════════════════════════════
+        parts.append(f"[b][color={C}][size=18]━━━ Synopsis ━━━[/size][/color][/b]")
+        synopsis = fr_overview or str(meta.get("overview", "")).strip() or "Aucun synopsis disponible."
+        parts.append(synopsis)
+        parts.append("")
+
+        # ══════════════════════════════════════════════════════
+        #  Informations techniques
+        # ══════════════════════════════════════════════════════
+        parts.append(f"[b][color={C}][size=18]━━━ Informations techniques ━━━[/size][/color][/b]")
+
+        type_label = self._get_type_label(meta)
+        if type_label:
+            parts.append(f"[b][color={C}]Type :[/color][/b] [i]{type_label}[/i]")
+
+        resolution = meta.get("resolution", "")
+        if resolution:
+            parts.append(f"[b][color={C}]Résolution :[/color][/b] [i]{resolution}[/i]")
+
+        container_display = self._format_container(mi_text)
+        if container_display:
+            parts.append(f"[b][color={C}]Format vidéo :[/color][/b] [i]{container_display}[/i]")
+
+        video_codec = (meta.get("video_encode", "").strip() or meta.get("video_codec", "")).strip()
+        video_codec = video_codec.replace("H.264", "H264").replace("H.265", "H265")
+        raw_codec = meta.get("video_codec", "").strip()
+        if video_codec and raw_codec and raw_codec != video_codec:
+            video_codec = f"{video_codec} ({raw_codec})"
+        if video_codec:
+            parts.append(f"[b][color={C}]Codec vidéo :[/color][/b] [i]{video_codec}[/i]")
+
+        hdr_dv_badge = self._format_hdr_dv_bbcode(meta)
+        if hdr_dv_badge:
+            parts.append(f"[b][color={C}]HDR :[/color][/b] {hdr_dv_badge}")
+
+        if mi_text:
+            vbr_match = re.search(r"(?:^|\n)Bit rate\s*:\s*(.+?)\s*(?:\n|$)", mi_text)
+            if vbr_match:
+                parts.append(f"[b][color={C}]Débit vidéo :[/color][/b] [i]{vbr_match.group(1).strip()}[/i]")
+
+        parts.append("")
+
+        # ── Audio tracks ──
+        parts.append(f"[b][color={C}][size=18]━━━ Audio(s) ━━━[/size][/color][/b]")
+        audio_lines = self._format_audio_bbcode(mi_text, meta)
+        if audio_lines:
+            parts.extend(f" {al}" for al in audio_lines)
+        else:
+            parts.append(" [i]Non spécifié[/i]")
+        parts.append("")
+
+        # ── Subtitles ──
+        parts.append(f"[b][color={C}][size=18]━━━ Sous-titre(s) ━━━[/size][/color][/b]")
+        sub_lines = self._format_subtitle_bbcode(mi_text, meta)
+        if sub_lines:
+            parts.extend(f" {sl}" for sl in sub_lines)
+        else:
+            parts.append(" [i]Aucun[/i]")
+        parts.append("")
+
+        # ══════════════════════════════════════════════════════
+        #  Release
+        # ══════════════════════════════════════════════════════
+        parts.append(f"[b][color={C}][size=18]━━━ Release ━━━[/size][/color][/b]")
+
+        release_name = meta.get("uuid", "")
+        parts.append(f"[b][color={C}]Titre :[/color][/b] [i]{release_name}[/i]")
+
+        size_str = self._get_total_size(meta, mi_text)
+        if size_str:
+            parts.append(f"[b][color={C}]Taille totale :[/color][/b] {size_str}")
+
+        file_count = self._count_files(meta)
+        if file_count:
+            parts.append(f"[b][color={C}]Nombre de fichier(s) :[/color][/b] {file_count}")
+
+        group = self._get_release_group(meta)
+        if group:
+            parts.append(f"[b][color={C}]Groupe :[/color][/b] [i]{group}[/i]")
+
+        # ── Screenshots (opt-in) ──
+        include_screens = self.config["TRACKERS"].get(self.tracker, {}).get("include_screenshots", False)
+        image_list: list[dict[str, Any]] = meta.get("image_list", []) if include_screens else []
+        if image_list:
+            parts.append("")
+            parts.append(f"[b][color={C}][size=18]━━━ Captures d'écran ━━━[/size][/color][/b]")
+            for img in image_list:
+                raw = img.get("raw_url", "")
+                web = img.get("web_url", "")
+                if raw:
+                    if web:
+                        parts.append(f"[url={web}][img]{raw}[/img][/url]")
+                    else:
+                        parts.append(f"[img]{raw}[/img]")
+
+        # Close center
+        parts.append("[/center]")
+
+        # ── Signature ──
+        ua_sig = meta.get("ua_signature", "Created by Upload Assistant")
+        parts.append("")
+        parts.append(f"[right][url=https://github.com/yippee0903/Upload-Assistant][size=1]{ua_sig}[/size][/url][/right]")
+
+        return "\n".join(parts)
+
+    # ──────────────────────────────────────────────────────────
+    #  MediaInfo text helpers
+    # ──────────────────────────────────────────────────────────
+
+    async def _get_mediainfo_text(self, meta: Meta) -> str:
+        """Read MediaInfo text from temp files."""
+        base = os.path.join(meta.get("base_dir", ""), "tmp", meta.get("uuid", ""))
+
+        for fname in ("MEDIAINFO_CLEANPATH.txt", "MEDIAINFO.txt"):
+            fpath = os.path.join(base, fname)
+            if os.path.exists(fpath):
+                async with aiofiles.open(fpath, encoding="utf-8") as f:
+                    content = await f.read()
+                    if content.strip():
+                        return content
+
+        if meta.get("bdinfo") is not None:
+            bd_path = os.path.join(base, "BD_SUMMARY_00.txt")
+            if os.path.exists(bd_path):
+                async with aiofiles.open(bd_path, encoding="utf-8") as f:
+                    return await f.read()
+
+        fallback = str(meta.get("mediainfo_text") or "").strip()
+        if fallback:
+            return fallback
+
+        return ""
+
+    @staticmethod
+    def _format_french_date(date_str: str) -> str:
+        """Format YYYY-MM-DD to French full date, e.g. '24 octobre 2011'."""
+        try:
+            dt = datetime.strptime(date_str, "%Y-%m-%d")
+            day_str = "1er" if dt.day == 1 else str(dt.day)
+            return f"{day_str} {FRENCH_MONTHS[dt.month]} {dt.year}"
+        except (ValueError, IndexError):
+            return date_str
+
+    # ──────────────────────────────────────────────────────────
+    #  NFO generation
+    # ──────────────────────────────────────────────────────────
+
+    async def _get_or_generate_nfo(self, meta: Meta) -> Optional[str]:
+        """Generate a MediaInfo-based NFO for the upload."""
+        nfo_gen = SceneNfoGenerator(self.config)
+        return await nfo_gen.generate_nfo(meta, self.tracker)
+
+    # ──────────────────────────────────────────────────────────
+    #  Dupe search
+    # ──────────────────────────────────────────────────────────
+
+    async def search_existing(self, meta: Meta, _disctype: str) -> list[dict[str, Union[str, None]]]:
+        cookies = await self.cookie_validator.load_session_cookies(meta, self.tracker)
+        self.session.cookies.clear()
+        if cookies is not None:
+            self.session.cookies.update(cookies)
+
+        dupes: list[dict[str, Union[str, None]]] = []
+
+        # Search by TMDB ID first, fallback to title
+        tmdb_id = meta.get("tmdb", "")
+        search_term = str(tmdb_id) if tmdb_id else str(meta.get("title", ""))
+        if not search_term:
+            console.print(f"[yellow]{self.tracker}: No TMDB ID or title for dupe search[/yellow]")
+            return dupes
+
+        search_url = f"{self.base_url}/browse.php"
+        params: dict[str, str] = {"search": search_term, "cat": "0"}
+
+        try:
+            response = await self.session.get(search_url, params=params)
+            response.raise_for_status()
+            soup = BeautifulSoup(response.text, "html.parser")
+
+            # Look for torrent links in results table
+            torrent_links = soup.find_all("a", href=re.compile(r"details\.php\?id=\d+"))
+
+            for link in torrent_links:
+                if not isinstance(link, Tag):
+                    continue
+                name = link.get_text(strip=True)
+                href = link.get("href", "")
+                if not name or not href:
+                    continue
+                full_url = f"{self.base_url}/{href}" if not str(href).startswith("http") else str(href)
+                dupes.append({"name": name, "size": None, "link": full_url})
+
+        except Exception as e:
+            console.print(f"[bold red]{self.tracker}: Error searching for duplicates: {e}[/bold red]")
+
+        return dupes
+
+    # ──────────────────────────────────────────────────────────
+    #  Build form data
+    # ──────────────────────────────────────────────────────────
+
+    async def get_data(self, meta: Meta) -> dict[str, Any]:
+        """Build the multipart form data dict for HDF upload.php."""
+        name_result = await self.get_name(meta)
+        title = name_result.get("name", "") if isinstance(name_result, dict) else str(name_result)
+
+        # Build audio tag for language detection
+        audio_tag = await self._build_audio_string(meta)
+
+        # Language flags
+        lang_flags = self._compute_language_flags(meta, audio_tag)
+
+        # Description
+        description = await self._build_description(meta)
+
+        # MediaInfo text
+        mi_text = await self._get_mediainfo_text(meta)
+
+        # Category
+        category_id = await self.get_category_id(meta)
+
+        # TMDB URL
+        tmdb_id = meta.get("tmdb", "")
+        tmdb_cat = "movie" if str(meta.get("category", "")).upper() != "TV" else "tv"
+        tmdb_url = f"https://www.themoviedb.org/{tmdb_cat}/{tmdb_id}" if tmdb_id else ""
+
+        # Scene flag
+        is_scene = "1" if meta.get("scene", False) else "0"
+
+        # Team / release group
+        team = self._get_release_group(meta)
+
+        # Versions
+        versions = self._get_versions(meta)
+
+        data: dict[str, Any] = {
+            "name": title,
+            "category": str(category_id),
+            "tmdburl": tmdb_url,
+            "descr": description,
+            "mediainfo": mi_text,
+            "scene": is_scene,
+            "codec": self._get_codec_id(meta),
+            "resolution": self._get_resolution_id(meta),
+            "filetype": self._get_file_type(meta),
+            "team": team,
+        }
+
+        # Language checkboxes
+        lang_field_map = {
+            "VFI": "lang_vfi",
+            "VFF": "lang_vff",
+            "VFQ": "lang_vfq",
+            "VO": "lang_vo",
+            "VOF": "lang_vof",
+            "VOQ": "lang_voq",
+            "VF": "lang_vf",
+            "MULTi": "lang_multi",
+            "subtitles": "lang_subtitles",
+            "muet": "lang_muet",
+        }
+        for flag_key, form_field in lang_field_map.items():
+            if lang_flags.get(flag_key, False):
+                data[form_field] = "1"
+
+        # Version checkboxes
+        version_field_map: dict[str, str] = {
+            "Remaster": "version_remaster",
+            "Director's Cut": "version_dc",
+            "Version Longue": "version_vl",
+            "UnCut": "version_uncut",
+            "UnRated": "version_unrated",
+            "2in1": "version_2in1",
+            "Source Netflix": "version_nf",
+            "Source Amazon": "version_amzn",
+            "Source AppleTV": "version_atvp",
+            "Source Canal+": "version_cnlp",
+            "Source Disney+": "version_dsnp",
+            "Criterion": "version_criterion",
+            "Custom / HYBRiD": "version_custom",
+            "HDR": "version_hdr",
+            "HDR10+": "version_hdr10plus",
+            "Dolby Vision": "version_dv",
+            "IMAX": "version_imax",
+            "Bonus": "version_bonus",
+        }
+        for ver in versions:
+            if ver in version_field_map:
+                data[version_field_map[ver]] = "1"
+
+        # Anonymous
+        anon = meta.get("anon", False) or self.config["TRACKERS"].get(self.tracker, {}).get("anon", False)
+        if anon:
+            data["anonymous"] = "1"
+
+        return data
+
+    # ──────────────────────────────────────────────────────────
+    #  Upload
+    # ──────────────────────────────────────────────────────────
+
+    async def upload(self, meta: Meta, _disctype: str) -> bool:
+        """Upload torrent to HD-Forever (hdf.world)."""
+        cookies = await self.cookie_validator.load_session_cookies(meta, self.tracker)
+        self.session.cookies.clear()
+        if cookies is not None:
+            self.session.cookies.update(cookies)
+
+        data = await self.get_data(meta)
+
+        is_uploaded = await self.cookie_auth_uploader.handle_upload(
+            meta=meta,
+            tracker=self.tracker,
+            source_flag=self.source_flag,
+            torrent_url=self.torrent_url,
+            data=data,
+            torrent_field_name="torrent",
+            upload_cookies=self.session.cookies,
+            upload_url=self.upload_url,
+            hash_is_id=True,
+            success_text="details.php?id=",
+        )
+
+        return is_uploaded

--- a/src/trackersetup.py
+++ b/src/trackersetup.py
@@ -42,6 +42,7 @@ from src.trackers.G3MINI import G3MINI
 from src.trackers.GF import GF
 from src.trackers.GPW import GPW
 from src.trackers.HDB import HDB
+from src.trackers.HDF import HDF
 from src.trackers.HDS import HDS
 from src.trackers.HDT import HDT
 from src.trackers.HHD import HHD
@@ -1349,6 +1350,7 @@ tracker_class_map: dict[str, type[Any]] = {
     "GF": GF,
     "GPW": GPW,
     "HDB": HDB,
+    "HDF": HDF,
     "HDS": HDS,
     "HDT": HDT,
     "HHD": HHD,
@@ -1442,7 +1444,7 @@ api_trackers = {
 
 other_api_trackers = {"ANT", "BHDTV", "C411", "DC", "GPW", "NBL", "RTF", "SN", "SPD", "TL", "TORR9", "TVC"}
 
-http_trackers = {"AR", "ASC", "AZ", "BJS", "BT", "CZ", "FF", "FL", "HDB", "HDS", "HDT", "IS", "MTV", "PHD", "PTER", "PTS", "TTG"}
+http_trackers = {"AR", "ASC", "AZ", "BJS", "BT", "CZ", "FF", "FL", "HDB", "HDF", "HDS", "HDT", "IS", "MTV", "PHD", "PTER", "PTS", "TTG"}
 
 # ── Inherent tracker behaviors (not user-configurable) ──
 # Trackers that exclude .nfo files from torrents and API uploads
@@ -1452,7 +1454,7 @@ nfo_skip_trackers = frozenset({"DP", "FNP", "HHD", "LST", "LUME", "STC", "ULCX"}
 notag_labels: dict[str, str] = {"C411": "NOTAG", "FNP": "NOGROUP", "G3MINI": "NoGrP", "GF": "NoTag"}
 
 # Trackers that skip the English audio/subtitle requirement check
-english_check_skip_trackers = frozenset({"C411", "G3MINI", "GF", "TOS", "TORR9"})
+english_check_skip_trackers = frozenset({"C411", "G3MINI", "GF", "HDF", "TOS", "TORR9"})
 
 # Trackers that require French audio or subtitles (warn if neither is detected)
-french_check_trackers = frozenset({"C411", "G3MINI", "GF", "TOS", "TORR9"})
+french_check_trackers = frozenset({"C411", "G3MINI", "GF", "HDF", "TOS", "TORR9"})

--- a/tests/test_hdf.py
+++ b/tests/test_hdf.py
@@ -1,0 +1,431 @@
+# Tests for HDF tracker — hdf.world (HD-Forever)
+"""
+Test suite for the HDF tracker implementation.
+Covers: category mapping, codec mapping, resolution mapping,
+        language flags, versions, and release naming.
+"""
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.trackers.HDF import HDF
+
+# ─── Helpers ──────────────────────────────────────────────────
+
+
+def _config(extra_tracker: dict[str, Any] | None = None) -> dict[str, Any]:
+    tracker_cfg: dict[str, Any] = {
+        "announce_url": "https://hdf.world/announce.php?passkey=FAKE_PASSKEY",
+        "anon": False,
+        "include_screenshots": False,
+    }
+    if extra_tracker:
+        tracker_cfg.update(extra_tracker)
+    return {
+        "TRACKERS": {"HDF": tracker_cfg},
+        "DEFAULT": {"tmdb_api": "fake-tmdb-key"},
+    }
+
+
+def _meta_base(**overrides: Any) -> dict[str, Any]:
+    m: dict[str, Any] = {
+        "category": "MOVIE",
+        "type": "WEBDL",
+        "title": "The Box",
+        "year": "2009",
+        "resolution": "1080p",
+        "source": "WEB",
+        "audio": "DDP5.1",
+        "video_encode": "H264",
+        "video_codec": "AVC",
+        "service": "AMZN",
+        "tag": "-HDForever",
+        "edition": "",
+        "repack": "",
+        "3D": "",
+        "uhd": "",
+        "hdr": "",
+        "webdv": "",
+        "part": "",
+        "season": "",
+        "episode": "",
+        "is_disc": None,
+        "search_year": "",
+        "manual_year": None,
+        "manual_date": None,
+        "no_season": False,
+        "no_year": False,
+        "no_aka": False,
+        "debug": False,
+        "tv_pack": 0,
+        "path": "",
+        "name": "",
+        "uuid": "test-uuid",
+        "base_dir": "/tmp",
+        "overview": "A test movie.",
+        "poster": "",
+        "tmdb": 1234,
+        "imdb_id": 1234567,
+        "original_language": "en",
+        "image_list": [],
+        "bdinfo": None,
+        "region": "",
+        "dvd_size": "",
+        "mediainfo": {"media": {"track": []}},
+        "scene": False,
+        "anime": False,
+        "genres": "",
+        "keywords": "",
+        "anon": False,
+    }
+    m.update(overrides)
+    return m
+
+
+# ═══════════════════════════════════════════════════════════════
+#   Category mapping
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestGetCategoryId:
+    """Test HDF category ID mapping."""
+
+    @pytest.mark.parametrize(
+        "category,genres,keywords,anime,expected_id",
+        [
+            # Standard movies
+            ("MOVIE", "", "", False, 1),
+            # TV series
+            ("TV", "", "", False, 3),
+            # Anime movies
+            ("MOVIE", "", "", True, 2),
+            # Anime series
+            ("TV", "", "", True, 4),
+            # Documentaries (movie)
+            ("MOVIE", "Documentary", "", False, 5),
+            # Documentaries via keywords
+            ("MOVIE", "", "documentary", False, 5),
+            # Concerts
+            ("MOVIE", "Music", "", False, 7),
+        ],
+    )
+    def test_category_mapping(
+        self,
+        category: str,
+        genres: str,
+        keywords: str,
+        anime: bool,
+        expected_id: int,
+    ):
+        tracker = HDF(_config())
+        meta = _meta_base(category=category, genres=genres, keywords=keywords, anime=anime)
+        result = asyncio.run(tracker.get_category_id(meta))
+        assert result == expected_id
+
+
+# ═══════════════════════════════════════════════════════════════
+#   Codec mapping
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestGetCodecId:
+    """Test codec mapping."""
+
+    @pytest.mark.parametrize(
+        "video_codec,video_encode,expected",
+        [
+            ("AVC", "x264", "x264"),
+            ("AVC", "H264", "x264"),
+            ("HEVC", "x265", "x265"),
+            ("HEVC", "H265", "x265"),
+            ("", "AV1", "AV1"),
+            ("", "", ""),
+        ],
+    )
+    def test_codec_mapping(self, video_codec: str, video_encode: str, expected: str):
+        result = HDF._get_codec_id(_meta_base(video_codec=video_codec, video_encode=video_encode))
+        assert result == expected
+
+
+# ═══════════════════════════════════════════════════════════════
+#   Resolution mapping
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestGetResolutionId:
+    """Test resolution mapping."""
+
+    @pytest.mark.parametrize(
+        "resolution,expected",
+        [
+            ("2160p", "2160p"),
+            ("1080p", "1080p"),
+            ("1080i", "1080p"),
+            ("720p", "720p"),
+        ],
+    )
+    def test_resolution_mapping(self, resolution: str, expected: str):
+        result = HDF._get_resolution_id(_meta_base(resolution=resolution))
+        assert result == expected
+
+
+# ═══════════════════════════════════════════════════════════════
+#   File type mapping
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestGetFileType:
+    """Test release type to file type mapping."""
+
+    @pytest.mark.parametrize(
+        "release_type,is_disc,expected",
+        [
+            ("REMUX", None, "REMUX"),
+            ("WEBDL", None, "WEB-DL"),
+            ("WEBRIP", None, "WEB-DL"),
+            ("ENCODE", None, "ENCODE"),
+            ("DISC", "BDMV", "FULL"),
+        ],
+    )
+    def test_file_type_mapping(self, release_type: str, is_disc: Any, expected: str):
+        result = HDF._get_file_type(_meta_base(type=release_type, is_disc=is_disc or ""))
+        assert result == expected
+
+
+# ═══════════════════════════════════════════════════════════════
+#   Language flags
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestComputeLanguageFlags:
+    """Test language flag computation from audio tag."""
+
+    def _tracker(self) -> HDF:
+        return HDF(_config())
+
+    def test_multi_vff(self):
+        tracker = self._tracker()
+        flags = tracker._compute_language_flags(_meta_base(), "MULTI.VFF")
+        assert flags["MULTi"] is True
+        assert flags["VFF"] is True
+        assert flags["VFQ"] is False
+
+    def test_multi_vfq(self):
+        tracker = self._tracker()
+        flags = tracker._compute_language_flags(_meta_base(), "MULTI.VFQ")
+        assert flags["MULTi"] is True
+        assert flags["VFQ"] is True
+        assert flags["VFF"] is False
+
+    def test_multi_vfi(self):
+        tracker = self._tracker()
+        flags = tracker._compute_language_flags(_meta_base(), "MULTI.VFI")
+        assert flags["MULTi"] is True
+        assert flags["VFI"] is True
+
+    def test_multi_vf2(self):
+        tracker = self._tracker()
+        flags = tracker._compute_language_flags(_meta_base(), "MULTI.VF2")
+        assert flags["MULTi"] is True
+        assert flags["VFF"] is True  # VF2 implies VFF present
+
+    def test_vff_solo(self):
+        tracker = self._tracker()
+        flags = tracker._compute_language_flags(_meta_base(), "VFF")
+        assert flags["VFF"] is True
+        assert flags["MULTi"] is False
+
+    def test_vof(self):
+        tracker = self._tracker()
+        flags = tracker._compute_language_flags(_meta_base(), "VOF")
+        assert flags["VOF"] is True
+        assert flags["MULTi"] is False
+
+    def test_vostfr(self):
+        tracker = self._tracker()
+        flags = tracker._compute_language_flags(_meta_base(), "VOSTFR")
+        assert flags["VO"] is True
+        assert flags["subtitles"] is True
+
+    def test_muet(self):
+        tracker = self._tracker()
+        flags = tracker._compute_language_flags(_meta_base(), "MUET")
+        assert flags["muet"] is True
+
+
+# ═══════════════════════════════════════════════════════════════
+#   Version flags
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestGetVersions:
+    """Test version/edition flag mapping."""
+
+    def test_directors_cut(self):
+        versions = HDF._get_versions(_meta_base(edition="Director's Cut"))
+        assert "Director's Cut" in versions
+
+    def test_remaster(self):
+        versions = HDF._get_versions(_meta_base(edition="Remaster"))
+        assert "Remaster" in versions
+
+    def test_extended(self):
+        versions = HDF._get_versions(_meta_base(edition="Extended"))
+        assert "Version Longue" in versions
+
+    def test_hdr_dv(self):
+        versions = HDF._get_versions(_meta_base(hdr="DV HDR10+"))
+        assert "HDR10+" in versions
+        assert "Dolby Vision" in versions
+
+    def test_hdr_only(self):
+        versions = HDF._get_versions(_meta_base(hdr="HDR"))
+        assert "HDR" in versions
+
+    def test_criterion(self):
+        versions = HDF._get_versions(_meta_base(edition="Criterion"))
+        assert "Criterion" in versions
+
+    def test_imax(self):
+        versions = HDF._get_versions(_meta_base(edition="IMAX"))
+        assert "IMAX" in versions
+
+    def test_service_netflix(self):
+        versions = HDF._get_versions(_meta_base(service="NF"))
+        assert "Source Netflix" in versions
+
+    def test_service_amazon(self):
+        versions = HDF._get_versions(_meta_base(service="AMZN"))
+        assert "Source Amazon" in versions
+
+    def test_service_disney(self):
+        versions = HDF._get_versions(_meta_base(service="DSNP"))
+        assert "Source Disney+" in versions
+
+    def test_service_canal(self):
+        versions = HDF._get_versions(_meta_base(service="CNLP"))
+        assert "Source Canal+" in versions
+
+    def test_service_appletv(self):
+        versions = HDF._get_versions(_meta_base(service="ATVP"))
+        assert "Source AppleTV" in versions
+
+    def test_hybrid(self):
+        versions = HDF._get_versions(_meta_base(edition="HYBRiD"))
+        assert "Custom / HYBRiD" in versions
+
+    def test_no_versions(self):
+        versions = HDF._get_versions(_meta_base(edition="", hdr="", service=""))
+        assert versions == []
+
+
+# ═══════════════════════════════════════════════════════════════
+#   Banned groups
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestBannedGroups:
+    """Test that HDF banned groups are properly set."""
+
+    def test_banned_groups_from_rules(self):
+        tracker = HDF(_config())
+        assert "EXTREME" in tracker.banned_groups
+        assert "RARBG" in tracker.banned_groups
+        assert "FGT" in tracker.banned_groups
+        assert "SUNS3T" in tracker.banned_groups
+        assert "FL3ER" in tracker.banned_groups
+        assert "WoLFHD" in tracker.banned_groups
+
+
+# ═══════════════════════════════════════════════════════════════
+#   French date formatting
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestFormatFrenchDate:
+    """Test French date formatting."""
+
+    def test_standard_date(self):
+        assert HDF._format_french_date("2009-11-24") == "24 novembre 2009"
+
+    def test_first_of_month(self):
+        assert HDF._format_french_date("2023-01-01") == "1er janvier 2023"
+
+    def test_invalid_date(self):
+        assert HDF._format_french_date("not-a-date") == "not-a-date"
+
+
+# ═══════════════════════════════════════════════════════════════
+#   Naming (through FrenchTrackerMixin.get_name)
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestNaming:
+    """Test that HDF naming follows French conventions via the mixin."""
+
+    def _tracker(self) -> HDF:
+        return HDF(_config())
+
+    @patch.object(HDF, "_get_french_title", new_callable=AsyncMock, return_value="")
+    def test_basic_movie_name(self, mock_title: AsyncMock):
+        """Basic movie should include service in name (INCLUDE_SERVICE_IN_NAME=True)."""
+        tracker = self._tracker()
+        meta = _meta_base(
+            category="MOVIE",
+            type="WEBDL",
+            title="The Box",
+            year="2009",
+            resolution="1080p",
+            video_encode="H264",
+            service="AMZN",
+            tag="-HDForever",
+            hdr="",
+        )
+        # Build audio tag requires mediainfo tracks
+        meta["mediainfo"] = {
+            "media": {
+                "track": [
+                    {"@type": "Audio", "Language": "fr", "Title": "VFF"},
+                    {"@type": "Audio", "Language": "en"},
+                ]
+            }
+        }
+        result = asyncio.run(tracker.get_name(meta))
+        name = result.get("name", "") if isinstance(result, dict) else str(result)
+
+        # Should contain service (AMZN) since INCLUDE_SERVICE_IN_NAME=True
+        assert "AMZN" in name
+        # Should use WEB-DL label (dot-separated in release names: WEB.DL)
+        assert "WEB" in name
+
+    @patch.object(HDF, "_get_french_title", new_callable=AsyncMock, return_value="")
+    def test_remux_name(self, mock_title: AsyncMock):
+        """REMUX naming."""
+        tracker = self._tracker()
+        meta = _meta_base(
+            category="MOVIE",
+            type="REMUX",
+            title="The Box",
+            year="2009",
+            resolution="1080p",
+            video_codec="AVC",
+            video_encode="",
+            service="",
+            tag="-HDForever",
+            hdr="",
+            source="Blu-ray",
+        )
+        meta["mediainfo"] = {
+            "media": {
+                "track": [
+                    {"@type": "Audio", "Language": "fr", "Title": "VFI"},
+                    {"@type": "Audio", "Language": "en"},
+                ]
+            }
+        }
+        result = asyncio.run(tracker.get_name(meta))
+        name = result.get("name", "") if isinstance(result, dict) else str(result)
+        assert "REMUX" in name


### PR DESCRIPTION
## Summary

Adds support for **HDF** (HD-Forever / hdf.world), a French private tracker.

### Implementation

- **Authentication**: Cookie-based (no API) via `CookieValidator` + `CookieAuthUploader`
- **French tracker**: Uses `FrenchTrackerMixin` for naming, audio BBCode, and descriptions
- **Upload**: POST to `hdf.world/upload.php` with multipart form data

### Features

- **Categories**: Films, Films d'animation, Séries, Séries d'animation, Documentaires, Spectacles, Concerts
- **Language flags**: VFI, VFF, VFQ, VO, VOF, VOQ, VF?, MULTi, Sous-titres, Muet
- **Version flags**: Remaster, Director's Cut, Version Longue, UnCut, UnRated, 2in1, streaming sources (Netflix, Amazon, Disney+, Canal+, AppleTV+), Criterion, Custom/HYBRiD, HDR, HDR10+, Dolby Vision, IMAX, Bonus
- **Banned groups**: EXTREME, RARBG, FGT, HDMIDIMADRIDI, Foxhound, HDSpace, FL3ER, SUNS3T, WoLFHD
- **Dupe checking**: Searches `browse.php` by TMDB ID or title
- **Naming**: `INCLUDE_SERVICE_IN_NAME = True`, `WEB_LABEL = "WEB-DL"`

### Files Changed

- `src/trackers/HDF.py` — New tracker implementation
- `src/trackersetup.py` — Registration (import, class_map, http_trackers, english_check_skip, french_check)
- `data/example-config.py` — Config section and tracker list
- `tests/test_hdf.py` — 50 unit tests

### Notes

Form field names (`lang_vfi`, `version_remaster`, etc.) are best-guess placeholders. Real upload testing will be needed to verify the exact `<input name="...">` values from the upload form.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for HDF tracker with automated torrent uploads to hdf.world, including metadata mapping, language detection, and French-localized descriptions.

* **Tests**
  * Added comprehensive test coverage for HDF tracker integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->