### PR TITLE
AD_TRACK_RE change (add (AD))

### DIFF
--- a/src/audio.py
+++ b/src/audio.py
@@ -25,7 +25,7 @@ TrackDict = dict[str, Any]
 
 
 # Compiled pattern shared with src/trackers/FRENCH.py — keep in sync.
-AD_TRACK_RE = re.compile(r"\baudio[\s_-]?description\b|\b[a-z]{2}\s+AD\b|\bAD\s*:", re.IGNORECASE)
+AD_TRACK_RE = re.compile(r"\baudio[\s_-]?description\b|\b[a-z]{2}\s+AD\b|\bAD\s*:|\(AD\)", re.IGNORECASE)
 
 
 class AudioManager:


### PR DESCRIPTION
Some tracks title use `(AD)` in title. 
```
Audio #2
[...]
Title                                    : VFF (AD)
Language                                 : French (FR)
Service kind                             : Complete Main
[...]
```
So I modified the regex according to this option.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of audio description tracks by expanding pattern matching to recognize additional descriptor formats in track titles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->