### PR TITLE
fix: normalize VC-1 to VC1 in French release names

### DIFF
--- a/src/trackers/FRENCH.py
+++ b/src/trackers/FRENCH.py
@@ -881,14 +881,14 @@ class FrenchTrackerMixin:
         dvd_size = ""
 
         if meta.get("is_disc") == "BDMV":
-            video_codec = meta.get("video_codec", "").replace("H.264", "H264").replace("H.265", "H265")
+            video_codec = meta.get("video_codec", "").replace("H.264", "H264").replace("H.265", "H265").replace("VC-1", "VC1")
             region = meta.get("region", "") or ""
         elif meta.get("is_disc") == "DVD":
             region = meta.get("region", "") or ""
             dvd_size = meta.get("dvd_size", "")
         else:
-            video_codec = meta.get("video_codec", "").replace("H.264", "H264").replace("H.265", "H265")
-            video_encode = meta.get("video_encode", "").replace("H.264", "H264").replace("H.265", "H265")
+            video_codec = meta.get("video_codec", "").replace("H.264", "H264").replace("H.265", "H265").replace("VC-1", "VC1")
+            video_encode = meta.get("video_encode", "").replace("H.264", "H264").replace("H.265", "H265").replace("VC-1", "VC1")
 
         if category == "TV":
             year = meta["year"] if meta.get("search_year", "") != "" else ""

--- a/tests/test_c411.py
+++ b/tests/test_c411.py
@@ -804,6 +804,18 @@ class TestCodecCleanup:
         assert 'H265' in name
         assert 'H.265' not in name
 
+    def test_vc1_cleaned(self):
+        """VC-1 must appear as VC1 (no hyphen, no dot)."""
+        meta = _meta_base(
+            title='Test', year='2024', type='REMUX', source='BluRay',
+            resolution='1080p', video_codec='VC-1',
+            mediainfo=_mi([_audio_track('fr')]), original_language='en',
+        )
+        name = self._run(meta)
+        assert 'VC1' in name
+        assert 'VC-1' not in name
+        assert 'VC.1' not in name
+
     def test_hdr10plus_cleaned(self):
         meta = _meta_base(
             title='Test', year='2024', type='WEBDL', source='WEB',


### PR DESCRIPTION
VC-1 was being turned into VC.1 by the hyphen-to-dot conversion in _format_name. Add .replace('VC-1', 'VC1') alongside the existing H.264→H264 / H.265→H265 normalizations.