### PR TITLE
fix(g3mini): reorder Hybrid and video codec in release names

### DIFF
--- a/src/trackers/G3MINI.py
+++ b/src/trackers/G3MINI.py
@@ -273,7 +273,7 @@ class G3MINI(FrenchTrackerMixin, UNIT3D):
             elif type == "HDTV":  # HDTV
                 name = f"{title} {year} {season}{episode} {part} {edition} {repack} {language} {resolution} {source} {audio} {video_encode}"
             elif type == "DVDRIP":
-                name = f"{title} {year} {season} {language} {source} DVDRip {audio} {video_encode}"
+                name = f"{title} {year} {season}{episode} {language} {source} DVDRip {audio} {video_encode}"
 
         try:
             name = " ".join(name.split())

--- a/tests/test_g3mini.py
+++ b/tests/test_g3mini.py
@@ -233,3 +233,22 @@ class TestGetName:
         # Language tag (MULTi) must appear
         assert 'MULTi' in name, f"Language tag missing: {name}"
         assert name.endswith('x264-SGF'), f"Video encode not at end: {name}"
+
+    def test_tv_dvdrip_includes_episode(self):
+        """TV DVDRIP must include both season and episode in the name."""
+        meta = _meta_base(
+            category='TV',
+            type='DVDRIP',
+            source='DVD',
+            video_encode='x264',
+            video_codec='',
+            season='S01',
+            episode='E03',
+            webdv='',
+            hdr='',
+            uhd='',
+        )
+        name = self._run(meta)
+        assert 'S01E03' in name, f"Season+episode missing: {name}"
+        assert 'DVDRip' in name, f"DVDRip tag missing: {name}"
+        assert name.endswith('x264-SGF'), f"Video encode not at end: {name}"


### PR DESCRIPTION
## Problem
G3MINI staff rejected uploads because the release name had incorrect ordering:
- **Hybrid** was placed before language tags instead of next to DV.HDR
- **Video codec** (HEVC) appeared before audio instead of at the end before the group tag

**Before:** `Title.2005.Hybrid.MULTi.2160p.UHD.BluRay.REMUX.DV.HDR.HEVC.DTSX.7.1-SGF`
**After:**  `Title.2005.MULTi.2160p.UHD.BluRay.REMUX.Hybrid.DV.HDR.DTSX.7.1.HEVC-SGF`

## Changes
- **`src/trackers/G3MINI.py`**: Reordered all MOVIE and TV templates (DISC, REMUX, ENCODE, WEBDL, WEBRIP) so that:
  - `{hybrid}` sits directly before `{hdr}` (after REMUX/source)
  - `{video_codec}`/`{video_encode}` comes after `{audio}` (end of name, before tag)
- **`tests/test_g3mini.py`** (new): 7 tests covering Hybrid positioning, video codec ordering, and the exact rejection case

## Testing
All 593 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Reordered tokens in generated release names for movies and TV to improve consistency and readability—moved video codec, audio, HDR/Hybrid, language, region, source, UHD and related tokens across various formats (REMUX/ENCODE/WEBDL/WEBRIP/DVDRIP/BDMV/HDDVD/HDTV).

* **Tests**
  * Added comprehensive tests validating naming order across formats, season/episode handling, language placement, case-sensitivity and numerous edge cases to ensure stable release-name output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->