### PR TITLE
fix: increase timeout to check if torrent was added

### DIFF
--- a/src/torrent_clients/qbittorrent.py
+++ b/src/torrent_clients/qbittorrent.py
@@ -875,7 +875,7 @@ class QbittorrentClientMixin:
                     if qbt_client is None:
                         raise RuntimeError("qbt_client cannot be None")
                     torrents_info = await self.retry_qbt_operation(
-                        lambda: asyncio.to_thread(qbt_client.torrents_info, torrent_hashes=torrent.infohash), "Check torrent addition", max_retries=1, initial_timeout=10.0
+                        lambda: asyncio.to_thread(qbt_client.torrents_info, torrent_hashes=torrent.infohash), "Check torrent addition", initial_timeout=10.0
                     )
                     if len(torrents_info) > 0:
                         break


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of torrent client operations by increasing retry attempts for failed operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->