### PR TITLE
fix(HDF): use hex pattern for torrent ID extraction

### DIFF
--- a/src/trackers/HDF.py
+++ b/src/trackers/HDF.py
@@ -880,7 +880,7 @@ class HDF(FrenchTrackerMixin):
             torrent_field_name="file_input",
             upload_cookies=self.session.cookies,
             upload_url=self.upload_url,
-            id_pattern=r"torrentid=(\d+)",
+            id_pattern=r"torrentid=([a-fA-F0-9]+)",
             success_text="torrents.php?id=",
         )
 

--- a/tests/test_hdf.py
+++ b/tests/test_hdf.py
@@ -871,3 +871,27 @@ class TestArtistsFallback:
         data = asyncio.run(tracker.get_data(meta))
         assert "artists[]" in data
         assert "1" in data["importance[]"]
+
+
+# ─── Upload configuration ────────────────────────────────────────────
+
+
+class TestUploadConfig:
+    """Verify upload method passes correct parameters."""
+
+    def test_id_pattern_matches_hex_hashes(self):
+        """id_pattern must capture full hex hashes, not just leading digits."""
+        import re
+
+        pattern = r"torrentid=([a-fA-F0-9]+)"
+        # Hash starting with a letter
+        url = "https://hdf.world/torrents.php?id=123&torrentid=ceb30e7c7aa019be65b5d18bbaf332384975df92"
+        match = re.search(pattern, url)
+        assert match is not None
+        assert match.group(1) == "ceb30e7c7aa019be65b5d18bbaf332384975df92"
+
+        # Hash starting with digits (should capture full hash, not just digits)
+        url2 = "https://hdf.world/torrents.php?id=456&torrentid=114c638c3d93e32ff404ff769d172b6a4bf5ee7a"
+        match2 = re.search(pattern, url2)
+        assert match2 is not None
+        assert match2.group(1) == "114c638c3d93e32ff404ff769d172b6a4bf5ee7a"


### PR DESCRIPTION
## Problem

HDF uses hex hashes as torrent IDs (e.g. `ceb30e7c7aa019be65b5d18bbaf332384975df92`), not numeric IDs.

The previous `id_pattern=r"torrentid=(\d+)"` would:
- **Fail entirely** for hashes starting with a letter (e.g. `ceb30e...` → no match)
- **Capture only leading digits** for hashes starting with numbers (e.g. `114c638c...` → captures only `114`)

## Fix

Change `id_pattern` from `\d+` to `[a-fA-F0-9]+` to capture the full hex hash.

## Tests

Added `TestUploadConfig::test_id_pattern_matches_hex_hashes` covering both cases (hash starting with letter and hash starting with digits).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated HDF torrent upload to properly extract and identify torrent IDs using hexadecimal format (alphanumeric identifiers) in addition to decimal numbers, improving compatibility with server response parsing.

* **Tests**
  * Added validation test for hexadecimal torrent ID pattern matching in HDF uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->