### PR TITLE
feat(NST): update langue to new allowed values (Français, VF, VFF, VF…

### DIFF
--- a/src/trackers/NST.py
+++ b/src/trackers/NST.py
@@ -378,7 +378,7 @@ class NST(FrenchTrackerMixin, UNIT3D):
         """Derive the NST langue tag from the release name / audio metadata.
 
         NST accepts: Français, VF, VFF, VFI, VFQ.
-        FrenchTrackerMixin embeds VFF/VFQ/VFI/VF2/VOF etc. in the name.
+        FrenchTrackerMixin embeds VFF/VFQ/VFI/VF/VF2/VF3/VOF etc. in the name.
         """
         name = meta.get("name", "")
         upper = name.upper()
@@ -388,8 +388,8 @@ class NST(FrenchTrackerMixin, UNIT3D):
             if f".{tag}." in upper or upper.endswith(f".{tag}"):
                 return tag
 
-        # VF2 (dual VFF+VFQ) → generic VF
-        if ".VF2." in upper or upper.endswith(".VF2"):
+        # Generic VF with optional digits (VF, VF2, VF3, VF4 …) → "VF"
+        if re.search(r"\.VF\d*(\.|$)", upper):
             return "VF"
 
         # VOF (original French) → Français

--- a/tests/test_nst.py
+++ b/tests/test_nst.py
@@ -318,6 +318,15 @@ class TestDetectNstLangue:
     def test_vf2_maps_to_vf(self):
         assert NST._detect_nst_langue({"name": "Movie.2026.VF2.1080p.WEB.H264-GRP"}) == "VF"
 
+    def test_plain_vf_maps_to_vf(self):
+        assert NST._detect_nst_langue({"name": "Movie.2026.VF.1080p.WEB.H264-GRP"}) == "VF"
+
+    def test_vf3_maps_to_vf(self):
+        assert NST._detect_nst_langue({"name": "Movie.2026.VF3.1080p.WEB.H264-GRP"}) == "VF"
+
+    def test_vf_at_end_of_name(self):
+        assert NST._detect_nst_langue({"name": "Movie.2026.1080p.WEB.VF"}) == "VF"
+
     def test_vof_maps_to_francais(self):
         assert NST._detect_nst_langue({"name": "Movie.2026.VOF.1080p.WEB.H264-GRP"}) == "Français"
 


### PR DESCRIPTION
…I, VFQ)

NST dropped Multi, Anglais, VOSTFR, VFSTFR, Muet from their langue field. Rewrite _detect_nst_langue to detect VF variant tags (.VFF., .VFQ., .VFI., .VF2., .VOF., .MULTI.VFF. etc.) from the release name, falling back to audio_languages for generic Français.  Update all tests accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Refined NST language detection to prioritize explicit VF variant tags (VFF, VFQ, VFI, VF) and better map VO/French indicators to "Français"; reduced reliance on inferred "Multi"/English from audio listings.
* **Tests**
  * Updated unit tests to reflect new detection outputs and adjusted expectations for various release-name scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->