### PR TITLE
fix(HDF): version flags missed due to edition.py stripping

### DIFF
--- a/src/trackers/HDF.py
+++ b/src/trackers/HDF.py
@@ -306,12 +306,16 @@ class HDF(FrenchTrackerMixin):
         """
         versions: list[str] = []
         edition = str(meta.get("edition", "")).lower()
+        # edition.py strips some words ("remastered", "version") from
+        # meta["edition"], so fall back to the original folder/file name
+        # stored in meta["uuid"] for markers that may have been removed.
+        uuid_upper = str(meta.get("uuid", "")).upper().replace(".", " ")
 
-        if "remaster" in edition:
+        if "remaster" in edition or "REMASTER" in uuid_upper:
             versions.append("Remaster")
         if "director" in edition:
             versions.append("Director's Cut")
-        if "extended" in edition or "version longue" in edition:
+        if "extended" in edition or "version longue" in edition or ("VERSION" in uuid_upper and "LONGUE" in uuid_upper):
             versions.append("Version Longue")
         if "uncut" in edition:
             versions.append("UnCut")
@@ -321,7 +325,8 @@ class HDF(FrenchTrackerMixin):
             versions.append("2in1")
         if "criterion" in edition:
             versions.append("Criterion")
-        if "hybrid" in edition or "custom" in edition:
+        webdv = str(meta.get("webdv", "")).lower()
+        if webdv in ("hybrid", "custom") or "hybrid" in edition or "custom" in edition:
             versions.append("Custom / HYBRiD")
         if "imax" in edition:
             versions.append("IMAX")

--- a/tests/test_hdf.py
+++ b/tests/test_hdf.py
@@ -276,8 +276,18 @@ class TestGetVersions:
         versions = HDF._get_versions(_meta_base(edition="Remaster"))
         assert "Remaster" in versions
 
+    def test_remastered_stripped_by_edition_py(self):
+        """edition.py strips 'Remastered' from edition; uuid fallback catches it."""
+        versions = HDF._get_versions(_meta_base(edition="", uuid="Movie.1999.REMASTERED.1080p.BluRay.x264-GRP"))
+        assert "Remaster" in versions
+
     def test_extended(self):
         versions = HDF._get_versions(_meta_base(edition="Extended"))
+        assert "Version Longue" in versions
+
+    def test_version_longue_stripped_by_edition_py(self):
+        """edition.py strips 'version' from edition; uuid fallback catches it."""
+        versions = HDF._get_versions(_meta_base(edition="", uuid="Movie.2001.VERSION.LONGUE.1080p.BluRay.x264-GRP"))
         assert "Version Longue" in versions
 
     def test_hdr_dv(self):
@@ -318,6 +328,16 @@ class TestGetVersions:
         assert "Source AppleTV" in versions
 
     def test_hybrid(self):
+        # webdv flag (normal path — edition is stripped by edition.py)
+        versions = HDF._get_versions(_meta_base(webdv="Hybrid"))
+        assert "Custom / HYBRiD" in versions
+
+    def test_custom(self):
+        versions = HDF._get_versions(_meta_base(webdv="Custom"))
+        assert "Custom / HYBRiD" in versions
+
+    def test_hybrid_fallback_edition(self):
+        # Fallback: if "hybrid" still appears in edition somehow
         versions = HDF._get_versions(_meta_base(edition="HYBRiD"))
         assert "Custom / HYBRiD" in versions
 


### PR DESCRIPTION
## Problem

`edition.py` strips certain words from `meta["edition"]` before HDF sees them:
- **"remastered"** → in the `bad` list → removed → Remaster checkbox never ticked
- **"version"** → in the `bad` list → "Version Longue" becomes "LONGUE" → checkbox missed
- **Hybrid/Custom** → moved to `meta["webdv"]` → `meta["edition"]` emptied

## Fix

- **Custom / HYBRiD**: check `meta["webdv"]` (where `edition.py` stores the flag)
- **Remaster**: fall back to `meta["uuid"]` (original folder/file name)
- **Version Longue**: same uuid fallback for the stripped "version" word

## Tests

+4 tests for cases where the flag is recovered despite `edition.py` cleanup (118 total).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of release variants (Remaster, Version Longue, Custom/HYBRiD) through additional metadata sources.

* **Tests**
  * Added test coverage for version detection using multiple metadata sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->