### PR TITLE
feat(French): default track indicator + subtitle element count

### DIFF
--- a/src/trackers/FRENCH.py
+++ b/src/trackers/FRENCH.py
@@ -1165,6 +1165,8 @@ class FrenchTrackerMixin:
                     current["channel_layout"] = val
                 elif key == "Title":
                     current["title"] = val
+                elif key == "Default":
+                    current["default"] = val
 
         if current:
             tracks.append(current)
@@ -1205,6 +1207,8 @@ class FrenchTrackerMixin:
                     current["forced"] = val
                 elif key == "Default":
                     current["default"] = val
+                elif key == "Count of elements":
+                    current["element_count"] = val
 
         if current:
             tracks.append(current)
@@ -1443,6 +1447,7 @@ class FrenchTrackerMixin:
             except (AttributeError, TypeError):
                 pass
 
+        default_found = False
         for i, at in enumerate(tracks):
             lang = at.get("language", "Unknown")
             flag = self._lang_to_flag(lang)
@@ -1567,6 +1572,11 @@ class FrenchTrackerMixin:
                 elif lang_region == "hans":
                     name = "Cantonais (simplifié)"
 
+            # ── Default track detection ──
+            is_default = at.get("default", "").lower() == "yes" and not default_found
+            if is_default:
+                default_found = True
+
             # ── Audio Description detection ──
             is_audio_desc = self._is_audio_desc_track(at)
 
@@ -1602,6 +1612,8 @@ class FrenchTrackerMixin:
                 parts.append(" [AD]")
             if commentary_tag:
                 parts.append(f" [{commentary_tag}]")
+            if is_default:
+                parts.append(" (piste par défaut)")
             if layout:
                 parts.append(f" [{layout}]")
             codec = commercial or fmt
@@ -1641,6 +1653,7 @@ class FrenchTrackerMixin:
             except (AttributeError, TypeError):
                 pass
 
+        default_found = False
         for i, st in enumerate(tracks):
             lang = st.get("language", "") or "Unknown"
             flag = self._lang_to_flag(lang)
@@ -1648,6 +1661,10 @@ class FrenchTrackerMixin:
             fmt = st.get("format", "")
             fmt_short = self._sub_format_short(fmt) if fmt else ""
             forced = st.get("forced", "").lower() == "yes"
+            is_default = st.get("default", "").lower() == "yes" and not default_found
+            if is_default:
+                default_found = True
+            element_count = st.get("element_count", "")
             title = st.get("title", "")
 
             # Detect forced from title field too
@@ -1771,11 +1788,29 @@ class FrenchTrackerMixin:
             if is_commentary:
                 qualifier += ", commentaire"
 
-            parts: list[str] = [f"{flag} {name}"]
-            if fmt_short:
-                parts.append(f" : {fmt_short} ({qualifier})")
+            # Default / forced status indicator
+            if is_default and forced:
+                status = " (piste par défaut et forcée)"
+            elif is_default:
+                status = " (piste par défaut)"
+            elif forced:
+                status = " (piste forcée)"
             else:
-                parts.append(f" ({qualifier})")
+                status = ""
+
+            # Element count display
+            count_part = f", {element_count} éléments" if element_count else ""
+
+            # Parenthesized info after format: (qualifier, N éléments)
+            paren_inner = f"{qualifier}{count_part}"
+
+            parts: list[str] = [f"{flag} {name}"]
+            if status:
+                parts.append(status)
+            if fmt_short:
+                parts.append(f" : {fmt_short} ({paren_inner})" if paren_inner else f" : {fmt_short}")
+            elif paren_inner:
+                parts.append(f" ({paren_inner})")
             lines.append("".join(parts))
         return lines
 

--- a/tests/test_french_dupe.py
+++ b/tests/test_french_dupe.py
@@ -1295,6 +1295,56 @@ class TestFormatAudioBbcode:
         c = C411(_config())
         assert c._format_audio_bbcode('') == []
 
+    def test_default_track_indicator(self):
+        mi = (
+            "Audio #1\n"
+            "Language                                 : French\n"
+            "Commercial name                          : AC3\n"
+            "Channel(s)                               : 6 channels\n"
+            "Bit rate                                 : 384 kb/s\n"
+            "Default                                  : Yes\n"
+            "\nAudio #2\n"
+            "Language                                 : English\n"
+            "Commercial name                          : AC3\n"
+            "Channel(s)                               : 6 channels\n"
+            "Bit rate                                 : 384 kb/s\n"
+            "Default                                  : No\n"
+        )
+        c = C411(_config())
+        lines = c._format_audio_bbcode(mi)
+        assert len(lines) == 2
+        assert '(piste par d\u00e9faut)' in lines[0]
+        assert '(piste par d\u00e9faut)' not in lines[1]
+
+    def test_default_only_first_yes(self):
+        """Only the first track with Default=Yes gets the indicator."""
+        mi = (
+            "Audio #1\n"
+            "Language                                 : French\n"
+            "Commercial name                          : AC3\n"
+            "Default                                  : Yes\n"
+            "\nAudio #2\n"
+            "Language                                 : English\n"
+            "Commercial name                          : AC3\n"
+            "Default                                  : Yes\n"
+        )
+        c = C411(_config())
+        lines = c._format_audio_bbcode(mi)
+        assert '(piste par d\u00e9faut)' in lines[0]
+        assert '(piste par d\u00e9faut)' not in lines[1]
+
+    def test_no_default_track(self):
+        """When no track has Default=Yes, no indicator is shown."""
+        mi = (
+            "Audio\n"
+            "Language                                 : French\n"
+            "Commercial name                          : AC3\n"
+            "Default                                  : No\n"
+        )
+        c = C411(_config())
+        lines = c._format_audio_bbcode(mi)
+        assert '(piste par d\u00e9faut)' not in lines[0]
+
 
 class TestFormatSubtitleBbcode:
     """Test _format_subtitle_bbcode from the mixin."""
@@ -1354,6 +1404,98 @@ class TestFormatSubtitleBbcode:
     def test_empty_mi(self):
         c = C411(_config())
         assert c._format_subtitle_bbcode('') == []
+
+    def test_element_count(self):
+        mi = (
+            "Text\n"
+            "Language                                 : French\n"
+            "Format                                   : UTF-8\n"
+            "Forced                                   : No\n"
+            "Count of elements                        : 858\n"
+        )
+        c = C411(_config())
+        lines = c._format_subtitle_bbcode(mi)
+        assert len(lines) == 1
+        assert '858 \u00e9l\u00e9ments' in lines[0]
+
+    def test_default_and_forced_subtitle(self):
+        mi = (
+            "Text\n"
+            "Language                                 : French\n"
+            "Format                                   : UTF-8\n"
+            "Default                                  : Yes\n"
+            "Forced                                   : Yes\n"
+            "Count of elements                        : 49\n"
+        )
+        c = C411(_config())
+        lines = c._format_subtitle_bbcode(mi)
+        assert len(lines) == 1
+        assert 'piste par d\u00e9faut et forc\u00e9e' in lines[0]
+        assert 'forc\u00e9s' in lines[0]
+        assert '49 \u00e9l\u00e9ments' in lines[0]
+
+    def test_forced_but_not_default_subtitle(self):
+        mi = (
+            "Text\n"
+            "Language                                 : French\n"
+            "Format                                   : UTF-8\n"
+            "Default                                  : No\n"
+            "Forced                                   : Yes\n"
+        )
+        c = C411(_config())
+        lines = c._format_subtitle_bbcode(mi)
+        assert 'piste forc\u00e9e' in lines[0]
+        assert 'piste par d\u00e9faut' not in lines[0]
+
+    def test_default_not_forced_subtitle(self):
+        mi = (
+            "Text\n"
+            "Language                                 : French\n"
+            "Format                                   : UTF-8\n"
+            "Default                                  : Yes\n"
+            "Forced                                   : No\n"
+        )
+        c = C411(_config())
+        lines = c._format_subtitle_bbcode(mi)
+        assert 'piste par d\u00e9faut)' in lines[0]
+        assert 'forc\u00e9e' not in lines[0]
+
+    def test_full_subtitle_example(self):
+        """Test the complete GoodFellas-like scenario from issue #111."""
+        mi = (
+            "Text #1\n"
+            "Language                                 : French\n"
+            "Format                                   : UTF-8\n"
+            "Title                                    : Forced\n"
+            "Default                                  : Yes\n"
+            "Forced                                   : Yes\n"
+            "Count of elements                        : 49\n"
+            "\nText #2\n"
+            "Language                                 : French\n"
+            "Format                                   : UTF-8\n"
+            "Default                                  : No\n"
+            "Forced                                   : No\n"
+            "Count of elements                        : 858\n"
+            "\nText #3\n"
+            "Language                                 : English\n"
+            "Format                                   : UTF-8\n"
+            "Default                                  : No\n"
+            "Forced                                   : No\n"
+            "Count of elements                        : 823\n"
+        )
+        c = C411(_config())
+        lines = c._format_subtitle_bbcode(mi)
+        assert len(lines) == 3
+        # Track 1: French forced + default
+        assert 'forc\u00e9s' in lines[0]
+        assert 'piste par d\u00e9faut et forc\u00e9e' in lines[0]
+        assert '49 \u00e9l\u00e9ments' in lines[0]
+        # Track 2: French complets
+        assert 'complets' in lines[1]
+        assert '858 \u00e9l\u00e9ments' in lines[1]
+        # Track 3: English complets
+        assert 'Anglais' in lines[2]
+        assert '823 \u00e9l\u00e9ments' in lines[2]
 
 
 class TestFormatHdrDvBbcode:


### PR DESCRIPTION
Closes #111

## Changes

Enhancements to `FrenchTrackerMixin._format_audio_bbcode` and `_format_subtitle_bbcode` — applies to all French trackers (C411, TORR9, GF, HDF, NST, etc.).

### Audio tracks

- Parse `Default` field from MediaInfo text
- Show `(piste par défaut)` on the first track with `Default: Yes`

```
🇫🇷 Français (piste par défaut) [5.1] : Dolby Digital @ 384 kb/s
🇺🇸 Anglais [5.1] : Dolby Digital Plus @ 768 kb/s
🇫🇷 Français [AD] [5.1] : Dolby Digital @ 384 kb/s
```

### Subtitle tracks

- Parse `Count of elements` from MediaInfo text
- Show element count: `SRT (858 éléments)`
- Show default/forced status: `(piste par défaut et forcée)`, `(piste par défaut)`, `(piste forcée)`
- Capitalize qualifier tag: `Forcés`, `Complets`, `SDH`

```
🇫🇷 Français Forcés (piste par défaut et forcée) : SRT (49 éléments)
🇫🇷 Français Complets : SRT (858 éléments)
🇺🇸 Anglais SDH : SRT (823 éléments)
```

## Tests

+8 new tests, 803 total (all pass).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved French track labels: detect and mark the first default audio track only, and show combined default/forced status for subtitles.
  * Display subtitle element counts and refine placement and wording of French status qualifiers.

* **Tests**
  * Added comprehensive tests covering audio/subtitle default/forced labeling, element counts, and multi-track scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->