### PR TITLE
(NST) FIX: French titles and remove UHD tag for encode

### DIFF
--- a/src/trackers/NST.py
+++ b/src/trackers/NST.py
@@ -8,6 +8,7 @@ import aiofiles
 from src.console import console
 from src.get_desc import DescriptionBuilder
 from src.rehostimages import RehostImagesManager
+from src.tmdb import TmdbManager
 from src.trackers.COMMON import COMMON
 from src.trackers.FRENCH import FrenchTrackerMixin
 from src.trackers.UNIT3D import UNIT3D
@@ -43,6 +44,7 @@ class NST(FrenchTrackerMixin, UNIT3D):
         self.torrent_url = f"{self.base_url}/torrents/"
         self.rehost_images_manager = RehostImagesManager(config)
         self.approved_image_hosts = ["imgbox", "ptscreens", "onlyimage", "pixhost"]
+        self.tmdb_manager = TmdbManager(config)
         self.banned_groups: list[str] = []
         self.source_flag = "NST"
 
@@ -55,6 +57,8 @@ class NST(FrenchTrackerMixin, UNIT3D):
 
     # NST wants streaming service in name
     INCLUDE_SERVICE_IN_NAME: bool = True
+
+    UHD_ONLY_FOR_REMUX_DISC: bool = True
 
     # ── Category helpers ──────────────────────────────────────────────
 


### PR DESCRIPTION
         - Import TmdbManager to get PREFER_ORIGINAL_TITLE workins
         - Add UHD_ONLY_FOR_REMUX_DISC to remove UHD from title when it's an encode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * NST tracker now integrates TMDB for enhanced metadata support.
  * UHD-only behavior updated for remux disc releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->