### PR TITLE
chore: merge upstream Audionut/Upload-Assistant v7.1.4

### DIFF
--- a/data/version.py
+++ b/data/version.py
@@ -1,4 +1,19 @@
-__version__ = "v7.1.3"
+__version__ = "v7.1.4"
+
+"""
+Release Notes for version v7.1.4 (2026-04-16):
+
+# ## What's Changed
+# 
+# * ANT: key in header by @Audionut in 27cb44e
+# * DP: banned groups by @Audionut in d1da3dc
+# * BHD: encode settings by @Audionut in 4066131
+# * fix tvmovie handle when no imdb by @Audionut in 323b3e3
+# * fix: ffmpeg round to even scale by @Audionut in 2f614c5
+# 
+# **Full Changelog**: https://github.com/Audionut/Upload-Assistant/compare/v7.1.3...v7.1.4
+"""
+
 
 """
 Release Notes for version v7.1.3 (2026-04-14):

--- a/data/version.py
+++ b/data/version.py
@@ -1,4 +1,21 @@
-__version__ = "v7.1.2"
+__version__ = "v7.1.3"
+
+"""
+Release Notes for version v7.1.3 (2026-04-14):
+
+# ## What's Changed
+# 
+# * mkbrr: add windows arm support by @Audionut in 0fabdb0
+# * fix: bdmv playlist scoring by @Audionut in a5a7693
+# * OTW: only 1 resolution per episode by @Audionut in daef192
+# * fix(ASC): missing TMDB data for description building (#1331) by @wastaken7 in 8040523
+# * feat: add support for CBR pending torrents API (#1332) by @wastaken7 in f5e420b
+# * ANT bdinfo update (#1334) by @Audionut in cf42a25
+# * Improved season pack pattern check for anime (#1335) by @Khoa Pham in 2d1b0cf
+# 
+# **Full Changelog**: https://github.com/Audionut/Upload-Assistant/compare/v7.1.2...v7.1.3
+"""
+
 
 """
 Release Notes for version v7.1.2 (2026-03-28):

--- a/data/version.py
+++ b/data/version.py
@@ -2721,4 +2721,4 @@ __version__ = "3.5.3.1"
 # The historical __version__ assignments above (one per
 # release-notes block) are kept for reference.  The *real*
 # runtime version must come last so it wins at import time.
-__version__ = "v7.1.2"
+__version__ = "v7.1.4"

--- a/src/dupe_checking.py
+++ b/src/dupe_checking.py
@@ -467,7 +467,7 @@ class DupeChecker:
 
                 if same_season_episode_dupe and (target_resolution.lower() not in each.lower()):
                     await log_exclusion(f"OTW same-season episode resolution mismatch: expected '{target_resolution}'", each)
-                    return False
+                    return True
 
             if not skip_resolution_check:
                 if target_resolution and target_resolution not in each:

--- a/src/dupe_checking.py
+++ b/src/dupe_checking.py
@@ -458,20 +458,11 @@ class DupeChecker:
 
             skip_resolution_check = bool(is_dvd or "DVD" in target_source or is_dvdrip)
 
-            if (
-                tracker_name == "OTW"
-                and not is_tv_pack
-                and meta.get("category") == "TV"
-                and target_episode
-                and target_resolution
-            ):
+            if tracker_name == "OTW" and not is_tv_pack and meta.get("category") == "TV" and target_episode and target_resolution:
                 dupe_season_match = re.search(r"[sS](\d+)", each)
                 dupe_has_episode = bool(re.search(r"[eE]\d{2}", each))
                 same_season_episode_dupe = (
-                    target_season_number is not None
-                    and dupe_season_match is not None
-                    and int(dupe_season_match.group(1)) == target_season_number
-                    and dupe_has_episode
+                    target_season_number is not None and dupe_season_match is not None and int(dupe_season_match.group(1)) == target_season_number and dupe_has_episode
                 )
 
                 if same_season_episode_dupe and (target_resolution.lower() not in each.lower()):

--- a/src/dupe_checking.py
+++ b/src/dupe_checking.py
@@ -158,6 +158,9 @@ class DupeChecker:
         is_hdtv = meta.get('type') == "HDTV"
         target_source = str(meta.get("source", ""))
         is_sd = int(meta.get('sd') or 0)
+        is_tv_pack = meta.get('category') == "TV" and (coerce_int(meta.get('tv_pack')) or 0) == 1
+        target_season_match = re.search(r'[sS](\d+)', str(target_season or ""))
+        target_season_number = int(target_season_match.group(1)) if target_season_match else None
 
         filenames: list[str] = []
         filelist_value = meta.get('filelist')
@@ -425,6 +428,26 @@ class DupeChecker:
                 return True
 
             skip_resolution_check = bool(is_dvd or "DVD" in target_source or is_dvdrip)
+
+            if (
+                tracker_name == "OTW"
+                and not is_tv_pack
+                and meta.get('category') == "TV"
+                and target_episode
+                and target_resolution
+            ):
+                dupe_season_match = re.search(r'[sS](\d+)', each)
+                dupe_has_episode = bool(re.search(r'[eE]\d{2}', each))
+                same_season_episode_dupe = (
+                    target_season_number is not None
+                    and dupe_season_match is not None
+                    and int(dupe_season_match.group(1)) == target_season_number
+                    and dupe_has_episode
+                )
+
+                if same_season_episode_dupe and (target_resolution.lower() not in each.lower()):
+                    await log_exclusion(f"OTW same-season episode resolution mismatch: expected '{target_resolution}'", each)
+                    return False
 
             if not skip_resolution_check:
                 if target_resolution and target_resolution not in each:

--- a/src/getseasonep.py
+++ b/src/getseasonep.py
@@ -417,7 +417,7 @@ class SeasonEpisodeManager:
         episode_only_pattern = r'\b[Ee](\d{1,3})(?:[Ee](\d{1,3}))?\b'
 
         # Pattern for anime: " - 43 (1080p)" or "43 (1080p)" or similar
-        anime_pattern = r'(?:\s-\s)?(\d{1,3})\s*\((?:\d+p|480p|480i|576i|576p|720p|1080i|1080p|2160p)\)'
+        anime_pattern = r'(?:\s-\s)?(\d{1,4})(?:v\d+)?\s*\((?:\d+[pi])\)'
 
         # Normalize season_int once so all (season, episode) tuples are (int, int)
         raw_season_int = meta.get('season_int', 1)

--- a/src/prep.py
+++ b/src/prep.py
@@ -968,12 +968,14 @@ class Prep:
 
         # lets check for tv movies
         meta['tv_movie'] = False
-        is_tv_movie = meta.get('imdb_info', {}).get('type', '')
-        tv_movie_keywords = ['tv movie', 'tv special', 'tvmovie']
-        if any(re.search(rf'(^|,\s*){re.escape(keyword)}(\s*,|$)', is_tv_movie, re.IGNORECASE) for keyword in tv_movie_keywords):
-            if meta['debug']:
-                console.print(f"[yellow]Identified as TV Movie based on IMDb type: {is_tv_movie}[/yellow]")
-            meta['tv_movie'] = True
+        if meta['imdb_id'] != 0:
+            is_tv_movie = meta.get('imdb_info', {}).get('type', '')
+            if is_tv_movie:
+                tv_movie_keywords = ['tv movie', 'tv special', 'tvmovie']
+                if any(re.search(rf'(^|,\s*){re.escape(keyword)}(\s*,|$)', is_tv_movie, re.IGNORECASE) for keyword in tv_movie_keywords):
+                    if meta['debug']:
+                        console.print(f"[yellow]Identified as TV Movie based on IMDb type: {is_tv_movie}[/yellow]")
+                    meta['tv_movie'] = True
 
         if meta['category'] == "TV" or meta.get('tv_movie', False):
             both_ids_searched = False

--- a/src/takescreens.py
+++ b/src/takescreens.py
@@ -106,6 +106,13 @@ async def sanitize_filename(filename: str) -> str:
     return re.sub(r'[<>:"/\\|?*]', '_', filename)
 
 
+def round_to_even(value: float) -> int:
+    rounded = int(round(value))
+    if rounded % 2 != 0:
+        rounded += 1
+    return rounded
+
+
 async def disc_screenshots(
         meta: dict[str, Any],
         filename: str,
@@ -772,8 +779,8 @@ async def capture_dvd_screenshot(task: tuple[int, str, str, str, dict[str, Any],
         # Build filter chain
         vf_filters: list[str] = []
         if w_sar != 1 or h_sar != 1:
-            scaled_w = int(round(width * w_sar))
-            scaled_h = int(round(height * h_sar))
+            scaled_w = round_to_even(width * w_sar)
+            scaled_h = round_to_even(height * h_sar)
             vf_filters.append(f"scale={scaled_w}:{scaled_h}")
 
         if meta.get('frame_overlay', False):
@@ -1266,8 +1273,8 @@ async def capture_screenshot(args: tuple[int, str, float, str, float, float, flo
         if ss_time < 0:
             return None
 
-        scaled_w = int(round(width * w_sar))
-        scaled_h = int(round(height * h_sar))
+        scaled_w = round_to_even(width * w_sar)
+        scaled_h = round_to_even(height * h_sar)
 
         # Normalize path for cross-platform compatibility
         path = os.path.normpath(path)
@@ -1313,8 +1320,8 @@ async def capture_screenshot(args: tuple[int, str, float, str, float, float, flo
             vf_filters: list[str] = []
 
             if w_sar != 1 or h_sar != 1:
-                scaled_w = int(round(width * w_sar))
-                scaled_h = int(round(height * h_sar))
+                scaled_w = round_to_even(width * w_sar)
+                scaled_h = round_to_even(height * h_sar)
                 vf_filters.append(f"scale={scaled_w}:{scaled_h}")
                 if loglevel == 'verbose' or (meta and meta.get('debug', False)):
                     console.print(f"[cyan]Applied PAR scale -> {scaled_w}x{scaled_h}[/cyan]")
@@ -1435,8 +1442,8 @@ async def capture_screenshot(args: tuple[int, str, float, str, float, float, flo
         vf_filters: list[str] = []
 
         if w_sar != 1 or h_sar != 1:
-            scaled_w = int(round(width * w_sar))
-            scaled_h = int(round(height * h_sar))
+            scaled_w = round_to_even(width * w_sar)
+            scaled_h = round_to_even(height * h_sar)
             vf_filters.append(f"scale={scaled_w}:{scaled_h}")
 
         if hdr_tonemap:
@@ -1687,7 +1694,9 @@ async def check_libplacebo_compatibility(w_sar: float, h_sar: float, width: floa
         output_map = "0:v"  # Default output mapping
 
         if w_sar != 1 or h_sar != 1:
-            filter_parts.append(f"{input_label}scale={int(round(width * w_sar))}:{int(round(height * h_sar))}[scaled]")
+            scaled_w = round_to_even(width * w_sar)
+            scaled_h = round_to_even(height * h_sar)
+            filter_parts.append(f"{input_label}scale={scaled_w}:{scaled_h}[scaled]")
             input_label = "[scaled]"
             output_map = "[scaled]"
 

--- a/src/trackers/ANT.py
+++ b/src/trackers/ANT.py
@@ -120,7 +120,7 @@ class ANT:
             flags.append("HDR10")
         if "DV" in meta["hdr"]:
             flags.append("DV")
-        if "Criterion" in (meta.get("distributor", "") or meta.get("edition", "")):
+        if "Criterion" in meta.get("distributor", "") or "Criterion" in meta.get("edition", ""):
             flags.append("Criterion")
         if "REMUX" in meta["type"]:
             flags.append("Remux")

--- a/src/trackers/ANT.py
+++ b/src/trackers/ANT.py
@@ -273,12 +273,21 @@ class ANT:
         }
 
         if meta.get("is_disc", "") == "BDMV":
-            async with aiofiles.open(f"{meta['base_dir']}/tmp/{meta['uuid']}/BD_SUMMARY_00.txt", encoding="utf-8") as f:
+            bdinfo_path = f"{meta['base_dir']}/tmp/{meta['uuid']}/BD_SUMMARY_00.txt"
+            if not os.path.exists(bdinfo_path):
+                console.print(f"[bold red]{self.tracker}: BD_SUMMARY_00.txt not found, cannot upload.[/bold red]")
+                meta["skipping"] = self.tracker
+                return False
+            async with aiofiles.open(bdinfo_path, encoding="utf-8") as f:
                 bdinfo_output = await f.read()
             data.update({"bdinfo": bdinfo_output})
             data.update({"container_type": "m2ts"})
         else:
             mi_path = f"{meta['base_dir']}/tmp/{meta['uuid']}/MEDIAINFO_CLEANPATH.txt"
+            if not os.path.exists(mi_path):
+                console.print(f"[bold red]{self.tracker}: MEDIAINFO_CLEANPATH.txt not found, cannot upload.[/bold red]")
+                meta["skipping"] = self.tracker
+                return False
             async with aiofiles.open(mi_path, encoding="utf-8") as f:
                 mediainfo_output = await f.read()
             data.update({"mediainfo": mediainfo_output})

--- a/src/trackers/ANT.py
+++ b/src/trackers/ANT.py
@@ -87,8 +87,8 @@ class ANT:
             "RMTeam",
             "SANTi",
             "SicFoI",
-            "SPASM",
             "SM737",
+            "SPASM",
             "SPDVD",
             "STUTTERSHIT",
             "TBS",
@@ -280,7 +280,7 @@ class ANT:
         else:
             mi_path = f"{meta['base_dir']}/tmp/{meta['uuid']}/MEDIAINFO_CLEANPATH.txt"
             async with aiofiles.open(mi_path, encoding="utf-8") as f:
-                mediainfo_output = str(await f.read())
+                mediainfo_output = await f.read()
             data.update({"mediainfo": mediainfo_output})
         if meta["scene"]:
             # ID of "Scene?" checkbox on upload form is actually "censored"

--- a/src/trackers/ANT.py
+++ b/src/trackers/ANT.py
@@ -32,11 +32,11 @@ class ANT:
         self.upload_url = 'https://anthelion.me/api.php'
         self.banned_groups = [
             '3LTON', '4yEo', 'ADE', 'AFG', 'AniHLS', 'AnimeRG', 'AniURL', 'AROMA', 'aXXo', 'Brrip', 'CHD', 'CM8',
-            'CrEwSaDe', 'd3g', 'DDR', 'DNL', 'DeadFish', 'ELiTE', 'eSc', 'FaNGDiNG0', 'FGT', 'Flights', 'FRDS',
-            'FUM', 'HAiKU', 'HD2DVD', 'HDS', 'HDTime', 'Hi10', 'ION10', 'iPlanet', 'JIVE', 'KiNGDOM', 'Leffe',
-            'LiGaS', 'LOAD', 'MeGusta', 'MkvCage', 'mHD', 'mSD', 'NhaNc3', 'nHD', 'NOIVTC', 'nSD', 'Oj', 'Ozlem',
-            'PiRaTeS', 'PRoDJi', 'RAPiDCOWS', 'RARBG', 'RetroPeeps', 'RDN', 'REsuRRecTioN', 'RMTeam', 'SANTi',
-            'SicFoI', 'SPASM', 'SPDVD', 'STUTTERSHIT', 'TBS', 'Telly', 'TM', 'UPiNSMOKE', 'URANiME', 'WAF', 'xRed',
+            'CrEwSaDe', 'd3g', 'DDR', 'DNL', 'DeadFish', 'ELiTE', 'eSc', 'EVO', 'FaNGDiNG0', 'FGT', 'FRDS', 'FUM',
+            'HAiKU', 'HD2DVD', 'HDS', 'HDTime', 'Hi10', 'ION10', 'iPlanet', 'JIVE', 'KiNGDOM', 'Leffe', 'LiGaS',
+            'LOAD', 'MeGusta', 'MkvCage', 'mHD', 'mSD', 'NhaNc3', 'nHD', 'NOIVTC', 'nSD', 'Oj', 'Ozlem', 'PiRaTeS',
+            'PRoDJi', 'RAPiDCOWS', 'RARBG', 'RetroPeeps', 'RDN', 'REsuRRecTioN', 'RMTeam', 'SANTi', 'SicFoI',
+            'SPASM', 'SM737', 'SPDVD', 'STUTTERSHIT', 'TBS', 'Telly', 'TM', 'UPiNSMOKE', 'URANiME', 'WAF', 'xRed',
             'XS', 'YIFY', 'YTS', 'Zeus', 'ZKBL', 'ZmN', 'ZMNT'
         ]
         pass
@@ -46,7 +46,7 @@ class ANT:
         flags.extend(
             [
                 each
-                for each in ['Directors', 'Extended', 'Uncut', 'Unrated', '4KRemaster']
+                for each in ['Directors', 'Extended', 'Uncut', 'Unrated', '4KRemaster', 'IMAX']
                 if each in str(meta.get('edition', '')).replace("'", "")
             ]
         )
@@ -65,7 +65,7 @@ class ANT:
             flags.append('HDR10')
         if "DV" in meta['hdr']:
             flags.append('DV')
-        if "Criterion" in meta.get('distributor', ''):
+        if "Criterion" in (meta.get('distributor', '') or meta.get('edition', '')):
             flags.append('Criterion')
         if "REMUX" in meta['type']:
             flags.append('Remux')
@@ -203,12 +203,22 @@ class ANT:
             'api_key': str(self.tracker_config.get('api_key', '')).strip(),
             'action': 'upload',
             'tmdbid': meta['tmdb'],
-            'mediainfo': await self.mediainfo(meta),
             'flags[]': flags,
             'release_desc': await self.edit_desc(meta),
         }
-        if meta['bdinfo'] is not None:
-            data.update({"media": "BluRay"})
+
+        if meta.get('is_disc', "") == "BDMV":
+            async with aiofiles.open(
+                f"{meta['base_dir']}/tmp/{meta['uuid']}/BD_SUMMARY_00.txt", encoding="utf-8"
+            ) as f:
+                bdinfo_output = await f.read()
+            data.update({"bdinfo": bdinfo_output})
+            data.update({"container_type": "m2ts"})
+        else:
+            mi_path = f"{meta['base_dir']}/tmp/{meta['uuid']}/MEDIAINFO_CLEANPATH.txt"
+            async with aiofiles.open(mi_path, encoding='utf-8') as f:
+                mediainfo_output = str(await f.read())
+            data.update({"mediainfo": mediainfo_output})
         if meta['scene']:
             # ID of "Scene?" checkbox on upload form is actually "censored"
             data['censored'] = 1
@@ -389,16 +399,6 @@ class ANT:
         console.print(f"{self.tracker}: Audio will be set to 'Other'. [bold red]Correct manually if necessary.[/bold red]")
         return "Other"
 
-    async def mediainfo(self, meta: Meta) -> str:
-        if meta.get('is_disc') == 'BDMV':
-            mediainfo = str(await self.common.get_bdmv_mediainfo(meta, remove=['File size', 'Overall bit rate'], char_limit=100000))
-        else:
-            mi_path = f"{meta['base_dir']}/tmp/{meta['uuid']}/MEDIAINFO_CLEANPATH.txt"
-            async with aiofiles.open(mi_path, encoding='utf-8') as f:
-                mediainfo = str(await f.read())
-
-        return mediainfo
-
     async def edit_desc(self, meta: Meta) -> str:
         builder = DescriptionBuilder(self.tracker, self.config)
         desc_parts: list[str] = []
@@ -415,11 +415,6 @@ class ANT:
                 if logo_resize_url.endswith(".svg"):
                     logo_resize_url = logo_resize_url.replace(".svg", ".png")
                 desc_parts.append(f"[align=center][img]https://image.tmdb.org/t/p/w300/{logo_resize_url}[/img][/align]")
-
-        # BDinfo
-        bdinfo = await builder.get_bdinfo_section(meta)
-        if bdinfo:
-            desc_parts.append(f"[spoiler=BDInfo][pre]{bdinfo}[/pre][/spoiler]")
 
         if user_desc:
             # User description

--- a/src/trackers/ANT.py
+++ b/src/trackers/ANT.py
@@ -475,7 +475,6 @@ class ANT:
             return dupes
 
         params = {
-            'apikey': api_key.strip(),
             't': 'search',
             'o': 'json'
         }
@@ -484,9 +483,14 @@ class ANT:
         elif int(meta['imdb_id']) != 0:
             params['imdb'] = meta['imdb']
 
+        headers = {
+            "X-API-Key": api_key.strip(),
+            'User-Agent': f'Upload Assistant/2.4 ({platform.system()} {platform.release()})'
+        }
+
         try:
             async with httpx.AsyncClient(timeout=15.0) as client:
-                response = await client.get(url=self.search_url, params=params)
+                response = await client.get(url=self.search_url, params=params, headers=headers)
                 if response.status_code == 200:
                     try:
                         data = response.json()
@@ -560,8 +564,12 @@ class ANT:
                 console.print(f"[yellow]{self.tracker}: API key not configured, skipping file-based search.")
             return imdb_tmdb_list
 
+        headers = {
+            "X-API-Key": api_key.strip(),
+            'User-Agent': f'Upload Assistant/2.4 ({platform.system()} {platform.release()})'
+        }
+
         params: dict[str, Any] = {
-            'apikey': api_key.strip(),
             't': 'search',
             'filename': filename,
             'o': 'json'
@@ -569,7 +577,7 @@ class ANT:
 
         try:
             async with httpx.AsyncClient(timeout=15.0) as client:
-                response = await client.get(url=self.search_url, params=params)
+                response = await client.get(url=self.search_url, params=params, headers=headers)
                 if response.status_code == 200:
                     try:
                         data = response.json()

--- a/src/trackers/ASC.py
+++ b/src/trackers/ASC.py
@@ -111,7 +111,7 @@ class ASC:
                 self.season_tmdb_data = local_results['season']
             else:
                 tasks_to_run.append(
-                    ('season', self.tmdb_manager.get_tmdb_localized_data(meta, data_type='season', language='pt-BR', append_to_response=''))
+                    ('season', self.tmdb_manager.get_tmdb_localized_data(meta, data_type='season', language='pt-BR', append_to_response='credits'))
                 )
 
         if meta.get('category') == 'TV' and not meta.get('tv_pack', False):
@@ -119,7 +119,7 @@ class ASC:
                 self.episode_tmdb_data = local_results['episode']
             else:
                 tasks_to_run.append(
-                    ('episode', self.tmdb_manager.get_tmdb_localized_data(meta, data_type='episode', language='pt-BR', append_to_response=''))
+                    ('episode', self.tmdb_manager.get_tmdb_localized_data(meta, data_type='episode', language='pt-BR', append_to_response='credits'))
                 )
 
         if tasks_to_run:

--- a/src/trackers/BHD.py
+++ b/src/trackers/BHD.py
@@ -339,6 +339,12 @@ class BHD:
             else:
                 meta['skipping'] = "BHD"
                 return []
+
+        if not meta['valid_mi_settings']:
+            console.print(f"[bold red]No encoding settings in mediainfo, skipping {self.tracker} upload.[/bold red]")
+            meta['skipping'] = "BHD"
+            return []
+
         if meta['sd'] and not (meta['is_disc'] or "REMUX" in meta['type'] or "WEBDL" in meta['type']):
             if not meta['unattended']:
                 console.print("[bold red]Modified SD content not allowed at BHD[/bold red]")

--- a/src/trackers/CBR.py
+++ b/src/trackers/CBR.py
@@ -18,6 +18,7 @@ class CBR(UNIT3D):
         self.search_url = f'{self.base_url}/api/torrents/filter'
         self.torrent_url = f'{self.base_url}/torrents/'
         self.requests_url = f'{self.base_url}/api/requests/filter'
+        self.pending_url = f"{self.base_url}/api/torrents/pending"
         self.banned_groups = [
             "4K4U", "afm72", "Alcaide_Kira", "AROMA", "ASM", "Bandi", "BiTOR", "BLUDV", "Bluespots",
             "BOLS", "CaNNIBal", "Comando", "d3g", "DepraveD", "EMBER", "FGT", "FreetheFish", "Garshasp",

--- a/src/trackers/DP.py
+++ b/src/trackers/DP.py
@@ -24,11 +24,11 @@ class DP(UNIT3D):
         self.torrent_url = f'{self.base_url}/torrents/'
         self.banned_groups = [
             'ARCADE', 'aXXo', 'BANDOLEROS', 'BONE', 'BRrip', 'CM8', 'CrEwSaDe', 'CTFOH', 'dAV1nci', 'DNL',
-            'eranger2', 'FaNGDiNG0', 'FiSTER', 'flower', 'GalaxyTV', 'HD2DVD', 'HDT', 'HDTime', 'iHYTECH',
-            'ION10', 'iPlanet', 'KiNGDOM', 'LAMA', 'MeGusta', 'mHD', 'mSD', 'NaNi', 'NhaNc3', 'nHD',
-            'nikt0', 'nSD', 'OFT', 'PiTBULL', 'PRODJi', 'RARBG', 'Rifftrax', 'ROCKETRACCOON',
-            'SANTi', 'SasukeducK', 'SEEDSTER', 'ShAaNiG', 'Sicario', 'STUTTERSHIT', 'TAoE',
-            'TGALAXY', 'TGx', 'TORRENTGALAXY', 'ToVaR', 'TSP', 'TSPxL', 'ViSION', 'VXT',
+            'eranger2', 'FaNGDiNG0', 'FGT', 'FiSTER', 'flower', 'GalaxyTV', 'HD2DVD', 'HDTime', 'HorribleSubs',
+            'iHYTECH', 'ION10', 'iPlanet', 'KiNGDOM', 'LAMA', 'MeGusta', 'mHD', 'mSD', 'NaNi', 'NhaNc3', 'nHD',
+            'nikt0', 'nSD', 'OFT', 'PiTBULL', 'PRODJi', 'PSA', 'RARBG', 'Rifftrax', 'ROCKETRACCOON',
+            'SANTi', 'SasukeducK', 'SEEDSTER', 'ShAaNiG', 'Sicario', 'STUTTERSHIT', 'Subsplease', 'SyncUp',
+            'TAoE', 'TGALAXY', 'TGx', 'TORRENTGALAXY', 'ToVaR', 'Trix', 'TSP', 'TSPxL', 'ViSION', 'VXT',
             'WAF', 'WKS', 'X0r', 'YIFY', 'YTS',
         ]
         pass
@@ -49,11 +49,6 @@ class DP(UNIT3D):
         if not await self.common.check_language_requirements(
             meta, self.tracker, languages_to_check=nordic_languages, check_audio=True, check_subtitle=True
         ):
-            return False
-
-        if meta['type'] == "ENCODE" and meta.get('tag', "") in ['FGT']:
-            if not meta['unattended']:
-                console.print(f"[bold red]{self.tracker} does not allow FGT encodes, skipping upload.")
             return False
 
         if meta['type'] not in ['WEBDL'] and meta.get('tag', "") in ['EVO']:

--- a/src/trackers/UNIT3D.py
+++ b/src/trackers/UNIT3D.py
@@ -108,63 +108,64 @@ class UNIT3D:
         request_params: ParamsList
         request_params = params_list if params_list is not None else list(params_dict.items())
 
+        urls_to_check = [self.search_url]
+        if getattr(self, "pending_url", None):
+            urls_to_check.append(self.pending_url)
+
         try:
             async with httpx.AsyncClient(timeout=10.0, follow_redirects=True) as client:
-                response = await client.get(url=self.search_url, headers=headers, params=request_params)
-                response.raise_for_status()
-                if response.status_code == 200:
-                    data = response.json()
-                    for each in data["data"]:
-                        torrent_id = each.get("id", None)
-                        attributes = each.get("attributes", {})
-                        name = attributes.get("name", "")
-                        size = attributes.get("size", 0)
-                        result: dict[str, Any]
-                        if not meta["is_disc"]:
-                            result = {
-                                "name": name,
-                                "size": size,
-                                "files": [
-                                    file["name"]
-                                    for file in attributes.get("files", [])
-                                    if isinstance(file, dict) and "name" in file
-                                ],
-                                "file_count": (
-                                    len(attributes.get("files", []))
-                                    if isinstance(attributes.get("files"), list)
-                                    else 0
-                                ),
-                                "trumpable": attributes.get("trumpable", False),
-                                "link": attributes.get("details_link", None),
-                                "download": attributes.get("download_link", None),
-                                "id": torrent_id,
-                                "type": attributes.get("type", None),
-                                "res": attributes.get("resolution", None),
-                                "internal": attributes.get("internal", False),
-                            }
-                        else:
-                            result = {
-                                "name": name,
-                                "size": size,
-                                "files": [],
-                                "file_count": (
-                                    len(attributes.get("files", []))
-                                    if isinstance(attributes.get("files"), list)
-                                    else 0
-                                ),
-                                "trumpable": attributes.get("trumpable", False),
-                                "link": attributes.get("details_link", None),
-                                "download": attributes.get("download_link", None),
-                                "id": torrent_id,
-                                "type": attributes.get("type", None),
-                                "res": attributes.get("resolution", None),
-                                "internal": attributes.get("internal", False),
-                                "bd_info": attributes.get("bd_info", ""),
-                                "description": attributes.get("description", ""),
-                            }
-                        dupes.append(result)
-                else:
-                    console.print(f"[bold red]Failed to search torrents. HTTP Status: {response.status_code}")
+                for url in urls_to_check:
+                    check_pending = False
+                    if "api/torrents/pending" in url:
+                        check_pending = True
+                    response = await client.get(url=url, headers=headers, params=request_params)
+                    response.raise_for_status()
+
+                    if response.status_code == 200:
+                        data = response.json()
+                        for each in data.get("data", []):
+                            if check_pending:
+                                entry_tmdb = str(each.get("tmdb_id") or "")
+                                if entry_tmdb != str(meta.get("tmdb", "")):
+                                    continue
+                            torrent_id = each.get("id", None)
+                            attributes = each if check_pending else each.get("attributes", {})
+                            name = attributes.get("name", "")
+                            size = attributes.get("size", 0)
+                            result: dict[str, Any]
+                            if not meta["is_disc"]:
+                                result = {
+                                    "name": name,
+                                    "size": size,
+                                    "files": [file["name"] for file in attributes.get("files", []) if isinstance(file, dict) and "name" in file],
+                                    "file_count": (len(attributes.get("files", [])) if isinstance(attributes.get("files"), list) else 0),
+                                    "trumpable": attributes.get("trumpable", False),
+                                    "link": f"{self.base_url}/torrents/pending" if check_pending else attributes.get("details_link", None),
+                                    "download": attributes.get("download_link", None),
+                                    "id": torrent_id,
+                                    "type": attributes.get("type", None),
+                                    "res": attributes.get("resolution", None),
+                                    "internal": attributes.get("internal", False),
+                                }
+                            else:
+                                result = {
+                                    "name": name,
+                                    "size": size,
+                                    "files": [],
+                                    "file_count": (len(attributes.get("files", [])) if isinstance(attributes.get("files"), list) else 0),
+                                    "trumpable": attributes.get("trumpable", False),
+                                    "link": f"{self.base_url}/torrents/pending" if check_pending else attributes.get("details_link", None),
+                                    "download": attributes.get("download_link", None),
+                                    "id": torrent_id,
+                                    "type": attributes.get("type", None),
+                                    "res": attributes.get("resolution", None),
+                                    "internal": attributes.get("internal", False),
+                                    "bd_info": attributes.get("bd_info", ""),
+                                    "description": attributes.get("description", ""),
+                                }
+                            dupes.append(result)
+                    else:
+                        console.print(f"[bold red]Failed to search torrents. HTTP Status: {response.status_code}")
         except httpx.HTTPStatusError as e:
             if e.response.status_code == 302:
                 meta["tracker_status"][self.tracker][

--- a/src/trackers/UNIT3D.py
+++ b/src/trackers/UNIT3D.py
@@ -76,15 +76,16 @@ class UNIT3D:
             "perPage": "100",
         }
         params_list: Optional[ParamsList] = None
-        resolutions = await self.get_resolution_id(meta)
-        resolution_id = str(resolutions["resolution_id"])
-        if resolution_id in ["3", "4"]:
-            # Convert params to list of tuples to support duplicate keys
-            params_list = list(params_dict.items())
-            params_list.append(("resolutions[]", "3"))
-            params_list.append(("resolutions[]", "4"))
-        else:
-            params_dict["resolutions[]"] = resolution_id
+        if self.tracker not in ["OTW"]:
+            resolutions = await self.get_resolution_id(meta)
+            resolution_id = str(resolutions["resolution_id"])
+            if resolution_id in ["3", "4"]:
+                # Convert params to list of tuples to support duplicate keys
+                params_list = list(params_dict.items())
+                params_list.append(("resolutions[]", "3"))
+                params_list.append(("resolutions[]", "4"))
+            else:
+                params_dict["resolutions[]"] = resolution_id
 
         if self.tracker not in ["SP", "STC"]:
             type_id = str((await self.get_type_id(meta))["type_id"])

--- a/src/trackers/UNIT3D.py
+++ b/src/trackers/UNIT3D.py
@@ -113,8 +113,15 @@ class UNIT3D:
                     check_pending = False
                     if "api/torrents/pending" in url:
                         check_pending = True
-                    response = await client.get(url=url, headers=headers, params=request_params)
-                    response.raise_for_status()
+                    try:
+                        response = await client.get(url=url, headers=headers, params=request_params)
+                        response.raise_for_status()
+                    except (httpx.HTTPStatusError, httpx.RequestError) as pending_err:
+                        if check_pending:
+                            if meta.get("debug"):
+                                console.print(f"[yellow]{self.tracker}: pending endpoint error: {pending_err}[/yellow]")
+                            continue
+                        raise
 
                     if response.status_code == 200:
                         data = response.json()
@@ -135,7 +142,7 @@ class UNIT3D:
                                     "files": [file["name"] for file in attributes.get("files", []) if isinstance(file, dict) and "name" in file],
                                     "file_count": (len(attributes.get("files", [])) if isinstance(attributes.get("files"), list) else 0),
                                     "trumpable": attributes.get("trumpable", False),
-                                    "link": f"{self.base_url}/torrents/pending" if check_pending else attributes.get("details_link", None),
+                                    "link": f"{self.base_url}/torrents/{torrent_id}" if check_pending else attributes.get("details_link", None),
                                     "download": attributes.get("download_link", None),
                                     "id": torrent_id,
                                     "type": attributes.get("type", None),
@@ -149,7 +156,7 @@ class UNIT3D:
                                     "files": [],
                                     "file_count": (len(attributes.get("files", [])) if isinstance(attributes.get("files"), list) else 0),
                                     "trumpable": attributes.get("trumpable", False),
-                                    "link": f"{self.base_url}/torrents/pending" if check_pending else attributes.get("details_link", None),
+                                    "link": f"{self.base_url}/torrents/{torrent_id}" if check_pending else attributes.get("details_link", None),
                                     "download": attributes.get("download_link", None),
                                     "id": torrent_id,
                                     "type": attributes.get("type", None),

--- a/src/trackers/UNIT3D.py
+++ b/src/trackers/UNIT3D.py
@@ -405,6 +405,11 @@ class UNIT3D:
         if exclusive_flag:
             merged["exclusive"] = exclusive_flag
 
+        # For some FRENCH UNIT3D trackers we need to upload .nfo along video files
+        # We recreate .torrent before it was read to be sent
+        if self.tracker in ["NST", "TOS", "GF", "G3MINI"]:
+            await self._recreated_torrent_if_nfo(meta, self.common, self.config, self.tracker, self.source_flag)
+
         return merged
 
     async def get_additional_files(self, meta: dict[str, Any]) -> dict[str, tuple[str, bytes, str]]:
@@ -412,7 +417,7 @@ class UNIT3D:
         base_dir = meta["base_dir"]
         uuid = meta["uuid"]
         specified_dir_path = os.path.join(base_dir, "tmp", uuid, "*.nfo")
-        nfo_files = glob.glob(specified_dir_path)
+        nfo_files = (self._get_nfo_files(meta) if hasattr(self, "_get_nfo_files") else []) or glob.glob(specified_dir_path)
         if not nfo_files and meta.get("keep_nfo", False) and (meta.get("keep_folder", False) or meta.get("isdir", False)):
             search_dir = meta["path"] if os.path.isdir(meta["path"]) or meta.get("isdir", False) else os.path.dirname(meta["path"])
             nfo_files = glob.glob(os.path.join(search_dir, "*.nfo"))
@@ -428,7 +433,12 @@ class UNIT3D:
         data = await self.get_data(meta)
         base = f"{meta['base_dir']}/tmp/{meta['uuid']}"
         nonfo_path = f"{base}/BASE_NONFO.torrent"
-        torrent_file_path = nonfo_path if meta.get("skip_nfo", False) and os.path.exists(nonfo_path) else f"{base}/BASE.torrent"
+        if meta.get("skip_nfo", False) and os.path.exists(nonfo_path):
+            torrent_file_path = nonfo_path
+        elif "upload_torrent_path" in meta:
+            torrent_file_path = meta["upload_torrent_path"]
+        else:
+            torrent_file_path = f"{base}/BASE.torrent"
         async with aiofiles.open(torrent_file_path, "rb") as f:
             torrent_bytes = await f.read()
         files = {"torrent": ("torrent.torrent", torrent_bytes, "application/x-bittorrent")}

--- a/src/trackers/UNIT3D.py
+++ b/src/trackers/UNIT3D.py
@@ -420,7 +420,10 @@ class UNIT3D:
         specified_dir_path = os.path.join(base_dir, "tmp", uuid, "*.nfo")
         nfo_files = glob.glob(specified_dir_path)
         if not nfo_files and meta.get("keep_nfo", False) and (meta.get("keep_folder", False) or meta.get("isdir", False)):
-            search_dir = os.path.dirname(meta["path"])
+            if os.path.isdir(meta["path"]) or meta.get("isdir", False):
+                search_dir = meta["path"]
+            else:
+                search_dir = os.path.dirname(meta["path"])
             nfo_files = glob.glob(os.path.join(search_dir, "*.nfo"))
 
         if nfo_files:
@@ -432,7 +435,12 @@ class UNIT3D:
 
     async def upload(self, meta: dict[str, Any], _: Any) -> bool:
         data = await self.get_data(meta)
-        torrent_file_path = f"{meta['base_dir']}/tmp/{meta['uuid']}/BASE.torrent"
+        base = f"{meta['base_dir']}/tmp/{meta['uuid']}"
+        nonfo_path = f"{base}/BASE_NONFO.torrent"
+        if meta.get("skip_nfo", False) and os.path.exists(nonfo_path):
+            torrent_file_path = nonfo_path
+        else:
+            torrent_file_path = f"{base}/BASE.torrent"
         async with aiofiles.open(torrent_file_path, "rb") as f:
             torrent_bytes = await f.read()
         files = {"torrent": ("torrent.torrent", torrent_bytes, "application/x-bittorrent")}

--- a/src/trackers/UNIT3D.py
+++ b/src/trackers/UNIT3D.py
@@ -420,10 +420,7 @@ class UNIT3D:
         specified_dir_path = os.path.join(base_dir, "tmp", uuid, "*.nfo")
         nfo_files = glob.glob(specified_dir_path)
         if not nfo_files and meta.get("keep_nfo", False) and (meta.get("keep_folder", False) or meta.get("isdir", False)):
-            if os.path.isdir(meta["path"]) or meta.get("isdir", False):
-                search_dir = meta["path"]
-            else:
-                search_dir = os.path.dirname(meta["path"])
+            search_dir = meta["path"] if os.path.isdir(meta["path"]) or meta.get("isdir", False) else os.path.dirname(meta["path"])
             nfo_files = glob.glob(os.path.join(search_dir, "*.nfo"))
 
         if nfo_files:
@@ -437,10 +434,7 @@ class UNIT3D:
         data = await self.get_data(meta)
         base = f"{meta['base_dir']}/tmp/{meta['uuid']}"
         nonfo_path = f"{base}/BASE_NONFO.torrent"
-        if meta.get("skip_nfo", False) and os.path.exists(nonfo_path):
-            torrent_file_path = nonfo_path
-        else:
-            torrent_file_path = f"{base}/BASE.torrent"
+        torrent_file_path = nonfo_path if meta.get("skip_nfo", False) and os.path.exists(nonfo_path) else f"{base}/BASE.torrent"
         async with aiofiles.open(torrent_file_path, "rb") as f:
             torrent_bytes = await f.read()
         files = {"torrent": ("torrent.torrent", torrent_bytes, "application/x-bittorrent")}

--- a/src/trackers/UNIT3D.py
+++ b/src/trackers/UNIT3D.py
@@ -127,44 +127,31 @@ class UNIT3D:
                         data = response.json()
                         for each in data.get("data", []):
                             if check_pending:
-                                entry_tmdb = str(each.get("tmdb_id") or "")
+                                entry_tmdb = str(each.get("tmdb_id", ""))
                                 if entry_tmdb != str(meta.get("tmdb", "")):
                                     continue
                             torrent_id = each.get("id", None)
                             attributes = each if check_pending else each.get("attributes", {})
                             name = attributes.get("name", "")
                             size = attributes.get("size", 0)
-                            result: dict[str, Any]
-                            if not meta["is_disc"]:
-                                result = {
-                                    "name": name,
-                                    "size": size,
-                                    "files": [file["name"] for file in attributes.get("files", []) if isinstance(file, dict) and "name" in file],
-                                    "file_count": (len(attributes.get("files", [])) if isinstance(attributes.get("files"), list) else 0),
-                                    "trumpable": attributes.get("trumpable", False),
-                                    "link": f"{self.base_url}/torrents/{torrent_id}" if check_pending else attributes.get("details_link", None),
-                                    "download": attributes.get("download_link", None),
-                                    "id": torrent_id,
-                                    "type": attributes.get("type", None),
-                                    "res": attributes.get("resolution", None),
-                                    "internal": attributes.get("internal", False),
-                                }
-                            else:
-                                result = {
-                                    "name": name,
-                                    "size": size,
-                                    "files": [],
-                                    "file_count": (len(attributes.get("files", [])) if isinstance(attributes.get("files"), list) else 0),
-                                    "trumpable": attributes.get("trumpable", False),
-                                    "link": f"{self.base_url}/torrents/{torrent_id}" if check_pending else attributes.get("details_link", None),
-                                    "download": attributes.get("download_link", None),
-                                    "id": torrent_id,
-                                    "type": attributes.get("type", None),
-                                    "res": attributes.get("resolution", None),
-                                    "internal": attributes.get("internal", False),
-                                    "bd_info": attributes.get("bd_info", ""),
-                                    "description": attributes.get("description", ""),
-                                }
+                            files_list = [file["name"] for file in attributes.get("files", []) if isinstance(file, dict) and "name" in file]
+                            result: dict[str, Any] = {
+                                "name": name,
+                                "size": size,
+                                "files": files_list,
+                                "file_count": (len(attributes.get("files", [])) if isinstance(attributes.get("files"), list) else 0),
+                                "trumpable": attributes.get("trumpable", False),
+                                "link": f"{self.base_url}/torrents/{torrent_id}" if check_pending else attributes.get("details_link", None),
+                                "download": attributes.get("download_link", None),
+                                "id": torrent_id,
+                                "type": attributes.get("type", None),
+                                "res": attributes.get("resolution", None),
+                                "internal": attributes.get("internal", False),
+                            }
+                            if meta["is_disc"]:
+                                result["files"] = []
+                                result["bd_info"] = attributes.get("bd_info", "")
+                                result["description"] = attributes.get("description", "")
                             dupes.append(result)
                     else:
                         console.print(f"[bold red]Failed to search torrents. HTTP Status: {response.status_code}")


### PR DESCRIPTION
Merge upstream changes from Audionut/Upload-Assistant (v7.1.4) into master.

Key changes from upstream:
- `takescreens.py`: use `round_to_even()` for PAR scaling
- `prep.py`: guard `imdb_id != 0` before TV movie detection
- `getseasonep.py`: improved anime episode pattern (`\d{1,4}`, supports `v2` suffix)
- `dupe_checking.py`: add `is_tv_pack` / `target_season_number` for OTW per-episode resolution check
- `trackers/ANT.py`: add IMAX flag, refactor mediainfo/bdinfo upload, move API key to header
- `trackers/ASC.py`: add `credits` to TMDB append_to_response
- `trackers/BHD.py`: add `valid_mi_settings` gate
- `trackers/CBR.py`, `DP.py`: updated banned groups lists, add `pending_url`
- `trackers/UNIT3D.py`: support pending torrents check in dupe search

All 821 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pending-torrent searching support added for select trackers.

* **Improvements**
  * Screenshot scaling now ensures even dimensions for compatibility.
  * Improved TV episode duplicate detection with pre-resolution filtering.
  * TMDB season/episode fetch now requests credits when localized data is missing.

* **Tracker Updates**
  * Multiple trackers: updated banned-group lists, search/upload/pending result handling, NFO/BDInfo/mediainfo handling, API auth headers, and footer link updates.

* **Version**
  * In-app version bumped to v7.1.4 with updated inline release notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->