### PR TITLE
(NXM) FIX: Use met.get("category") for tmdb_type

### DIFF
--- a/src/trackers/NXM.py
+++ b/src/trackers/NXM.py
@@ -341,7 +341,7 @@ class NXM(FrenchTrackerMixin):
         # ── Multipart form ──
 
         tmdb_id = meta.get("tmdb_id", "")
-        tmdb_type = meta.get("tmdb_type", "").lower()
+        tmdb_type = meta.get("category", "").lower()
 
         files: dict[str, tuple[str, bytes, str]] = {
             "torrent": ("torrent.torrent", torrent_bytes, "application/x-bittorrent"),


### PR DESCRIPTION
NXM api field `tmdb_type` only accepts `tv`or `movie` and sometimes meta.get("tmdb_type") return "Scripted" for TV show. I use instead met.get("category") (from `get_cat()`) from [src/prep.py ](https://github.com/yippee0903/Upload-Assistant/blob/master/src/prep.py) because this function only returns `MOVIE` or `TV`