### PR TITLE
fix: c411 slot rules

### DIFF
--- a/src/trackers/C411.py
+++ b/src/trackers/C411.py
@@ -254,9 +254,23 @@ class C411(FrenchTrackerMixin):
 
     @classmethod
     def _is_lossless_from_name(cls, name: str) -> bool:
-        """Return True if a torrent name contains a lossless audio marker."""
+        """Return True if a torrent name contains a lossless audio marker or is a PURE disc source.
+
+        PURE disc sources (REMUX, BDMV, full BD rips, ISO) are inherently lossless;
+        their names often omit explicit audio tokens, so we treat them as lossless
+        to avoid incorrectly filtering them in the lossy/lossless coexistence check.
+        """
         n = name.upper().replace("-", ".")
-        return any(tag in n for tag in cls._LOSSLESS_NAME_MARKERS)
+        if any(tag in n for tag in cls._LOSSLESS_NAME_MARKERS):
+            return True
+        # PURE disc-image sources (BDMV, complete BD rips, ISO) often omit explicit
+        # audio tokens in the name; treat them as inherently lossless.
+        # REMUX releases are NOT included here: they almost always carry an explicit
+        # audio token, so we rely on the audio-marker check above for those.
+        _PURE_DISC_MARKERS = ("BDMV", "BD.FULL", "COMPLETE.BLURAY")
+        if any(marker in n for marker in _PURE_DISC_MARKERS):
+            return True
+        return "ISO" in n.split(".")
 
     @staticmethod
     def _is_h264_codec(codec: str) -> bool:
@@ -320,6 +334,10 @@ class C411(FrenchTrackerMixin):
         n = name.upper().replace(".", " ").replace("-", " ").replace("_", " ")
         tokens = set(n.split())
         for tag in cls._SPECIAL_EDITIONS:
+            # "AD" is too short and ambiguous as a name token (e.g. "Ad.Astra" → token "AD");
+            # it must only be detected from structured meta, not from the raw name.
+            if tag == "AD":
+                continue
             # Short tags (≤2 chars) must match a whole token to avoid false positives
             if len(tag) <= 2:
                 if tag in tokens:

--- a/src/trackers/C411.py
+++ b/src/trackers/C411.py
@@ -241,8 +241,10 @@ class C411(FrenchTrackerMixin):
     # Audio codecs that are considered lossless
     _LOSSLESS_AUDIO = {"TrueHD", "TrueHD Atmos", "DTS-HD MA", "DTS-HD.MA", "FLAC", "PCM", "LPCM", "DTS:X", "DTS-X"}
 
-    # Lossless audio markers used for name-based detection
-    _LOSSLESS_NAME_MARKERS = ("TRUEHD", "TRUE.HD", "DTS.HD.MA", "DTS.HD MA", "DTS-HD.MA", "DTSX", "DTS.X", "DTS-X", "FLAC", "LPCM", "PCM")
+    # Lossless audio markers used for name-based detection.
+    # _is_lossless_from_name normalizes the name with .upper().replace("-", "."),
+    # so markers must not contain "-" or spaces.
+    _LOSSLESS_NAME_MARKERS = ("TRUEHD", "TRUE.HD", "DTS.HD.MA", "DTSX", "DTS.X", "FLAC", "LPCM", "PCM")
 
     @staticmethod
     def _is_lossless_audio(audio: str) -> bool:
@@ -493,7 +495,7 @@ class C411(FrenchTrackerMixin):
         # Type
         is_remux = "REMUX" in n
         is_bdmv = "BDMV" in n or "BD.FULL" in n or "COMPLETE.BLURAY" in n
-        is_iso = "ISO" in n.split(".") or ".ISO" in n
+        is_iso = "ISO" in n.split(".")
         is_webrip = "WEBRIP" in n or "WEB.RIP" in n
         is_4klight = "4KLIGHT" in n
 

--- a/src/trackers/C411.py
+++ b/src/trackers/C411.py
@@ -203,19 +203,23 @@ class C411(FrenchTrackerMixin):
         return result
 
     # ──────────────────────────────────────────────────────────
-    #  C411 slot system — 4 profiles, 25 slots per edition
+    #  C411 slot system — 4 profiles, 27 slots per edition
     # ──────────────────────────────────────────────────────────
     #
     #  Compatibilité (2):    COMPAT-01, COMPAT-WR
-    #  Home Cinéma Pure (4): PURE-UHD-REMUX, PURE-UHD-BDMV, PURE-BD-REMUX, PURE-BD-BDMV
+    #  Home Cinéma Pure (6): PURE-UHD-REMUX, PURE-UHD-BDMV, PURE-UHD-ISO,
+    #                        PURE-BD-REMUX, PURE-BD-BDMV, PURE-BD-ISO
     #  Home Cinéma Optimisé (12): HCOPT-{1080,2160}-{BD,WR,4KL}-{H265,AV1}[-HDR]
     #  Optimisation (7):     OPTI-{1080,2160}-{HDR,SDR}-{BD,WR,4KL}
     #
     #  Special versions (UNCUT, THEATRICAL, EXTENDED, DIRECTOR'S CUT,
-    #  IMAX, Open Matte, Hybrid) each get an independent 25-slot set.
+    #  IMAX, Open Matte, Hybrid, AD) each get an independent 27-slot set.
     #
     #  Corrective versions (PROPER, REAL PROPER, REPACK, FIX, RERIP, V2)
     #  are always allowed — they replace the uploader's own previous version.
+    #
+    #  Lossy/Lossless coexistence: within the same slot, a lossy version
+    #  and a lossless version can permanently coexist.
     #
 
     # Special editions that get their own independent slot set
@@ -228,6 +232,7 @@ class C411(FrenchTrackerMixin):
         "IMAX",
         "OPEN MATTE",
         "HYBRID",
+        "AD",
     ]
 
     # Corrective version tags — uploads with these bypass dupe blocking
@@ -236,11 +241,20 @@ class C411(FrenchTrackerMixin):
     # Audio codecs that are considered lossless
     _LOSSLESS_AUDIO = {"TrueHD", "TrueHD Atmos", "DTS-HD MA", "DTS-HD.MA", "FLAC", "PCM", "LPCM", "DTS:X", "DTS-X"}
 
+    # Lossless audio markers used for name-based detection
+    _LOSSLESS_NAME_MARKERS = ("TRUEHD", "TRUE.HD", "DTS.HD.MA", "DTS.HD MA", "DTS-HD.MA", "DTSX", "DTS.X", "DTS-X", "FLAC", "LPCM", "PCM")
+
     @staticmethod
     def _is_lossless_audio(audio: str) -> bool:
         """Return True if the audio codec string indicates lossless audio."""
         au = audio.upper()
         return any(tag in au for tag in ("TRUEHD", "DTS-HD MA", "DTS-HD.MA", "DTS.HD.MA", "DTSX", "DTS.X", "DTS:X", "DTS-X", "FLAC", "PCM", "LPCM"))
+
+    @classmethod
+    def _is_lossless_from_name(cls, name: str) -> bool:
+        """Return True if a torrent name contains a lossless audio marker."""
+        n = name.upper().replace("-", ".")
+        return any(tag in n for tag in cls._LOSSLESS_NAME_MARKERS)
 
     @staticmethod
     def _is_h264_codec(codec: str) -> bool:
@@ -289,8 +303,12 @@ class C411(FrenchTrackerMixin):
         edition = str(meta.get("edition", "")).upper()
         if not edition:
             return ""
+        tokens = set(edition.replace(".", " ").replace("-", " ").replace("_", " ").split())
         for tag in cls._SPECIAL_EDITIONS:
-            if tag in edition:
+            if len(tag) <= 2:
+                if tag in tokens:
+                    return tag.replace("'", "").replace(" ", "-")
+            elif tag in edition:
                 return tag.replace("'", "").replace(" ", "-")
         return ""
 
@@ -298,8 +316,13 @@ class C411(FrenchTrackerMixin):
     def _detect_special_edition_from_name(cls, name: str) -> str:
         """Return normalised edition key parsed from a torrent name, or ''."""
         n = name.upper().replace(".", " ").replace("-", " ").replace("_", " ")
+        tokens = set(n.split())
         for tag in cls._SPECIAL_EDITIONS:
-            if tag in n:
+            # Short tags (≤2 chars) must match a whole token to avoid false positives
+            if len(tag) <= 2:
+                if tag in tokens:
+                    return tag.replace("'", "").replace(" ", "-")
+            elif tag in n:
                 return tag.replace("'", "").replace(" ", "-")
         return ""
 
@@ -403,9 +426,11 @@ class C411(FrenchTrackerMixin):
         edition = self._detect_special_edition_from_meta(meta)
         prefix = f"{edition}|" if edition else ""
 
-        # ── PURE: REMUX / BDMV (lossless, no encoding) ──
+        # ── PURE: REMUX / BDMV / ISO (lossless, no encoding) ──
         if release_type == "REMUX":
             return f"{prefix}PURE-UHD-REMUX" if is_4k else f"{prefix}PURE-BD-REMUX"
+        if is_disc == "ISO":
+            return f"{prefix}PURE-UHD-ISO" if is_4k else f"{prefix}PURE-BD-ISO"
         if release_type == "DISC" or is_disc == "BDMV":
             return f"{prefix}PURE-UHD-BDMV" if is_4k else f"{prefix}PURE-BD-BDMV"
 
@@ -468,6 +493,7 @@ class C411(FrenchTrackerMixin):
         # Type
         is_remux = "REMUX" in n
         is_bdmv = "BDMV" in n or "BD.FULL" in n or "COMPLETE.BLURAY" in n
+        is_iso = "ISO" in n.split(".") or ".ISO" in n
         is_webrip = "WEBRIP" in n or "WEB.RIP" in n
         is_4klight = "4KLIGHT" in n
 
@@ -492,6 +518,8 @@ class C411(FrenchTrackerMixin):
         # ── PURE ──
         if is_remux:
             return f"{prefix}PURE-UHD-REMUX" if is_4k else f"{prefix}PURE-BD-REMUX"
+        if is_iso:
+            return f"{prefix}PURE-UHD-ISO" if is_4k else f"{prefix}PURE-BD-ISO"
         if is_bdmv:
             return f"{prefix}PURE-UHD-BDMV" if is_4k else f"{prefix}PURE-BD-BDMV"
 
@@ -1742,6 +1770,18 @@ class C411(FrenchTrackerMixin):
                             console.print(
                                 f"[cyan]C411 coexistence: HDR-only upload — {before - len(dupes)} DV-only dupe(s) removed (temporary coexistence, no DV.HDR10 found)[/cyan]"
                             )
+
+        # ── Lossy / Lossless coexistence (permanent) ──
+        # A lossy version and a lossless version can always coexist in the same slot.
+        if dupes:
+            upload_audio = str(meta.get("audio", ""))
+            upload_lossless = self._is_lossless_audio(upload_audio)
+            before = len(dupes)
+            dupes = [d for d in dupes if self._is_lossless_from_name(d.get("name", "")) == upload_lossless]
+            if meta.get("debug") and len(dupes) < before:
+                kind = "lossless" if upload_lossless else "lossy"
+                opposite = "lossy" if upload_lossless else "lossless"
+                console.print(f"[cyan]C411 coexistence: {kind} upload — {before - len(dupes)} {opposite} dupe(s) removed (permanent coexistence)[/cyan]")
 
         # ── Tag dupes with slot for display ──
         for dupe in dupes:

--- a/tests/test_c411.py
+++ b/tests/test_c411.py
@@ -2020,3 +2020,245 @@ class TestC411GetMediainfoText:
         meta["mediainfo_text"] = "fallback MI"
         result = asyncio.run(c._get_mediainfo_text(meta))
         assert result == "fallback MI"
+
+
+# ─── Slot: ISO ────────────────────────────────────────────────
+
+
+class TestSlotISO:
+    """PURE-UHD-ISO and PURE-BD-ISO slots."""
+
+    def test_iso_uhd_from_meta(self):
+        c = C411(_config())
+        meta = _meta_base(type='DISC', is_disc='ISO', resolution='2160p')
+        meta['uhd'] = 'UHD'
+        slot = c._determine_c411_slot(meta)
+        assert slot == 'PURE-UHD-ISO'
+
+    def test_iso_bd_from_meta(self):
+        c = C411(_config())
+        meta = _meta_base(type='DISC', is_disc='ISO', resolution='1080p')
+        slot = c._determine_c411_slot(meta)
+        assert slot == 'PURE-BD-ISO'
+
+    def test_iso_uhd_from_name(self):
+        slot = C411._determine_c411_slot_from_name('Movie.2024.2160p.UHD.BluRay.ISO.DTS-HD.MA.7.1-GRP')
+        assert slot == 'PURE-UHD-ISO'
+
+    def test_iso_bd_from_name(self):
+        slot = C411._determine_c411_slot_from_name('Movie.2024.1080p.BluRay.ISO.DTS-HD.MA.5.1-GRP')
+        assert slot == 'PURE-BD-ISO'
+
+    def test_bdmv_not_matched_as_iso(self):
+        slot = C411._determine_c411_slot_from_name('Movie.2024.2160p.UHD.BDMV.DTS-HD.MA.7.1-GRP')
+        assert slot == 'PURE-UHD-BDMV'
+
+    def test_iso_not_matched_in_word(self):
+        """'ISO' embedded in another word (e.g. ISOLATION) should NOT match as ISO disc."""
+        slot = C411._determine_c411_slot_from_name('Isolation.2024.1080p.WEB-DL.AAC.2.0.H.264-GRP')
+        assert slot == 'COMPAT-01'
+
+
+# ─── Slot: AD special edition ────────────────────────────────
+
+
+class TestSlotADEdition:
+    """AD (Audio Description) as a special edition with independent slot set."""
+
+    def test_ad_from_meta(self):
+        c = C411(_config())
+        meta = _meta_base(edition='AD', resolution='1080p')
+        slot = c._determine_c411_slot(meta)
+        assert slot == 'AD|COMPAT-01'
+
+    def test_ad_from_name(self):
+        slot = C411._determine_c411_slot_from_name('Movie.2024.AD.FRENCH.1080p.WEB.x264-GRP')
+        assert slot == 'AD|COMPAT-01'
+
+    def test_ad_not_in_word(self):
+        """AD embedded in another word should NOT trigger special edition."""
+        slot = C411._determine_c411_slot_from_name('Adrenaline.2024.FRENCH.1080p.WEB.x264-GRP')
+        assert slot == 'COMPAT-01'
+
+    def test_ad_4k_remux(self):
+        c = C411(_config())
+        meta = _meta_base(edition='AD', type='REMUX', resolution='2160p')
+        meta['uhd'] = 'UHD'
+        slot = c._determine_c411_slot(meta)
+        assert slot == 'AD|PURE-UHD-REMUX'
+
+
+# ─── Lossy / Lossless coexistence ────────────────────────────
+
+
+class TestLossyLosslessCoexistence:
+    """Lossy and lossless versions permanently coexist in the same slot."""
+
+    TORZNAB_LOSSLESS = """<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:torznab="http://torznab.com/schemas/2015/feed">
+  <channel>
+    <item>
+      <title>Movie.2024.FRENCH.2160p.UHD.BluRay.REMUX.DTS-HD.MA.7.1-GRP</title>
+      <guid>https://c411.org/torrents/200</guid>
+      <link>https://c411.org/torrents/200/download</link>
+      <size>40000000000</size>
+    </item>
+  </channel>
+</rss>"""
+
+    TORZNAB_LOSSY = """<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:torznab="http://torznab.com/schemas/2015/feed">
+  <channel>
+    <item>
+      <title>Movie.2024.FRENCH.2160p.UHD.BluRay.REMUX.AC3.5.1-GRP</title>
+      <guid>https://c411.org/torrents/201</guid>
+      <link>https://c411.org/torrents/201/download</link>
+      <size>30000000000</size>
+    </item>
+  </channel>
+</rss>"""
+
+    TORZNAB_BOTH = """<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:torznab="http://torznab.com/schemas/2015/feed">
+  <channel>
+    <item>
+      <title>Movie.2024.FRENCH.2160p.UHD.BluRay.REMUX.DTS-HD.MA.7.1-GRP</title>
+      <guid>https://c411.org/torrents/200</guid>
+      <link>https://c411.org/torrents/200/download</link>
+      <size>40000000000</size>
+    </item>
+    <item>
+      <title>Movie.2024.FRENCH.2160p.UHD.BluRay.REMUX.AC3.5.1-GRP2</title>
+      <guid>https://c411.org/torrents/201</guid>
+      <link>https://c411.org/torrents/201/download</link>
+      <size>30000000000</size>
+    </item>
+  </channel>
+</rss>"""
+
+    def _make_mock(self, xml_text):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = xml_text
+        return mock_response
+
+    def test_lossy_upload_lossless_dupe_coexist(self):
+        """A lossy upload should NOT be blocked by a lossless dupe in the same slot."""
+        c = C411(_config())
+        meta = _meta_base(
+            type='REMUX', resolution='2160p', audio='AC3',
+            video_encode='', hdr='',
+        )
+        meta['uhd'] = 'UHD'
+        meta['is_disc'] = None
+
+        with patch('httpx.AsyncClient') as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=self._make_mock(self.TORZNAB_LOSSLESS))
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_cls.return_value = mock_client
+
+            dupes = asyncio.run(c.search_existing(meta, 'nodisc'))
+
+        assert dupes == [], "Lossy upload should coexist with lossless dupe"
+
+    def test_lossless_upload_lossy_dupe_coexist(self):
+        """A lossless upload should NOT be blocked by a lossy dupe in the same slot."""
+        c = C411(_config())
+        meta = _meta_base(
+            type='REMUX', resolution='2160p', audio='DTS-HD MA',
+            video_encode='', hdr='',
+        )
+        meta['uhd'] = 'UHD'
+        meta['is_disc'] = None
+
+        with patch('httpx.AsyncClient') as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=self._make_mock(self.TORZNAB_LOSSY))
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_cls.return_value = mock_client
+
+            dupes = asyncio.run(c.search_existing(meta, 'nodisc'))
+
+        assert dupes == [], "Lossless upload should coexist with lossy dupe"
+
+    def test_lossless_upload_lossless_dupe_blocks(self):
+        """A lossless upload should be blocked by an existing lossless dupe."""
+        c = C411(_config())
+        meta = _meta_base(
+            type='REMUX', resolution='2160p', audio='DTS-HD MA',
+            video_encode='', hdr='',
+        )
+        meta['uhd'] = 'UHD'
+        meta['is_disc'] = None
+
+        with patch('httpx.AsyncClient') as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=self._make_mock(self.TORZNAB_LOSSLESS))
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_cls.return_value = mock_client
+
+            dupes = asyncio.run(c.search_existing(meta, 'nodisc'))
+
+        assert len(dupes) == 1, "Lossless upload should be blocked by lossless dupe"
+
+    def test_lossy_upload_lossy_dupe_blocks(self):
+        """A lossy upload should be blocked by an existing lossy dupe."""
+        c = C411(_config())
+        meta = _meta_base(
+            type='REMUX', resolution='2160p', audio='AC3',
+            video_encode='', hdr='',
+        )
+        meta['uhd'] = 'UHD'
+        meta['is_disc'] = None
+
+        with patch('httpx.AsyncClient') as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=self._make_mock(self.TORZNAB_LOSSY))
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_cls.return_value = mock_client
+
+            dupes = asyncio.run(c.search_existing(meta, 'nodisc'))
+
+        assert len(dupes) == 1, "Lossy upload should be blocked by lossy dupe"
+
+    def test_lossy_upload_mixed_dupes_filters_lossless(self):
+        """When both lossy and lossless dupes exist, only same-type blocks."""
+        c = C411(_config())
+        meta = _meta_base(
+            type='REMUX', resolution='2160p', audio='AC3',
+            video_encode='', hdr='',
+        )
+        meta['uhd'] = 'UHD'
+        meta['is_disc'] = None
+
+        with patch('httpx.AsyncClient') as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=self._make_mock(self.TORZNAB_BOTH))
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_cls.return_value = mock_client
+
+            dupes = asyncio.run(c.search_existing(meta, 'nodisc'))
+
+        assert len(dupes) == 1, "Only same audio type should block"
+        assert 'AC3' in dupes[0]['name']
+
+    def test_is_lossless_from_name_truehd(self):
+        assert C411._is_lossless_from_name('Movie.2024.1080p.BluRay.REMUX.TrueHD.7.1-GRP') is True
+
+    def test_is_lossless_from_name_dtshd_ma(self):
+        assert C411._is_lossless_from_name('Movie.2024.1080p.BluRay.REMUX.DTS-HD.MA.5.1-GRP') is True
+
+    def test_is_lossless_from_name_flac(self):
+        assert C411._is_lossless_from_name('Movie.2024.1080p.BluRay.REMUX.FLAC.2.0-GRP') is True
+
+    def test_is_lossless_from_name_ac3_is_lossy(self):
+        assert C411._is_lossless_from_name('Movie.2024.1080p.BluRay.REMUX.AC3.5.1-GRP') is False
+
+    def test_is_lossless_from_name_aac_is_lossy(self):
+        assert C411._is_lossless_from_name('Movie.2024.1080p.WEB-DL.AAC.2.0.H.264-GRP') is False

--- a/tests/test_c411.py
+++ b/tests/test_c411.py
@@ -2058,6 +2058,11 @@ class TestSlotISO:
         slot = C411._determine_c411_slot_from_name('Isolation.2024.1080p.WEB-DL.AAC.2.0.H.264-GRP')
         assert slot == 'COMPAT-01'
 
+    def test_iso_not_matched_mid_name(self):
+        """'ISO' as a prefix inside a mid-name token (e.g. .Isolated.) must NOT match."""
+        slot = C411._determine_c411_slot_from_name('Movie.Isolated.2024.2160p.UHD.WEB-DL.AAC.2.0.H.264-GRP')
+        assert slot != 'PURE-UHD-ISO'
+
 
 # ─── Slot: AD special edition ────────────────────────────────
 

--- a/tests/test_c411.py
+++ b/tests/test_c411.py
@@ -2077,8 +2077,10 @@ class TestSlotADEdition:
         assert slot == 'AD|COMPAT-01'
 
     def test_ad_from_name(self):
+        # "AD" is intentionally skipped in name-based detection (too ambiguous as a token).
+        # Only meta-based detection sets the AD edition prefix.
         slot = C411._determine_c411_slot_from_name('Movie.2024.AD.FRENCH.1080p.WEB.x264-GRP')
-        assert slot == 'AD|COMPAT-01'
+        assert slot == 'COMPAT-01'
 
     def test_ad_not_in_word(self):
         """AD embedded in another word should NOT trigger special edition."""
@@ -2267,3 +2269,90 @@ class TestLossyLosslessCoexistence:
 
     def test_is_lossless_from_name_aac_is_lossy(self):
         assert C411._is_lossless_from_name('Movie.2024.1080p.WEB-DL.AAC.2.0.H.264-GRP') is False
+
+    def test_is_lossless_from_name_remux_no_audio_token(self):
+        """A REMUX name with no explicit audio tag falls back to False (unknown).
+        REMUX releases should always have audio in the name; BDMV/ISO are the ones
+        that legitimately omit audio tokens and are treated as lossless.
+        """
+        assert C411._is_lossless_from_name('Movie.2024.2160p.UHD.BluRay.REMUX.H265-GRP') is False
+
+    def test_is_lossless_from_name_bdmv_no_audio_token(self):
+        """A BDMV name with no explicit audio tag is treated as lossless (PURE disc)."""
+        assert C411._is_lossless_from_name('Movie.2024.2160p.UHD.BDMV-GRP') is True
+
+    def test_is_lossless_from_name_iso_no_audio_token(self):
+        """An ISO name with no explicit audio tag is treated as lossless (PURE disc)."""
+        assert C411._is_lossless_from_name('Movie.2024.2160p.UHD.BluRay.ISO-GRP') is True
+
+    def test_is_lossless_from_name_complete_bluray_no_audio_token(self):
+        """A COMPLETE.BLURAY name with no explicit audio tag is treated as lossless."""
+        assert C411._is_lossless_from_name('Movie.2024.Complete.Bluray-GRP') is True
+
+    def test_pure_bdmv_dupe_not_filtered_when_upload_is_lossless(self):
+        """A lossless BDMV upload must NOT silently drop a PURE-BD-BDMV dupe whose
+        name has no explicit audio token (disc images rarely include audio in the name).
+        Before the fix, _is_lossless_from_name returned False for such names, causing
+        the dupe to be incorrectly filtered by the lossy/lossless coexistence check.
+        """
+        c = C411(_config())
+        # Upload is a PURE-BD-BDMV (is_disc=BDMV, 1080p, lossless audio from meta)
+        meta = _meta_base(
+            type='DISC', resolution='1080p', audio='DTS-HD MA',
+            video_encode='', hdr='',
+        )
+        meta['is_disc'] = 'BDMV'
+
+        # Dupe is another BDMV in the same slot but without any audio token in the name
+        xml = """<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:torznab="http://torznab.com/schemas/2015/feed">
+  <channel>
+    <item>
+      <title>Movie.2024.FRENCH.1080p.BDMV-GRP</title>
+      <guid>https://c411.org/torrents/300</guid>
+      <link>https://c411.org/torrents/300/download</link>
+      <size>50000000000</size>
+    </item>
+  </channel>
+</rss>"""
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = xml
+
+        with patch('httpx.AsyncClient') as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_cls.return_value = mock_client
+
+            dupes = asyncio.run(c.search_existing(meta, 'nodisc'))
+
+        assert len(dupes) == 1, "PURE-BD-BDMV dupe must not be silently dropped by lossless filter"
+
+
+# ─── AD false positive: Ad.Astra regression ──────────────────
+
+
+class TestADFalsePositiveRegression:
+    """'AD' in a title like 'Ad.Astra' must NOT be detected as the Audio Description edition."""
+
+    def test_ad_astra_no_edition(self):
+        edition = C411._detect_special_edition_from_name(
+            'Ad.Astra.2019.2160p.UHD.BluRay.TrueHD.7.1.Atmos.HDR.H.265-GRP'
+        )
+        assert edition != 'AD', f"'Ad.Astra' must not trigger AD edition, got {edition!r}"
+
+    def test_ad_astra_slot_has_no_prefix(self):
+        slot = C411._determine_c411_slot_from_name(
+            'Ad.Astra.2019.2160p.UHD.BluRay.TrueHD.7.1.Atmos.HDR.H.265-GRP'
+        )
+        assert not slot.startswith('AD|'), f"Ad.Astra slot must not start with 'AD|', got {slot!r}"
+
+    def test_ad_from_meta_still_works(self):
+        """meta-based AD detection must still work after the name-based guard."""
+        c = C411(_config())
+        meta = _meta_base(edition='AD', resolution='1080p')
+        slot = c._determine_c411_slot(meta)
+        assert slot == 'AD|COMPAT-01'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recognizes ISO PURE variants (e.g., PURE-UHD-ISO / PURE-BD-ISO) and routes ISO disc releases to ISO PURE slots.
  * Adds name-based lossless detection for improved audio classification.
  * Supports AD special-edition when declared in structured metadata.

* **Bug Fixes**
  * Token-aware short-tag matching to reduce false special-edition detections (AD not inferred from raw names).
  * Refined duplicate filtering to allow permanent lossy/lossless coexistence within the same slot.

* **Tests**
  * Expanded tests for ISO handling, AD edition detection, and lossless/lossy coexistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->