### PR TITLE
fix: correctly stop whole process if qbit is unreachable

### DIFF
--- a/src/torrent_clients/qbittorrent.py
+++ b/src/torrent_clients/qbittorrent.py
@@ -285,7 +285,10 @@ class QbittorrentClientMixin:
 
         # Return cached user decision if already asked this session
         if cache_key in _qbit_user_decision_cache:
-            return _qbit_user_decision_cache[cache_key]
+            cached = _qbit_user_decision_cache[cache_key]
+            if not cached:
+                meta["qbit_offline_abort"] = True
+            return cached
 
         target = Redaction.redact_private_info(proxy_url) if proxy_url else f"{client.get('qbit_url')}:{client.get('qbit_port')}"
         console.print(f"[bold red]qBittorrent appears to be offline or unreachable ({target}).")

--- a/src/torrent_clients/qbittorrent.py
+++ b/src/torrent_clients/qbittorrent.py
@@ -295,6 +295,8 @@ class QbittorrentClientMixin:
             return False
         decision = await asyncio.to_thread(cli_ui.ask_yes_no, "Proceed anyway?", default=False)
         _qbit_user_decision_cache[cache_key] = decision
+        if not decision:
+            meta["qbit_offline_abort"] = True
         return decision
 
     async def _proxy_get_with_retry(

--- a/upload.py
+++ b/upload.py
@@ -427,7 +427,7 @@ async def validate_tracker_logins(meta: Meta, trackers: Optional[list[str]] = No
         await asyncio.gather(*[validate_single_tracker(tracker) for tracker in valid_trackers])
 
 
-async def process_meta(meta: Meta, base_dir: str, bot: Any = None) -> bool:
+async def process_meta(meta: Meta, base_dir: str, bot: Any = None) -> Optional[bool]:
     """Process the metadata for each queued path."""
     if use_discord and bot:
         await DiscordNotifier.send_discord_notification(config, bot, f"Starting upload process for: {meta['path']}", debug=meta.get("debug", False), meta=meta)
@@ -1286,7 +1286,6 @@ async def process_meta(meta: Meta, base_dir: str, bot: Any = None) -> bool:
             if meta.get("rehash", False) is False and not meta["base_torrent_created"] and not meta["we_checked_them_all"]:
                 reuse_torrent = await client.find_existing_torrent(meta)
                 if meta.get("qbit_offline_abort"):
-                    console.print("[bold red]Aborting: qBittorrent is offline and user chose not to proceed.")
                     return False
                 if reuse_torrent is not None:
                     reuse_success = await TorrentCreator.create_base_from_existing_torrent(reuse_torrent, meta["base_dir"], meta["uuid"], meta["path"])

--- a/upload.py
+++ b/upload.py
@@ -427,7 +427,7 @@ async def validate_tracker_logins(meta: Meta, trackers: Optional[list[str]] = No
         await asyncio.gather(*[validate_single_tracker(tracker) for tracker in valid_trackers])
 
 
-async def process_meta(meta: Meta, base_dir: str, bot: Any = None) -> None:
+async def process_meta(meta: Meta, base_dir: str, bot: Any = None) -> bool:
     """Process the metadata for each queued path."""
     if use_discord and bot:
         await DiscordNotifier.send_discord_notification(config, bot, f"Starting upload process for: {meta['path']}", debug=meta.get("debug", False), meta=meta)
@@ -1287,7 +1287,7 @@ async def process_meta(meta: Meta, base_dir: str, bot: Any = None) -> None:
                 reuse_torrent = await client.find_existing_torrent(meta)
                 if meta.get("qbit_offline_abort"):
                     console.print("[bold red]Aborting: qBittorrent is offline and user chose not to proceed.")
-                    return
+                    return False
                 if reuse_torrent is not None:
                     reuse_success = await TorrentCreator.create_base_from_existing_torrent(reuse_torrent, meta["base_dir"], meta["uuid"], meta["path"])
                     if not reuse_success:
@@ -1359,6 +1359,8 @@ async def process_meta(meta: Meta, base_dir: str, bot: Any = None) -> None:
 
         async with aiofiles.open(f"{meta['base_dir']}/tmp/{meta['uuid']}/meta.json", "w", encoding="utf-8") as f:
             await f.write(json.dumps(meta, indent=4))
+
+        return True
 
 
 async def cleanup_screenshot_temp_files(meta: Meta) -> None:
@@ -1819,6 +1821,9 @@ async def do_the_thing(base_dir: str) -> None:
             console.print(f"[green]Gathering info for {os.path.basename(path)}")
 
             await process_meta(meta, base_dir, bot=bot)
+            if meta.get("qbit_offline_abort"):
+                console.print("[bold red]Upload process aborted: qBittorrent is offline.")
+                return
             tracker_setup = TRACKER_SETUP(config=config)
             if "we_are_uploading" not in meta or not meta.get("we_are_uploading", False):
                 if config["DEFAULT"].get("cross_seeding", True):

--- a/upload.py
+++ b/upload.py
@@ -1285,6 +1285,9 @@ async def process_meta(meta: Meta, base_dir: str, bot: Any = None) -> None:
             reuse_torrent = None
             if meta.get("rehash", False) is False and not meta["base_torrent_created"] and not meta["we_checked_them_all"]:
                 reuse_torrent = await client.find_existing_torrent(meta)
+                if meta.get("qbit_offline_abort"):
+                    console.print("[bold red]Aborting: qBittorrent is offline and user chose not to proceed.")
+                    return
                 if reuse_torrent is not None:
                     reuse_success = await TorrentCreator.create_base_from_existing_torrent(reuse_torrent, meta["base_dir"], meta["uuid"], meta["path"])
                     if not reuse_success:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved offline handling for qBittorrent: when users decline proceeding, uploads are reliably aborted.
  * Upload workflow now halts immediately on abort, displays an "Upload process aborted: qBittorrent is offline." message, and prevents further queue processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->