### PR TITLE
fix(nfo): restrict NFO search to matching basename for single-file re…

### DIFF
--- a/src/trackers/FRENCH.py
+++ b/src/trackers/FRENCH.py
@@ -1824,13 +1824,16 @@ class FrenchTrackerMixin:
 
         Used by French trackers to include NFO files in .torrent and API upload."""
         path = str(meta.get("path", ""))
-        search_dir = path if os.path.isdir(path) else os.path.dirname(path)
-        if not search_dir:
-            return []
-        # Search top-level first, then subdirectories (season packs)
-        nfo_files = glob.glob(os.path.join(search_dir, "*.nfo"))
-        if not nfo_files:
-            nfo_files = glob.glob(os.path.join(search_dir, "**", "*.nfo"), recursive=True)
+        if os.path.isdir(path):
+            # Directory release: search top-level first, then subdirectories (season packs)
+            nfo_files = glob.glob(os.path.join(path, "*.nfo"))
+            if not nfo_files:
+                nfo_files = glob.glob(os.path.join(path, "**", "*.nfo"), recursive=True)
+        else:
+            # Single-file release: only match an NFO with the same base name
+            stem = os.path.splitext(path)[0]
+            nfo_path = f"{stem}.nfo"
+            nfo_files = [nfo_path] if os.path.isfile(nfo_path) else []
         if nfo_files:
             meta["keep_nfo"] = True
         return nfo_files


### PR DESCRIPTION
…leases

When meta['path'] is a single file (e.g. a .mkv), _get_nfo_files used to fall back to the parent directory and glob all *.nfo files there.  This picked up unrelated NFOs from other releases in the same folder and triggered unnecessary torrent recreation for French trackers.

Now only an NFO with the exact same stem is matched (e.g. release.nfo next to release.mkv).  Directory releases (season packs) are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined NFO file matching logic. When processing individual files, the system now matches only NFO files with identical base names instead of searching parent directories, improving metadata association accuracy. Directory scanning behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->