### PR TITLE
fix: TORR9 include NFO in torrent and hardlink whole folder when NFO …

### DIFF
--- a/src/trackers/TORR9.py
+++ b/src/trackers/TORR9.py
@@ -646,7 +646,14 @@ class TORR9(FrenchTrackerMixin):
         Optional data: tags, is_exclusive, is_anonymous
         """
         common = COMMON(config=self.config)
-        await common.create_torrent_for_upload(meta, self.tracker, self.source_flag)
+
+        # If an NFO file exists alongside the release, include it in the torrent
+        # so qBittorrent seeds the whole folder (mkv + nfo) and hardlinks accordingly.
+        nfo_files = self._get_nfo_files(meta)
+        if nfo_files:
+            await self._recreated_torrent_if_nfo(meta, self.common, self.config, self.tracker, self.source_flag)
+        else:
+            await common.create_torrent_for_upload(meta, self.tracker, self.source_flag)
 
         # ── Build release name ──
         name_result = await self.get_name(meta)

--- a/src/trackers/TORR9.py
+++ b/src/trackers/TORR9.py
@@ -645,15 +645,13 @@ class TORR9(FrenchTrackerMixin):
         Data fields:   title, description, nfo (plain-text), category, subcategory
         Optional data: tags, is_exclusive, is_anonymous
         """
-        common = COMMON(config=self.config)
-
         # If an NFO file exists alongside the release, include it in the torrent
         # so qBittorrent seeds the whole folder (mkv + nfo) and hardlinks accordingly.
         nfo_files = self._get_nfo_files(meta)
         if nfo_files:
             await self._recreated_torrent_if_nfo(meta, self.common, self.config, self.tracker, self.source_flag)
         else:
-            await common.create_torrent_for_upload(meta, self.tracker, self.source_flag)
+            await self.common.create_torrent_for_upload(meta, self.tracker, self.source_flag)
 
         # ── Build release name ──
         name_result = await self.get_name(meta)
@@ -843,7 +841,7 @@ class TORR9(FrenchTrackerMixin):
                 console.print(f"  Anonymous:   {anon}")
                 console.print(f"  Description: {description[:500]}…")
                 meta["tracker_status"][self.tracker]["status_message"] = "Debug mode, not uploaded."
-                await common.create_torrent_for_upload(
+                await self.common.create_torrent_for_upload(
                     meta,
                     f"{self.tracker}_DEBUG",
                     f"{self.tracker}_DEBUG",


### PR DESCRIPTION
…present

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the torrent upload mechanism to intelligently detect when NFO metadata files are present within releases and conditionally handle torrent creation accordingly, ensuring consistent and proper file generation across all release types.
  * Further improved the overall reliability and consistency of torrent upload handling for releases with accompanying metadata files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->