### PR TITLE
(audio.py) FIX: Regex AD not working

### DIFF
--- a/src/audio.py
+++ b/src/audio.py
@@ -25,7 +25,7 @@ TrackDict = dict[str, Any]
 
 
 # Compiled pattern shared with src/trackers/FRENCH.py — keep in sync.
-AD_TRACK_RE = re.compile(r"\baudio[\s_-]?description\b|\b[a-z]{2}\s+AD\b|\bAD\s*:|\(AD\)", re.IGNORECASE)
+AD_TRACK_RE = re.compile(r"\baudio[\s_-]?description\b|\b[a-z]{2}\s+AD\b|\bAD\b", re.IGNORECASE)
 
 # ── Shared codec mapping tables ──────────────────────────────────────
 # Used by both _get_audio_v2 (global meta['audio']) and

--- a/src/audio.py
+++ b/src/audio.py
@@ -25,7 +25,10 @@ TrackDict = dict[str, Any]
 
 
 # Compiled pattern shared with src/trackers/FRENCH.py — keep in sync.
-AD_TRACK_RE = re.compile(r"\baudio[\s_-]?description\b|\b[a-z]{2}\s+AD\b|\bAD\b", re.IGNORECASE)
+# `AD` must be uppercase to avoid matching the lowercase word "ad"
+# (e.g. Italian "ad alta voce", English noun "Ad"). Only the
+# "audio description" alternative is case-insensitive.
+AD_TRACK_RE = re.compile(r"(?i:\baudio[\s_-]?description\b)|\bAD\b")
 
 # ── Shared codec mapping tables ──────────────────────────────────────
 # Used by both _get_audio_v2 (global meta['audio']) and


### PR DESCRIPTION
I fix AD regex.
Before: https://regex101.com/?regex=%5Cbaudio%5B%5Cs_-%5D%3Fdescription%5Cb%7C%5Cb%5Ba-z%5D%7B2%7D%5Cs%2BAD%5Cb%7C%5CbAD%5Cs*%3A%7C%5C%28AD%5C%29&testString=AD%0AVFF+AD%0Aaudio+description%0A%28AD%29%0Afr+AD&flags=gm&flavor=pcre2&delimiter=%2F
After: https://regex101.com/?regex=%5Cbaudio%5B%5Cs_-%5D%3Fdescription%5Cb%7C%5Cb%5Ba-z%5D%7B2%7D%5Cs%2BAD%5Cb%7C%5CbAD%5Cb&testString=AD%0AVFF+AD%0Aaudio+description%0A%28AD%29%0Afr+AD&flags=gm&flavor=pcre2&delimiter=%2F

Things like VFF AD are now flags as AD audio track (no more MULTI.VOF)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio description track detection to be more precise: reduces false positives from lowercase "ad" and punctuation-marked labels, and better distinguishes genuine "Audio Description" tracks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->