### PR TITLE
(NST) FIX: Changes in "langue" field

### DIFF
--- a/src/trackers/NST.py
+++ b/src/trackers/NST.py
@@ -380,7 +380,7 @@ class NST(FrenchTrackerMixin, UNIT3D):
     async def get_additional_data(self, meta: dict[str, Any]) -> dict[str, Any]:
         data: dict[str, Any] = {"description_format": "bbcode"}
         # Map VF variant from the release name to NST's fixed "langue"
-        # choices: Français, VF, VFF, VFI, VFQ.
+        # choices: VOF, VFF, VFI, VFQ, VO.
         data["langue"] = self._detect_nst_langue(meta)
         return data
 
@@ -388,22 +388,21 @@ class NST(FrenchTrackerMixin, UNIT3D):
     def _detect_nst_langue(meta: dict[str, Any]) -> str:
         """Derive the NST langue tag from the release name / audio metadata.
 
-        NST accepts: VF, VOF, VFF, VFI, VFQ, VOSTFR, VFSTFR, Multi, Muet.
+        NST accepts: VOF, VFF, VFI, VFQ, VO.
         """
         name = meta.get("uuid") or meta.get("name", "")  # More precise on UUID, UA remove Multi etc when forging name
         upper = name.upper().replace(" ", ".")
         langs = []
 
         # New regex
-        if re.search(r"(?:^|\.)(TRUEFRENCH|FRENCH|VOF|VOB|VOQ|VF\S*)(?:\.|$)", upper):
-            langs.append("VF")
-
-        if re.search(r"(?:^|\.)(VOF)(?:\.|$)", upper):
+        if re.search(r"(?:^|\.)(TRUEFRENCH|FRENCH|VOF|VOB|VOQ)(?:\.|$)", upper):
             langs.append("VOF")
 
         if re.search(r"(?:^|\.)(VF2)(?:\.|$)", upper):
-            langs.append("VFF")
             langs.append("VFQ")
+
+        if re.search(r"(?:^|\.)(VF\d*)(?:\.|$)", upper):
+            langs.append("VFF")
 
         if re.search(r"(?:^|\.)(VFF)(?:\.|$)", upper):
             langs.append("VFF")
@@ -414,22 +413,13 @@ class NST(FrenchTrackerMixin, UNIT3D):
         if re.search(r"(?:^|\.)(VFQ)(?:\.|$)", upper):
             langs.append("VFQ")
 
-        if re.search(r"(?:^|\.)(VOSTFR)(?:\.|$)", upper):
-            langs.append("VOSTFR")
-
-        if re.search(r"(?:^|\.)(VFSTFR)(?:\.|$)", upper):
-            langs.append("VFSTFR")
-
         if re.search(r"(?:^|\.)(MULTI)(?:\.|$)", upper):
-            langs.append("Multi")
-
-        if re.search(r"(?:^|\.)(MUTE|MUET)(?:\.|$)", upper):
-            langs.append("Muet")
+            langs.append("VO")
 
         # Fallback: inspect Mediainfo
 
         tracks = meta.get("mediainfo", {}).get("media", {}).get("track", [])
-        langs_mi = [t for t in tracks if t.get("@type") == "Audio"]
+        langs_mi = [t for t in tracks if t.get("@type") == "Audio" and not FrenchTrackerMixin._is_audio_desc_track(t)]
         langs_all = langs_mi if langs_mi else (meta.get("audio_languages") or [])  # Ultimate fallback
 
         fr_aliases = {"french", "français", "francais", "fra", "fre", "fr", "fr-fr"}
@@ -445,22 +435,21 @@ class NST(FrenchTrackerMixin, UNIT3D):
             elif lang in be_aliases:
                 detected_langs.add("VFF")  # franco-belge -> VFF
             elif lang in fr_aliases:
-                detected_langs.add("VF")
                 detected_langs.add("VFF")
             else:
                 detected_langs.add("Autre")
 
-        # MULTI if more than one audiotrack
-        if len(langs_all) > 1 and "Multi" not in langs and "Autre" in detected_langs:
-            langs.append("Multi")
+        # VO if more than one audiotrack (MULTi implies the original language)
+        if len(langs_all) > 1 and "VO" not in langs and "Autre" in detected_langs:
+            langs.append("VO")
 
         # Add tag if not already inside
-        for tag in ("VFF", "VFQ", "VF", "VFF"):
+        for tag in ("VFF", "VFQ"):
             if tag in detected_langs and tag not in langs:
                 langs.append(tag)
 
-        # If Anglais without Multi, return empty
-        if "Autre" in detected_langs and "Multi" not in langs:
+        # If not French without VO, return empty
+        if "Autre" in detected_langs and "VO" not in langs:
             return ""
 
         return ", ".join(langs)

--- a/tests/test_nst.py
+++ b/tests/test_nst.py
@@ -56,7 +56,6 @@ def _meta_base(**overrides: Any) -> dict[str, Any]:
         "imdb_id": 1234567,
         "tmdb": 42,
         "debug": False,
-        "mediainfo": {},
         "mediainfo": {
            'media': {
               'track': []

--- a/tests/test_nst.py
+++ b/tests/test_nst.py
@@ -57,10 +57,25 @@ def _meta_base(**overrides: Any) -> dict[str, Any]:
         "tmdb": 42,
         "debug": False,
         "mediainfo": {},
+        "mediainfo": {
+           'media': {
+              'track': []
+           }
+        }
     }
     m.update(overrides)
     return m
 
+def _audio_track(lang: str = 'fr', **kw: Any) -> dict[str, Any]:
+    t: dict[str, Any] = {'@type': 'Audio', 'Language': lang}
+    t.update(kw)
+    return t
+
+def _mi(audio: list[dict[str, Any]], subs: list[dict[str, Any]] | None = None) -> dict[str, Any]:
+    tracks = list(audio)
+    if subs:
+        tracks.extend(subs)
+    return {'media': {'track': tracks}}
 
 # ═══════════════════════════════════════════════════════════════
 #   URL Configuration
@@ -307,47 +322,54 @@ class TestGetAdditionalData:
 
 class TestDetectNstLangue:
     def test_vff_in_name(self):
-        assert NST._detect_nst_langue({"name": "Movie.2026.VFF.1080p.WEB.H264-GRP"}) == "VF, VFF"
+        assert NST._detect_nst_langue({"name": "Movie.2026.VFF.1080p.WEB.H264-GRP"}) == "VFF"
 
     def test_vfq_in_name(self):
-        assert NST._detect_nst_langue({"name": "Movie.2026.VFQ.1080p.WEB.H264-GRP"}) == "VF, VFQ"
+        assert NST._detect_nst_langue({"name": "Movie.2026.VFQ.1080p.WEB.H264-GRP"}) == "VFQ"
 
     def test_vfi_in_name(self):
-        assert NST._detect_nst_langue({"name": "Movie.2026.VFI.1080p.WEB.H264-GRP"}) == "VF, VFI"
+        assert NST._detect_nst_langue({"name": "Movie.2026.VFI.1080p.WEB.H264-GRP"}) == "VFI"
 
     def test_vf2_maps_to_vf(self):
-        assert NST._detect_nst_langue({"name": "Movie.2026.VF2.1080p.WEB.H264-GRP"}) == "VF, VFF, VFQ"
+        assert NST._detect_nst_langue({"name": "Movie.2026.VF2.1080p.WEB.H264-GRP"}) == "VFQ, VFF"
 
     def test_plain_vf_maps_to_vf(self):
-        assert NST._detect_nst_langue({"name": "Movie.2026.VF.1080p.WEB.H264-GRP"}) == "VF"
+        assert NST._detect_nst_langue({"name": "Movie.2026.VF.1080p.WEB.H264-GRP"}) == "VFF"
 
     def test_vf3_maps_to_vf(self):
-        assert NST._detect_nst_langue({"name": "Movie.2026.VF3.1080p.WEB.H264-GRP"}) == "VF"
+        assert NST._detect_nst_langue({"name": "Movie.2026.VF3.1080p.WEB.H264-GRP"}) == "VFF"
 
     def test_vf_at_end_of_name(self):
-        assert NST._detect_nst_langue({"name": "Movie.2026.1080p.WEB.VF"}) == "VF"
+        assert NST._detect_nst_langue({"name": "Movie.2026.1080p.WEB.VF"}) == "VFF"
 
     def test_vof_maps_to_francais(self):
-        assert NST._detect_nst_langue({"name": "Movie.2026.VOF.1080p.WEB.H264-GRP"}) == "VF, VOF"
+        assert NST._detect_nst_langue({"name": "Movie.2026.VOF.1080p.WEB.H264-GRP"}) == "VOF"
 
     def test_french_tag_maps_to_francais(self):
-        assert NST._detect_nst_langue({"name": "Movie.2026.FRENCH.1080p.WEB-GRP"}) == "VF"
+        assert NST._detect_nst_langue({"name": "Movie.2026.FRENCH.1080p.WEB-GRP"}) == "VOF"
 
     def test_truefrench_maps_to_francais(self):
-        assert NST._detect_nst_langue({"name": "Movie.2026.TRUEFRENCH.1080p.WEB-GRP"}) == "VF"
+        assert NST._detect_nst_langue({"name": "Movie.2026.TRUEFRENCH.1080p.WEB-GRP"}) == "VOF"
 
     def test_multi_vff_returns_vff(self):
-        assert NST._detect_nst_langue({"name": "Movie.2026.MULTi.VFF.HDR.2160p.WEB.H265-GRP"}) == "VF, VFF, Multi"
+        assert NST._detect_nst_langue({"name": "Movie.2026.MULTi.VFF.HDR.2160p.WEB.H265-GRP"}) == "VFF, VO"
 
     def test_multi_vfq_returns_vfq(self):
-        assert NST._detect_nst_langue({"name": "Movie.2026.MULTi.VFQ.1080p.WEB-GRP"}) == "VF, VFQ, Multi"
+        assert NST._detect_nst_langue({"name": "Movie.2026.MULTi.VFQ.1080p.WEB-GRP"}) == "VFQ, VO"
 
     def test_multi_plain_returns_vf(self):
-        assert NST._detect_nst_langue({"name": "Movie.2026.MULTi.HDR.2160p.WEB.H265-GRP"}) == "Multi"
+        assert NST._detect_nst_langue({"name": "Movie.2026.MULTi.HDR.2160p.WEB.H265-GRP"}) == "VO"
 
     def test_francais_from_audio_languages(self):
         meta = {"name": "Movie.2026.1080p.WEB-GRP", "audio_languages": ["French"]}
-        assert NST._detect_nst_langue(meta) == "VFF, VF"
+        assert NST._detect_nst_langue(meta) == "VFF"
+
+    def test_french_ad_from_mediainfo(self):
+        meta = {
+            "name": "Movie.2026.1080p.WEB-GRP",
+            "mediainfo":_mi([_audio_track('fr-fr', Title="French (AD)")],
+                            [_audio_track('fr-fr', Title="French")]) }
+        assert NST._detect_nst_langue(meta) == "VFF"
 
     def test_empty_when_no_data(self):
         assert NST._detect_nst_langue({}) == ""
@@ -355,7 +377,7 @@ class TestDetectNstLangue:
     def test_region_coded_french_is_francais(self):
         """Region-coded French tracks (fr-fr, fr-ca) map to VF."""
         meta = {"name": "Movie.2026.1080p.WEB-GRP", "audio_languages": ["fr-fr", "fr-ca"]}
-        assert NST._detect_nst_langue(meta) == "VFF, VFQ, VF"
+        assert NST._detect_nst_langue(meta) == "VFF, VFQ"
 
     def test_english_only_returns_empty(self):
         """English-only releases get empty langue (NST requires VF)."""
@@ -366,7 +388,7 @@ class TestDetectNstLangue:
         tracker = NST(_config())
         meta = {"name": "Movie.2026.MULTi.VFF.HDR.2160p.WEB.H265-GRP"}
         result = asyncio.run(tracker.get_additional_data(meta))
-        assert result["langue"] == "VF, VFF, Multi"
+        assert result["langue"] == "VFF, VO"
 
 
 # ═══════════════════════════════════════════════════════════════


### PR DESCRIPTION
          - langue field only accepts VOF, VFF, VFI, VFQ and VO now
          - AD search to avoid "VOF, VO" when there is 2 tracks and one of them is "Audio Description"
          - Changes in tests

<img width="534" height="143" alt="Capture d’écran du 2026-04-28 10-56-34" src="https://github.com/user-attachments/assets/fa73488a-c952-4ccc-b500-9a2c71af7d87" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced language tag detection and normalization for media files to provide more consistent and accurate results.
  * Improved audio track analysis to better identify language variants and exclude audio descriptions.

* **Tests**
  * Updated test suite to verify improved language detection accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->