### PR TITLE
fix: sometimes tracker will send back a wrong .torrent file when it i…

### DIFF
--- a/src/trackers/UNIT3D.py
+++ b/src/trackers/UNIT3D.py
@@ -484,7 +484,30 @@ class UNIT3D:
                         torrent_id = await self.get_torrent_id(response_data)
 
                         meta["tracker_status"][self.tracker]["torrent_id"] = torrent_id
+
+                        # Preserve NFO-patched torrent before download (tracker may serve version without NFO)
+                        nfo_torrent_backup = None
+                        if meta.get("keep_nfo"):
+                            nfo_path = f"{base}/[{self.tracker}].torrent"
+                            if os.path.exists(nfo_path):
+                                async with aiofiles.open(nfo_path, "rb") as f_nfo:
+                                    nfo_torrent_backup = await f_nfo.read()
+
                         await self.common.download_tracker_torrent(meta, self.tracker, headers=headers, downurl=response_data["data"])
+
+                        # Restore NFO-patched torrent if tracker-downloaded version stripped the NFO
+                        if nfo_torrent_backup:
+                            from torf import Torrent  # noqa: PLC0415
+
+                            downloaded_path = f"{base}/[{self.tracker}].torrent"
+                            try:
+                                downloaded = Torrent.read(downloaded_path)
+                                if not any(str(f).lower().endswith(".nfo") for f in downloaded.files):
+                                    async with aiofiles.open(downloaded_path, "wb") as f_restore:
+                                        await f_restore.write(nfo_torrent_backup)
+                            except Exception:
+                                pass  # Keep downloaded version if check fails
+
                         return True  # Success
 
                 except httpx.HTTPStatusError as e:  # noqa: PERF203

--- a/src/trackers/UNIT3D.py
+++ b/src/trackers/UNIT3D.py
@@ -500,13 +500,19 @@ class UNIT3D:
                             from torf import Torrent  # noqa: PLC0415
 
                             downloaded_path = f"{base}/[{self.tracker}].torrent"
+                            needs_restore = False
                             try:
                                 downloaded = Torrent.read(downloaded_path)
-                                if not any(str(f).lower().endswith(".nfo") for f in downloaded.files):
+                                needs_restore = not any(str(f).lower().endswith(".nfo") for f in downloaded.files)
+                            except Exception:
+                                pass  # Cannot parse downloaded torrent; keep as-is
+                            if needs_restore:
+                                try:
                                     async with aiofiles.open(downloaded_path, "wb") as f_restore:
                                         await f_restore.write(nfo_torrent_backup)
-                            except Exception:
-                                pass  # Keep downloaded version if check fails
+                                    console.print(f"[cyan]{self.tracker}: Tracker torrent lacked NFO — restored NFO-patched version.[/cyan]")
+                                except Exception as write_err:
+                                    console.print(f"[yellow]{self.tracker}: Failed to restore NFO-patched torrent: {write_err}[/yellow]")
 
                         return True  # Success
 


### PR DESCRIPTION
…ncludes a .nfo file (despite asking for it)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UNIT3D tracker uploads to preserve NFO metadata: the system now backs up and restores NFO-patched tracker torrents when the tracker download would otherwise drop .nfo files. If torrent parsing fails, the downloaded torrent is retained.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->