### PR TITLE
feat(IHD): rewrite get_name to follow official naming guide

### DIFF
--- a/src/trackers/IHD.py
+++ b/src/trackers/IHD.py
@@ -245,21 +245,138 @@ class IHD(UNIT3D):
         return False
 
     async def get_name(self, meta: Meta) -> dict[str, str]:
-        ihd_name = str(meta.get("name", ""))
-        resolution = str(meta.get("resolution", ""))
+        """Build an IHD-compliant release name following the naming guide.
 
+        Full Disc / REMUX:
+          Name Year S##E## REPACK Resolution Edition Region 3D SOURCE [REMUX] HDR VCodec Dub Audio-Tag
+
+        Encode / WEB-DL / WEBRip / HDTV:
+          Name Year S##E## REPACK Resolution Edition 3D SOURCE TYPE Dub Audio Hi10P HDR VCodec-Tag
+
+        ``meta["audio"]`` already contains ``ACodec Channels [Object]`` (e.g. "DD+ 5.1 Atmos").
+        ``meta["video_encode"]`` may carry a "Hi10P" prefix (e.g. "Hi10P x264");
+        it is split so Hi10P can be placed after Audio for encode/web types.
+        """
+        title = str(meta.get("title", ""))
+        alt_title = str(meta.get("alt_title", "") or "")
+        if alt_title and alt_title != title:
+            title = f"{title} AKA {alt_title}"
+
+        year = str(meta.get("year", ""))
+        if int(meta.get("manual_year") or 0) > 0:
+            year = str(meta.get("manual_year"))
+
+        resolution = str(meta.get("resolution", ""))
+        if resolution == "OTHER":
+            resolution = ""
+
+        season = str(meta.get("season") or "")
+        episode = str(meta.get("episode") or "")
+        if meta.get("category") == "TV":
+            if not meta.get("search_year", ""):
+                year = ""
+            if meta.get("manual_date"):
+                season = ""
+                episode = ""
+        if meta.get("no_season", False):
+            season = ""
+        if meta.get("no_year", False):
+            year = ""
+        if meta.get("tv_pack", False):
+            episode = ""
+
+        repack = str(meta.get("repack", ""))
+        three_d = str(meta.get("3D", ""))
+        hdr = str(meta.get("hdr", ""))
+        uhd = str(meta.get("uhd", ""))
+        hybrid = str(meta.get("webdv", "")) if meta.get("webdv") else ""
+        source = str(meta.get("source", ""))
+        service = str(meta.get("service", ""))
+        audio = str(meta.get("audio", ""))
+        tag = str(meta.get("tag") or "-NOGROUP")
+        release_type = str(meta.get("type", ""))
+
+        edition = str(meta.get("edition", "") or "")
+        if "hybrid" in edition.upper():
+            edition = re.sub(r"\bHybrid\b", "", edition, flags=re.IGNORECASE).strip()
+
+        region = ""
+        video_codec = ""
+        video_encode_raw = str(meta.get("video_encode", "") or "")
+        hi10p = ""
+
+        if meta.get("is_disc") == "BDMV":
+            video_codec = str(meta.get("video_codec", ""))
+            region = str(meta.get("region", "") or "")
+        elif meta.get("is_disc") == "DVD":
+            region = str(meta.get("region", "") or "")
+        elif release_type in ("DISC", "REMUX"):
+            # Non-disc remux: codec is stored in video_codec (e.g. HEVC, AVC)
+            video_codec = str(meta.get("video_codec", "") or meta.get("video_encode", "") or "")
+        else:
+            # Separate "Hi10P" prefix from the actual codec token for encode/web types
+            parts = video_encode_raw.split()
+            if parts and parts[0] == "Hi10P":
+                hi10p = "Hi10P"
+                video_codec = " ".join(parts[1:])
+            else:
+                video_codec = video_encode_raw
+
+        # Dub tag derived from audio languages (Dual-Audio / Dubbed / Multi)
+        dub = ""
         if not meta.get("language_checked", False):
             await languages_manager.process_desc_language(meta, tracker=self.tracker)
         audio_languages_value = meta.get("audio_languages", [])
-        audio_languages: list[str] = []
         if isinstance(audio_languages_value, list):
             audio_languages_list = cast(list[Any], audio_languages_value)
-            audio_languages = [str(item) for item in audio_languages_list]
-        if audio_languages and not await languages_manager.has_english_language(audio_languages):
-            foreign_lang = str(audio_languages[0]).upper()
-            ihd_name = ihd_name.replace(resolution, f"{foreign_lang} {resolution}", 1)
+            al = [str(x) for x in audio_languages_list if str(x).strip()]
+            unique_al = list(dict.fromkeys(al))
+            if len(unique_al) > 1:
+                dub = "Multi"
+            elif "Dual-Audio" in audio:
+                dub = "Dual-Audio"
+            elif "Dubbed" in audio:
+                dub = "Dubbed"
 
-        return {"name": ihd_name}
+        # Strip dub tokens from audio string to avoid duplication
+        audio_clean = re.sub(r"\b(Dual-Audio|Dubbed|Multi)\b", "", audio).strip()
+        audio_clean = re.sub(r"\s{2,}", " ", audio_clean)
+
+        if release_type in ("DISC", "REMUX"):
+            type_token = "REMUX" if release_type == "REMUX" else ""
+            name = (
+                f"{title} {year} {season}{episode} {repack} {resolution} {uhd} "
+                f"{edition} {region} {three_d} {source} {type_token} "
+                f"{hybrid} {hdr} {video_codec} {dub} {audio_clean}"
+            )
+        else:
+            if release_type == "WEBDL":  # nosec B105
+                type_token = "WEB-DL"  # nosec B105
+                source_token = service
+            elif release_type == "WEBRIP":  # nosec B105
+                type_token = "WEBRip"  # nosec B105
+                source_token = service
+            elif release_type == "HDTV":  # nosec B105
+                type_token = "HDTV"  # nosec B105
+                source_token = ""  # nosec B105
+            elif release_type == "ENCODE":  # nosec B105
+                type_token = ""  # nosec B105
+                source_token = source
+            elif release_type == "DVDRIP":  # nosec B105
+                type_token = "DVDRip"  # nosec B105
+                source_token = source
+            else:
+                type_token = release_type
+                source_token = source
+
+            name = (
+                f"{title} {year} {season}{episode} {repack} {resolution} {uhd} "
+                f"{edition} {three_d} {source_token} {type_token} "
+                f"{dub} {audio_clean} {hi10p} {hybrid} {hdr} {video_codec}"
+            )
+
+        name = " ".join(name.split()) + tag
+        return {"name": name}
 
     async def get_additional_files(self, meta: Meta) -> dict[str, tuple[str, bytes, str]]:
         return {}

--- a/src/trackers/IHD.py
+++ b/src/trackers/IHD.py
@@ -297,7 +297,7 @@ class IHD(UNIT3D):
         release_type = str(meta.get("type", ""))
 
         edition = str(meta.get("edition", "") or "")
-        if "hybrid" in edition.upper():
+        if "HYBRID" in edition.upper():
             edition = re.sub(r"\bHybrid\b", "", edition, flags=re.IGNORECASE).strip()
 
         region = ""

--- a/tests/test_ihd.py
+++ b/tests/test_ihd.py
@@ -221,3 +221,15 @@ class TestIhdGetNameTag:
         t = _ihd(meta)
         result = _run(t.get_name(meta))
         assert result["name"].endswith("-NOGROUP")
+
+
+class TestIhdGetNameEdition:
+    def test_edition_hybrid_removed(self):
+        """'Hybrid' in edition must be stripped from the name; unrelated tokens survive."""
+        meta = _base_meta(edition="Hybrid", video_encode="Hi10P x264")
+        t = _ihd(meta)
+        result = _run(t.get_name(meta))
+        name = result["name"]
+        assert "Hybrid" not in name
+        assert "Hi10P" in name
+        assert "  " not in name  # no double whitespace from the removal

--- a/tests/test_ihd.py
+++ b/tests/test_ihd.py
@@ -1,0 +1,223 @@
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock
+
+from src.trackers.IHD import IHD
+
+
+def _config() -> dict[str, Any]:
+    return {
+        "TRACKERS": {
+            "IHD": {
+                "api_key": "fake",
+                "announce_url": "https://infinityhd.net/announce/FAKE",
+            }
+        },
+        "DEFAULT": {"tmdb_api": "fake"},
+    }
+
+
+def _run(coro: Any) -> Any:
+    return asyncio.run(coro)
+
+
+def _base_meta(**overrides: Any) -> dict[str, Any]:
+    meta: dict[str, Any] = {
+        "title": "12th Fail",
+        "alt_title": "",
+        "year": "2023",
+        "manual_year": None,
+        "category": "MOVIE",
+        "type": "WEBDL",
+        "source": "WEB",
+        "service": "AMZN",
+        "resolution": "1080p",
+        "uhd": "",
+        "hdr": "",
+        "season": "",
+        "episode": "",
+        "tv_pack": False,
+        "repack": "",
+        "3D": "",
+        "edition": "",
+        "region": "",
+        "audio": "DD+ 5.1 Atmos",
+        "video_encode": "H.264",
+        "video_codec": "",
+        "webdv": "",
+        "is_disc": False,
+        "tag": "-RAWR",
+        "search_year": "2023",
+        "no_season": False,
+        "no_year": False,
+        "manual_date": None,
+        "language_checked": True,
+        "audio_languages": ["Hindi"],
+        "debug": False,
+    }
+    meta.update(overrides)
+    return meta
+
+
+def _ihd(meta: dict[str, Any]) -> IHD:
+    t = IHD(_config())
+    t._build_audio_string = AsyncMock(return_value="")
+    return t
+
+
+class TestIhdGetNameWebDl:
+    """WEB-DL: … Resolution SERVICE WEB-DL Dub Audio Hi10P HDR VCodec-Tag"""
+
+    def test_webdl_basic_name(self):
+        meta = _base_meta()
+        t = _ihd(meta)
+        result = _run(t.get_name(meta))
+        name = result["name"]
+        # Service must appear before WEB-DL
+        assert "AMZN WEB-DL" in name
+        assert name.endswith("-RAWR")
+
+    def test_webdl_service_before_type(self):
+        """'12th Fail 2023 1080p AMZN WEB-DL DD+ 5.1 Atmos H.264-RAWR'"""
+        meta = _base_meta()
+        t = _ihd(meta)
+        result = _run(t.get_name(meta))
+        name = result["name"]
+        idx_amzn = name.index("AMZN")
+        idx_webdl = name.index("WEB-DL")
+        assert idx_amzn < idx_webdl
+
+    def test_webdl_hdr_after_audio(self):
+        """HDR must come after audio, before video codec."""
+        meta = _base_meta(hdr="HDR", video_encode="H.265")
+        t = _ihd(meta)
+        result = _run(t.get_name(meta))
+        name = result["name"]
+        idx_audio = name.index("DD+")
+        idx_hdr = name.index("HDR")
+        idx_codec = name.index("H.265")
+        assert idx_audio < idx_hdr < idx_codec
+
+    def test_webdl_hi10p_between_audio_and_hdr(self):
+        """Hi10P must appear after audio and before HDR/codec for encode/web."""
+        meta = _base_meta(video_encode="Hi10P x264", hdr="HDR")
+        t = _ihd(meta)
+        result = _run(t.get_name(meta))
+        name = result["name"]
+        assert "Hi10P" in name
+        idx_audio = name.index("DD+")
+        idx_hi10p = name.index("Hi10P")
+        idx_hdr = name.index("HDR")
+        assert idx_audio < idx_hi10p < idx_hdr
+
+    def test_webdl_no_duplicate_whitespace(self):
+        meta = _base_meta(repack="", edition="", hdr="", uhd="")
+        t = _ihd(meta)
+        result = _run(t.get_name(meta))
+        assert "  " not in result["name"]
+
+
+class TestIhdGetNameEncode:
+    """Encode: … Resolution SOURCE Dub Audio Hi10P HDR VCodec-Tag (no TYPE token)"""
+
+    def test_encode_no_webdl_token(self):
+        meta = _base_meta(type="ENCODE", source="BluRay", service="")
+        t = _ihd(meta)
+        result = _run(t.get_name(meta))
+        name = result["name"]
+        assert "WEB-DL" not in name
+        assert "BluRay" in name
+
+    def test_encode_order(self):
+        meta = _base_meta(type="ENCODE", source="BluRay", service="", hdr="HDR", video_encode="x264")
+        t = _ihd(meta)
+        result = _run(t.get_name(meta))
+        name = result["name"]
+        idx_bluray = name.index("BluRay")
+        idx_audio = name.index("DD+")
+        idx_hdr = name.index("HDR")
+        idx_codec = name.index("x264")
+        assert idx_bluray < idx_audio < idx_hdr < idx_codec
+
+
+class TestIhdGetNameRemux:
+    """REMUX: … Resolution SOURCE REMUX HDR VCodec Dub Audio-Tag"""
+
+    def test_remux_token_present(self):
+        meta = _base_meta(type="REMUX", source="BluRay", service="", video_encode="", video_codec="HEVC", is_disc=False)
+        t = _ihd(meta)
+        result = _run(t.get_name(meta))
+        assert "REMUX" in result["name"]
+
+    def test_remux_codec_before_audio(self):
+        meta = _base_meta(type="REMUX", source="BluRay", service="", video_encode="", video_codec="HEVC", is_disc=False)
+        t = _ihd(meta)
+        result = _run(t.get_name(meta))
+        name = result["name"]
+        assert name.index("HEVC") < name.index("DD+")
+
+
+class TestIhdGetNameTV:
+    """TV: season pack drops episode, year dropped when no search_year."""
+
+    def test_tv_pack_no_episode(self):
+        meta = _base_meta(
+            category="TV",
+            type="WEBDL",
+            service="NF",
+            season="S01",
+            episode="E01",
+            tv_pack=True,
+            search_year="2023",
+        )
+        t = _ihd(meta)
+        result = _run(t.get_name(meta))
+        name = result["name"]
+        assert "S01" in name
+        assert "E01" not in name
+
+    def test_tv_no_year_when_no_search_year(self):
+        meta = _base_meta(
+            category="TV",
+            type="WEBDL",
+            service="NF",
+            season="S01",
+            episode="E01",
+            tv_pack=False,
+            search_year="",
+        )
+        t = _ihd(meta)
+        result = _run(t.get_name(meta))
+        name = result["name"]
+        assert "2023" not in name
+
+
+class TestIhdGetNameDub:
+    """Dub tag (Multi/Dual-Audio/Dubbed) injected before audio string."""
+
+    def test_multi_dub_when_two_audio_tracks(self):
+        meta = _base_meta(audio_languages=["Hindi", "English"])
+        t = _ihd(meta)
+        result = _run(t.get_name(meta))
+        assert "Multi" in result["name"]
+
+    def test_no_dub_tag_for_single_language(self):
+        meta = _base_meta(audio_languages=["Hindi"])
+        t = _ihd(meta)
+        result = _run(t.get_name(meta))
+        assert "Multi" not in result["name"]
+        assert "Dual-Audio" not in result["name"]
+
+
+class TestIhdGetNameTag:
+    def test_tag_at_end(self):
+        meta = _base_meta(tag="-MYGRP")
+        t = _ihd(meta)
+        result = _run(t.get_name(meta))
+        assert result["name"].endswith("-MYGRP")
+
+    def test_nogroup_default_when_no_tag(self):
+        meta = _base_meta(tag=None)
+        t = _ihd(meta)
+        result = _run(t.get_name(meta))
+        assert result["name"].endswith("-NOGROUP")


### PR DESCRIPTION
Disc/REMUX format:
  Name Year S##E## REPACK Resolution UHD Edition Region 3D SOURCE [REMUX] HDR VCodec Dub Audio-Tag

Encode/WEB/HDTV format:
  Name Year S##E## REPACK Resolution UHD Edition 3D ServiceSOURCE TYPE Dub Audio Hi10P HDR VCodec-Tag

Key changes:
  - service token inserted before WEB-DL/WEBRip type
  - Hi10P extracted from video_encode, placed between audio and HDR for encodes
  - dub tag (Multi/Dual-Audio/Dubbed) derived from audio_languages count
  - REMUX (non-disc) uses meta[video_codec] not meta[video_encode]
  - nosec B105 on release-type string comparisons (bandit false positives)
  - year omitted when meta[search_year] is falsy

tests/test_ihd.py: 15 tests covering WEB-DL, Encode, REMUX, TV, dub, tag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Revamped release title generation for full IHD compliance: constructs names from metadata fields, improves handling of titles, year/episode rules, resolution/3D/HDR/UHD tokens, codec/encode ordering, audio/dub tagging, edition cleanup (removes “Hybrid”), and ensures consistent whitespace and trailing group tag.

* **Tests**
  * Added comprehensive tests to validate naming across WEB-DL, ENCODE, REMUX, and TV scenarios, token ordering, dub behavior, edition stripping, and group-tag handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yippee0903/Upload-Assistant/pull/188)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->