### PR TITLE
fix(prep): manual --category always overrides auto-detected category

### DIFF
--- a/src/prep.py
+++ b/src/prep.py
@@ -605,7 +605,11 @@ class Prep:
         except (ValueError, TypeError):
             meta["tvmaze_id"] = 0
 
-        if not meta.get("category"):
+        manual_cat = meta.get("manual_category")
+        if manual_cat:
+            # --category flag always wins over auto-detected / previously set category
+            meta["category"] = manual_cat.upper() if isinstance(manual_cat, str) else meta.get("category", "").upper()
+        elif not meta.get("category"):
             meta["category"] = await self.get_cat(video, meta)
         else:
             meta["category"] = meta["category"].upper()


### PR DESCRIPTION
When the user provides --tmdb <id> without a movie/tv prefix and --category movie during the correction prompt, parse_tmdb_id preserves the existing (wrong) category because the id has no prefix.  Then get_cat() (which reads manual_category) is never called because meta['category'] is already set.

Fix: check meta['manual_category'] first and set meta['category'] from it before falling through to get_cat() or the .upper() branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Manual category override functionality is now available during content preparation, enabling explicit category assignment with automatic text formatting applied. When manual override is not specified, the system intelligently derives category assignment using the existing derivation logic, ensuring consistent and reliable categorization across all content processing scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yippee0903/Upload-Assistant/pull/189)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->