### PR TITLE
fix(radarr): fall back to top result when no originalFilePath matches

### DIFF
--- a/src/radarr.py
+++ b/src/radarr.py
@@ -114,7 +114,9 @@ class RadarrManager:
                     movie = item
                     break
             else:
-                return None
+                # No exact file path match (expected for lookup-by-term results).
+                # Fall back to the top result, which Radarr orders by relevance.
+                movie = items[0]
         else:
             movie = items[0]
 


### PR DESCRIPTION
extract_movie_data() used 'for...else: return None' when searching by term (filename). The loop tried to match movie_file['originalFilePath'] against the search term (e.g. 'The.Matrix.1999.MULTi.1080p.WEB.H264-N3tFliX'), which never equals Radarr's stored path ('The Matrix (1999) - [...].mkv').

For lookup-by-term requests, Radarr returns results ordered by relevance; the top result is the best match. Fall back to items[0] instead of None so the calling code receives valid TMDB/IMDB IDs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved movie data lookup reliability. When exact matching isn't available, the system now uses the first available result instead of returning no data, ensuring more robust lookups.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yippee0903/Upload-Assistant/pull/191)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->