### PR TITLE
fix: g3mini naming

### DIFF
--- a/src/trackers/G3MINI.py
+++ b/src/trackers/G3MINI.py
@@ -95,7 +95,8 @@ class G3MINI(FrenchTrackerMixin, UNIT3D):
             if "integrale" in dupe.get("name", "").lower():
                 if dupe not in result:
                     result.append(dupe)
-                flags: list[str] = dupe.setdefault("flags", [])
+                stored = next(x for x in result if x == dupe)
+                flags: list[str] = stored.setdefault("flags", [])
                 if "integrale_supersede" not in flags:
                     flags.append("integrale_supersede")
         return result

--- a/src/trackers/G3MINI.py
+++ b/src/trackers/G3MINI.py
@@ -142,7 +142,7 @@ class G3MINI(FrenchTrackerMixin, UNIT3D):
             dvd_size = meta.get("dvd_size", "")
         else:
             video_codec = meta.get("video_codec", "")
-            video_encode = meta.get("video_encode", "")
+            video_encode = meta.get("video_encode", "").replace("H.264", "H264").replace("H.265", "H265")
         edition = self._format_edition(meta.get("edition", ""))
         if "hybrid" in edition.upper():
             edition = edition.replace("Hybrid", "").strip()
@@ -155,6 +155,8 @@ class G3MINI(FrenchTrackerMixin, UNIT3D):
                 episode = ""
         if meta.get("no_season", False) is True:
             season = ""
+        # Season pack: append COMPLETE when uploading a full season without an episode number
+        season_ep = season + (" COMPLETE" if meta.get("tv_pack") and season and not episode else episode)
         if meta.get("no_year", False) is True:
             year = ""
         if meta.get("no_aka", False) is True:
@@ -192,25 +194,25 @@ class G3MINI(FrenchTrackerMixin, UNIT3D):
         elif meta["category"] == "TV":  # TV SPECIFIC
             if type == "DISC":  # Disk
                 if meta["is_disc"] == "BDMV":
-                    name = f"{title} {year} {season}{episode} {three_d} {edition} {repack} {language} {resolution} {region} {uhd} {source} {hybrid} {hdr} {audio} {video_codec}"
+                    name = f"{title} {year} {season_ep} {three_d} {edition} {repack} {language} {resolution} {region} {uhd} {source} {hybrid} {hdr} {audio} {video_codec}"
                 if meta["is_disc"] == "DVD":
-                    name = f"{title} {year} {season}{episode}{three_d} {repack} {edition} {region} {source} {dvd_size} {audio}"
+                    name = f"{title} {year} {season_ep}{three_d} {repack} {edition} {region} {source} {dvd_size} {audio}"
                 elif meta["is_disc"] == "HDDVD":
-                    name = f"{title} {year} {season}{episode} {three_d} {edition} {repack} {language} {resolution} {source} {audio} {video_codec}"
+                    name = f"{title} {year} {season_ep} {three_d} {edition} {repack} {language} {resolution} {source} {audio} {video_codec}"
             elif type == "REMUX" and source in ("BluRay", "HDDVD"):  # BluRay Remux
-                name = f"{title} {year} {season}{episode} {part} {three_d} {edition} {repack} {language} {resolution} {uhd} {source} REMUX {hybrid} {hdr} {audio} {video_codec}"  # SOURCE
+                name = f"{title} {year} {season_ep} {part} {three_d} {edition} {repack} {language} {resolution} {uhd} {source} REMUX {hybrid} {hdr} {audio} {video_codec}"  # SOURCE
             elif type == "REMUX" and source in ("PAL DVD", "NTSC DVD", "DVD"):  # DVD Remux
-                name = f"{title} {year} {season}{episode} {part} {edition} {repack} {source} REMUX {audio}"  # SOURCE
+                name = f"{title} {year} {season_ep} {part} {edition} {repack} {source} REMUX {audio}"  # SOURCE
             elif type == "ENCODE":  # Encode
-                name = f"{title} {year} {season}{episode} {part} {edition} {repack} {language} {resolution} {uhd} {source} {hybrid} {hdr} {audio} {video_encode}"  # SOURCE
+                name = f"{title} {year} {season_ep} {part} {edition} {repack} {language} {resolution} {uhd} {source} {hybrid} {hdr} {audio} {video_encode}"  # SOURCE
             elif type == "WEBDL":  # WEB-DL
-                name = f"{title} {year} {season}{episode} {part} {edition} {repack} {language} {resolution} {uhd} {service} WEB-DL {hybrid} {hdr} {audio} {video_encode}"
+                name = f"{title} {year} {season_ep} {part} {edition} {repack} {language} {resolution} {uhd} {service} WEB-DL {hybrid} {hdr} {audio} {video_encode}"
             elif type == "WEBRIP":  # WEBRip
-                name = f"{title} {year} {season}{episode} {part} {edition} {repack} {language} {resolution} {uhd} {service} WEBRip {hybrid} {hdr} {audio} {video_encode}"
+                name = f"{title} {year} {season_ep} {part} {edition} {repack} {language} {resolution} {uhd} {service} WEBRip {hybrid} {hdr} {audio} {video_encode}"
             elif type == "HDTV":  # HDTV
-                name = f"{title} {year} {season}{episode} {part} {edition} {repack} {language} {resolution} {source} {audio} {video_encode}"
+                name = f"{title} {year} {season_ep} {part} {edition} {repack} {language} {resolution} {source} {audio} {video_encode}"
             elif type == "DVDRIP":
-                name = f"{title} {year} {season}{episode} {language} {source} DVDRip {audio} {video_encode}"
+                name = f"{title} {year} {season_ep} {language} {source} DVDRip {audio} {video_encode}"
 
         try:
             name = " ".join(name.split())

--- a/src/trackers/G3MINI.py
+++ b/src/trackers/G3MINI.py
@@ -72,6 +72,42 @@ class G3MINI(FrenchTrackerMixin, UNIT3D):
             resolved_id = resolution_id.get(meta_resolution, "10")
             return {"resolution_id": resolved_id}
 
+    def _check_g3mini_specific_dupes(
+        self,
+        all_dupes: list[dict[str, Any]],
+        filtered: list[dict[str, Any]],
+        meta: dict[str, Any],
+    ) -> list[dict[str, Any]]:
+        """Re-inject integrale dupes that must always block a G3MINI season-pack upload.
+
+        When uploading a season pack and an existing torrent's name contains
+        "integrale" (case-insensitive), that torrent is kept as a blocking dupe
+        regardless of language (same rule as TOS).
+        """
+        is_season_pack = meta.get("tv_pack", False) and meta.get("category") == "TV"
+        if not is_season_pack:
+            return filtered
+
+        result = list(filtered)
+        for dupe in all_dupes:
+            if not isinstance(dupe, dict):
+                continue
+            if "integrale" in dupe.get("name", "").lower():
+                if dupe not in result:
+                    result.append(dupe)
+                flags: list[str] = dupe.setdefault("flags", [])
+                if "integrale_supersede" not in flags:
+                    flags.append("integrale_supersede")
+        return result
+
+    async def search_existing(self, meta: dict[str, Any], _: Any = None) -> list[dict[str, Any]]:
+        """Wrap the standard French dupe check with G3MINI's integrale rule."""
+        from src.trackers.UNIT3D import UNIT3D as _UNIT3D
+
+        raw_dupes = await _UNIT3D.search_existing(self, meta, _)
+        filtered = await self._check_french_lang_dupes(raw_dupes, meta)
+        return self._check_g3mini_specific_dupes(raw_dupes, filtered, meta)
+
     async def get_additional_checks(self, meta: dict[str, Any]) -> bool:
         french_languages = ["french", "fre", "fra", "fr", "français", "francais", "fr-fr", "fr-ca"]
         # check or ignore audio req config
@@ -196,7 +232,7 @@ class G3MINI(FrenchTrackerMixin, UNIT3D):
                 if meta["is_disc"] == "BDMV":
                     name = f"{title} {year} {season_ep} {three_d} {edition} {repack} {language} {resolution} {region} {uhd} {source} {hybrid} {hdr} {audio} {video_codec}"
                 if meta["is_disc"] == "DVD":
-                    name = f"{title} {year} {season_ep}{three_d} {repack} {edition} {region} {source} {dvd_size} {audio}"
+                    name = f"{title} {year} {season_ep} {three_d} {repack} {edition} {region} {source} {dvd_size} {audio}"
                 elif meta["is_disc"] == "HDDVD":
                     name = f"{title} {year} {season_ep} {three_d} {edition} {repack} {language} {resolution} {source} {audio} {video_codec}"
             elif type == "REMUX" and source in ("BluRay", "HDDVD"):  # BluRay Remux

--- a/tests/test_g3mini.py
+++ b/tests/test_g3mini.py
@@ -285,3 +285,105 @@ class TestGetName:
         name = self._run(meta)
         assert 'VFF' in name, f"VFF missing after VFI normalisation: {name}"
         assert 'VFI' not in name, f"VFI should not appear: {name}"
+
+    # ── Season pack / COMPLETE ───────────────────────────────
+
+    def test_tv_season_pack_includes_complete(self):
+        """A full season pack (tv_pack=1, no episode) must include COMPLETE."""
+        meta = _meta_base(
+            category='TV',
+            type='WEBDL',
+            source='WEB',
+            video_encode='H265',
+            video_codec='',
+            service='NF',
+            season='S01',
+            episode='',
+            tv_pack=1,
+            webdv='',
+            hdr='',
+            uhd='',
+        )
+        name = self._run(meta)
+        assert 'S01.COMPLETE' in name, f"COMPLETE missing for season pack: {name}"
+
+    def test_tv_episode_does_not_include_complete(self):
+        """A single episode must NOT include COMPLETE."""
+        meta = _meta_base(
+            category='TV',
+            type='WEBDL',
+            source='WEB',
+            video_encode='H265',
+            video_codec='',
+            service='NF',
+            season='S01',
+            episode='E03',
+            tv_pack=0,
+            webdv='',
+            hdr='',
+            uhd='',
+        )
+        name = self._run(meta)
+        assert 'COMPLETE' not in name, f"COMPLETE must not appear for single episode: {name}"
+        assert 'S01E03' in name, f"S01E03 missing: {name}"
+
+    def test_tv_season_pack_remux_includes_complete(self):
+        """Season pack also works for REMUX type."""
+        meta = _meta_base(
+            category='TV',
+            type='REMUX',
+            source='BluRay',
+            season='S02',
+            episode='',
+            tv_pack=1,
+        )
+        name = self._run(meta)
+        assert 'S02.COMPLETE' in name, f"COMPLETE missing for REMUX season pack: {name}"
+
+    # ── H.264 / H.265 conversion ─────────────────────────────
+
+    def test_webdl_h265_dot_converted(self):
+        """H.265 from prep (with dot) must be normalised to H265 in the name."""
+        meta = _meta_base(
+            type='WEBDL',
+            source='WEB',
+            video_encode='H.265',
+            video_codec='',
+            service='NF',
+            webdv='',
+            hdr='',
+            uhd='',
+        )
+        name = self._run(meta)
+        assert 'H265' in name, f"H265 (no dot) expected: {name}"
+        assert 'H.265' not in name, f"H.265 with dot must not appear: {name}"
+
+    def test_webdl_h264_dot_converted(self):
+        """H.264 from prep (with dot) must be normalised to H264 in the name."""
+        meta = _meta_base(
+            type='WEBDL',
+            source='WEB',
+            video_encode='H.264',
+            video_codec='',
+            service='NF',
+            webdv='',
+            hdr='',
+            uhd='',
+        )
+        name = self._run(meta)
+        assert 'H264' in name, f"H264 (no dot) expected: {name}"
+        assert 'H.264' not in name, f"H.264 with dot must not appear: {name}"
+
+    def test_encode_x265_unchanged(self):
+        """x265 for encodes must pass through unchanged."""
+        meta = _meta_base(
+            type='ENCODE',
+            source='BluRay',
+            video_encode='x265',
+            video_codec='',
+            webdv='',
+            hdr='',
+            uhd='',
+        )
+        name = self._run(meta)
+        assert name.endswith('x265-SGF'), f"x265 not at end: {name}"

--- a/tests/test_g3mini.py
+++ b/tests/test_g3mini.py
@@ -387,3 +387,102 @@ class TestGetName:
         )
         name = self._run(meta)
         assert name.endswith('x265-SGF'), f"x265 not at end: {name}"
+
+    def test_tv_dvd_disc_3d_has_space_before(self):
+        """DVD DISC season_ep and three_d must be separated (not concatenated as S01E013D)."""
+        meta = _meta_base(
+            category='TV',
+            type='DISC',
+            is_disc='DVD',
+            source='DVD',
+            season='S01',
+            episode='E01',
+            **{'3D': '3D'},
+            video_encode='',
+            video_codec='',
+            webdv='',
+            hdr='',
+            uhd='',
+            region='',
+            dvd_size='',
+        )
+        name = self._run(meta)
+        # Before the fix, season_ep+three_d were concatenated → 'S01E013D'
+        assert 'S01E013D' not in name, f"season_ep and 3D must not be merged: {name}"
+        assert 'S01E01' in name, f"season_ep missing: {name}"
+        assert '3D' in name, f"3D tag missing: {name}"
+
+
+# ─── Integrale dupe check ─────────────────────────────────────
+
+
+class TestG3MiniIntegraleDupes:
+    """_check_g3mini_specific_dupes must re-inject integrale releases
+    when uploading a season pack."""
+
+    @staticmethod
+    def _g3() -> G3MINI:
+        return G3MINI(_config())
+
+    def test_integrale_dupe_blocks_season_pack(self):
+        """An existing 'integrale' release must be kept in the dupe list."""
+        g = self._g3()
+        meta = {'tv_pack': 1, 'category': 'TV'}
+        all_dupes = [{'name': 'Breaking.Bad.iNTEGRALE.MULTi.1080p.BluRay.x264-GRP', 'flags': []}]
+        filtered: list = []  # French filter dropped it
+        result = g._check_g3mini_specific_dupes(all_dupes, filtered, meta)
+        assert len(result) == 1
+        assert 'integrale_supersede' in result[0]['flags']
+
+    def test_integrale_flag_not_duplicated(self):
+        """integrale_supersede should appear only once even if called twice."""
+        g = self._g3()
+        meta = {'tv_pack': 1, 'category': 'TV'}
+        dupe = {'name': 'Show.iNTEGRALE.VFF.1080p-GRP', 'flags': ['integrale_supersede']}
+        result = g._check_g3mini_specific_dupes([dupe], [dupe], meta)
+        assert result[0]['flags'].count('integrale_supersede') == 1
+
+    def test_non_integrale_dupe_not_reinjected(self):
+        """A regular (non-integrale) dupe dropped by the French filter stays dropped."""
+        g = self._g3()
+        meta = {'tv_pack': 1, 'category': 'TV'}
+        all_dupes = [{'name': 'Breaking.Bad.S01.MULTi.1080p.BluRay.x264-GRP', 'flags': []}]
+        filtered: list = []
+        result = g._check_g3mini_specific_dupes(all_dupes, filtered, meta)
+        assert result == []
+
+    def test_non_season_pack_ignored(self):
+        """Integrale check must not fire for single-episode uploads."""
+        g = self._g3()
+        meta = {'tv_pack': 0, 'category': 'TV'}
+        all_dupes = [{'name': 'Show.iNTEGRALE.VFF.1080p-GRP', 'flags': []}]
+        filtered: list = []
+        result = g._check_g3mini_specific_dupes(all_dupes, filtered, meta)
+        assert result == []
+
+    def test_movie_upload_ignored(self):
+        """Integrale check must not fire for movie uploads."""
+        g = self._g3()
+        meta = {'tv_pack': 1, 'category': 'MOVIE'}
+        all_dupes = [{'name': 'Movie.iNTEGRALE.1080p-GRP', 'flags': []}]
+        filtered: list = []
+        result = g._check_g3mini_specific_dupes(all_dupes, filtered, meta)
+        assert result == []
+
+    def test_integrale_case_insensitive(self):
+        """Match must be case-insensitive: INTEGRALE, integrale, iNTEGRALE."""
+        g = self._g3()
+        meta = {'tv_pack': 1, 'category': 'TV'}
+        for name_variant in ['Show.INTEGRALE.VFF-GRP', 'Show.integrale.VFF-GRP', 'Show.iNTEGRALE.VFF-GRP']:
+            dupe = {'name': name_variant, 'flags': []}
+            result = g._check_g3mini_specific_dupes([dupe], [], meta)
+            assert len(result) == 1, f"integrale not matched in: {name_variant}"
+            assert 'integrale_supersede' in result[0]['flags']
+
+    def test_already_in_filtered_not_duplicated(self):
+        """A dupe that's already in filtered must appear only once in result."""
+        g = self._g3()
+        meta = {'tv_pack': 1, 'category': 'TV'}
+        dupe = {'name': 'Show.iNTEGRALE.VFF.1080p-GRP', 'flags': []}
+        result = g._check_g3mini_specific_dupes([dupe], [dupe], meta)
+        assert result.count(dupe) == 1

--- a/tests/test_g3mini.py
+++ b/tests/test_g3mini.py
@@ -486,3 +486,20 @@ class TestG3MiniIntegraleDupes:
         dupe = {'name': 'Show.iNTEGRALE.VFF.1080p-GRP', 'flags': []}
         result = g._check_g3mini_specific_dupes([dupe], [dupe], meta)
         assert result.count(dupe) == 1
+
+    def test_flag_set_on_stored_object_not_local_copy(self):
+        """integrale_supersede must be set on the object stored in result,
+        even when filtered holds an equal-but-distinct copy of the dupe."""
+        g = self._g3()
+        meta = {'tv_pack': 1, 'category': 'TV'}
+        dupe_in_all = {'name': 'Show.iNTEGRALE.VFF.1080p-GRP', 'flags': []}
+        # filtered holds a shallow copy — equal by value, distinct by identity
+        dupe_in_filtered = dict(dupe_in_all)
+        dupe_in_filtered['flags'] = []
+        assert dupe_in_filtered is not dupe_in_all  # distinct objects
+        result = g._check_g3mini_specific_dupes([dupe_in_all], [dupe_in_filtered], meta)
+        # The entry in result must carry the flag
+        assert len(result) == 1
+        assert 'integrale_supersede' in result[0]['flags'], (
+            "flag must be on the stored result object, not only on the local dupe"
+        )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Normalized video codec naming in release names — H.264/H.265 now display as H264/H265.
  * Fixed release name formatting so 3D tags remain separate (e.g., S01E01 and 3D).

* **New Features**
  * Reinstate existing "integrale" season releases for TV season-pack uploads when applicable.
  * Season-pack uploads now append a COMPLETE marker when a season is present with no episode.

* **Tests**
  * Added tests for codec normalization, COMPLETE season-pack naming, 3D separation, and integrale dupe handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yippee0903/Upload-Assistant/pull/196)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->