### PR TITLE
fix(dupe): skip file/similarity match for season-pack vs episode

### DIFF
--- a/src/dupe_checking.py
+++ b/src/dupe_checking.py
@@ -342,6 +342,8 @@ class DupeChecker:
                 skip_file_match_for_pack = is_tv_pack and dupe_is_episode
                 for file in filenames:
                     if tracker_name in ["MTV", "AR", "RTF"]:
+                        if skip_file_match_for_pack:
+                            break  # defer to the season/episode check below
                         # MTV: check if any dupe file is a substring of our file (ignoring extension)
                         if any(f.lower() in file.lower() for f in files):
                             meta["filename_match"] = f"{entry.get('name')} = {entry.get('link', None)}"

--- a/src/dupe_checking.py
+++ b/src/dupe_checking.py
@@ -334,6 +334,12 @@ class DupeChecker:
                 remember_match("trumpable_id")
 
             if not meta.get("is_disc"):
+                # When uploading a TV season pack, individual-episode entries on the tracker
+                # are NOT exact dupes — the season/episode check below handles them correctly.
+                # Skip the file-comparison early-return so it cannot set filename_match
+                # and bypass the season/episode exclusion for pack-vs-episode pairs.
+                dupe_is_episode = meta.get("category") == "TV" and bool(re.search(r"[sS]\d+[eE]\d{2}", each))
+                skip_file_match_for_pack = is_tv_pack and dupe_is_episode
                 for file in filenames:
                     if tracker_name in ["MTV", "AR", "RTF"]:
                         # MTV: check if any dupe file is a substring of our file (ignoring extension)
@@ -353,6 +359,8 @@ class DupeChecker:
                         if meta.get("debug") and entry_size is None and meta.get("source_size") is not None:
                             console.log(f"[debug] Size comparison failed due to ValueError: entry_size={entry.get('size')}, source_size={meta.get('source_size')}")
                     else:
+                        if skip_file_match_for_pack:
+                            break  # defer to the season/episode check below
                         if meta.get("debug"):
                             console.log(f"[debug] Comparing file: {file} against dupe files list.")
                             console.log(f"[debug] Dupe files list: {files[:10]}{'...' if len(files) > 10 else files}")
@@ -657,15 +665,22 @@ class DupeChecker:
             # matches AND the normalised names are very similar (≥ 0.75), treat
             # this as a confirmed dupe — the entry has already passed all
             # resolution/source/HDR exclusion checks above.
+            # Guard: a season-pack upload must never match an individual-episode
+            # entry via similarity — the names are near-identical but the
+            # releases are not the same thing.
             if not files and tag.strip() and tag.strip() in normalized:
-                target_normalized = await DupeChecker.normalize_filename(str(meta.get("name", "")))
-                similarity = SequenceMatcher(None, normalized, target_normalized).ratio()
-                if meta.get("debug"):
-                    console.log(f"[debug] Name similarity fallback: {similarity:.3f} (threshold 0.75) for {each}")
-                if similarity >= 0.75:
-                    meta["filename_match"] = f"{entry.get('name')} = {entry.get('link', None)}"
-                    remember_match("filename")
-                    return False
+                if is_tv_pack and bool(re.search(r"[sS]\d+[eE]\d{2}", each)):
+                    if meta.get("debug"):
+                        console.log(f"[debug] Skipping name-similarity: season-pack vs episode for {each}")
+                else:
+                    target_normalized = await DupeChecker.normalize_filename(str(meta.get("name", "")))
+                    similarity = SequenceMatcher(None, normalized, target_normalized).ratio()
+                    if meta.get("debug"):
+                        console.log(f"[debug] Name similarity fallback: {similarity:.3f} (threshold 0.75) for {each}")
+                    if similarity >= 0.75:
+                        meta["filename_match"] = f"{entry.get('name')} = {entry.get('link', None)}"
+                        remember_match("filename")
+                        return False
 
             if meta.get("debug"):
                 console.log(f"[cyan]Release PASSED all checks: {each}")

--- a/tests/test_dupe_checking.py
+++ b/tests/test_dupe_checking.py
@@ -337,3 +337,156 @@ class TestFrenchSupersedePlusFilenameMatch:
             "filename_match must NOT be set when the competing release has a "
             "different group tag"
         )
+
+
+# ═══════════════════════════════════════════════════════════════
+#  Season-pack upload vs individual-episode dupe guard
+# ═══════════════════════════════════════════════════════════════
+
+
+def _family_guy_s24_pack_meta(**overrides) -> dict[str, Any]:
+    """Minimal meta for a Family Guy S24 season-pack upload."""
+    meta: dict[str, Any] = {
+        "name": "Family Guy S24 1080p DSNP WEB-DL DD+ 5.1 H.264-FLUX",
+        "uuid": "Family.Guy.S24.1080p.DSNP.WEB-DL.DD+.5.1.H.264-FLUX",
+        "tmdb": "4057",
+        "resolution": "1080p",
+        "category": "TV",
+        "type": "WEBDL",
+        "source": "Disney+",
+        "is_disc": None,
+        "sd": 0,
+        "hdr": None,
+        "season": "S24",
+        "episode": None,
+        "tv_pack": 1,
+        "tag": "-FLUX",
+        "video_encode": "H.264",
+        "unattended": True,
+        "debug": False,
+        "filelist": [
+            "/dl/Family.Guy.S24E01.1080p.DSNP.WEB-DL.DD+.5.1.H.264-FLUX.mkv",
+            "/dl/Family.Guy.S24E02.1080p.DSNP.WEB-DL.DD+.5.1.H.264-FLUX.mkv",
+            "/dl/Family.Guy.S24E13.1080p.DSNP.WEB-DL.DD+.5.1.H.264-FLUX.mkv",
+        ],
+    }
+    meta.update(overrides)
+    return meta
+
+
+def _episode_entry(ep: str, with_files: bool = True) -> dict[str, Any]:
+    """Build a dupe entry for a single Family Guy episode."""
+    name = f"Family Guy S24{ep} 1080p DSNP WEB-DL DD+ 5.1 H.264-FLUX"
+    files = (
+        [f"Family.Guy.S24{ep}.1080p.DSNP.WEB-DL.DD+.5.1.H.264-FLUX.mkv"]
+        if with_files
+        else []
+    )
+    return {
+        "name": name,
+        "size": 1_500_000_000,
+        "files": files,
+        "file_count": len(files),
+        "trumpable": False,
+        "link": f"https://tracker.example/torrents/100",
+        "id": 100,
+        "type": "WEB-DL",
+        "res": "1080p",
+        "internal": False,
+    }
+
+
+class TestSeasonPackVsEpisodeGuard:
+    """
+    A TV season-pack upload must NEVER be flagged as an exact match of an
+    individual-episode entry on the tracker, regardless of whether the dupe
+    comparison fires via file list or name-similarity fallback.
+    """
+
+    def test_file_match_does_not_flag_pack_as_episode_dupe(self):
+        """
+        The season pack contains S24E13.mkv.  The tracker has an S24E13
+        episode entry whose file list includes that exact filename.
+        The file-comparison guard must prevent filename_match from being set.
+        """
+        meta = _family_guy_s24_pack_meta()
+        entry = _episode_entry("E13", with_files=True)
+
+        dupes = _run(_checker().filter_dupes([entry], meta, "DP"))
+
+        assert not meta.get("filename_match"), (
+            "filename_match must NOT be set when a season-pack upload matches "
+            "an individual-episode file — they are not the same release"
+        )
+        assert not meta.get("exact_filename_match"), (
+            "exact_filename_match must also not be set for pack-vs-episode"
+        )
+
+    def test_similarity_fallback_does_not_flag_pack_as_episode_dupe(self):
+        """
+        When the tracker returns no file list (e.g. LST) and names are near-
+        identical (Family Guy S24 vs Family Guy S24E13), the name-similarity
+        fallback must be skipped for season-pack vs episode pairs.
+        """
+        meta = _family_guy_s24_pack_meta()
+        entry = _episode_entry("E13", with_files=False)
+
+        dupes = _run(_checker().filter_dupes([entry], meta, "LST"))
+
+        assert not meta.get("filename_match"), (
+            "filename_match must NOT be set via name-similarity fallback when "
+            "a season-pack upload is compared against a single-episode entry"
+        )
+
+    def test_episode_upload_vs_same_episode_still_detected(self):
+        """
+        When uploading a *single episode* (not a pack) and the tracker has that
+        exact episode, the file-comparison must still detect it as a dupe.
+        """
+        meta = _family_guy_s24_pack_meta(
+            name="Family Guy S24E13 1080p DSNP WEB-DL DD+ 5.1 H.264-FLUX",
+            season="S24",
+            episode="E13",
+            tv_pack=0,
+            filelist=["/dl/Family.Guy.S24E13.1080p.DSNP.WEB-DL.DD+.5.1.H.264-FLUX.mkv"],
+        )
+        entry = _episode_entry("E13", with_files=True)
+
+        dupes = _run(_checker().filter_dupes([entry], meta, "DP"))
+
+        assert dupes, "identical episode upload must be detected as dupe"
+        assert meta.get("filename_match"), (
+            "filename_match must be set when episode upload matches episode dupe"
+        )
+
+    def test_pack_upload_vs_same_pack_still_detected(self):
+        """
+        When the tracker already has the same season pack, it must still be
+        detected as a dupe (no false exclusion from the new guard).
+        """
+        meta = _family_guy_s24_pack_meta()
+        # Season-pack entry whose name has no episode pattern
+        pack_entry: dict[str, Any] = {
+            "name": "Family Guy S24 1080p DSNP WEB-DL DD+ 5.1 H.264-FLUX",
+            "size": 20_000_000_000,
+            "files": [
+                "Family.Guy.S24E01.1080p.DSNP.WEB-DL.DD+.5.1.H.264-FLUX.mkv",
+                "Family.Guy.S24E02.1080p.DSNP.WEB-DL.DD+.5.1.H.264-FLUX.mkv",
+                "Family.Guy.S24E13.1080p.DSNP.WEB-DL.DD+.5.1.H.264-FLUX.mkv",
+            ],
+            "file_count": 3,
+            "trumpable": False,
+            "link": "https://tracker.example/torrents/200",
+            "id": 200,
+            "type": "WEB-DL",
+            "res": "1080p",
+            "internal": False,
+        }
+
+        dupes = _run(_checker().filter_dupes([pack_entry], meta, "DP"))
+
+        assert dupes, "season-pack upload vs same season-pack on tracker must be detected as dupe"
+        assert meta.get("filename_match"), (
+            "filename_match must be set when season-pack upload matches an "
+            "existing season-pack entry on the tracker"
+        )

--- a/tests/test_dupe_checking.py
+++ b/tests/test_dupe_checking.py
@@ -414,6 +414,7 @@ class TestSeasonPackVsEpisodeGuard:
 
         dupes = _run(_checker().filter_dupes([entry], meta, "DP"))
 
+        assert not dupes, "the episode entry must be filtered out — it is not a dupe of the season pack"
         assert not meta.get("filename_match"), (
             "filename_match must NOT be set when a season-pack upload matches "
             "an individual-episode file — they are not the same release"
@@ -433,6 +434,7 @@ class TestSeasonPackVsEpisodeGuard:
 
         dupes = _run(_checker().filter_dupes([entry], meta, "LST"))
 
+        assert not dupes, "the episode entry must be filtered out — it is not a dupe of the season pack"
         assert not meta.get("filename_match"), (
             "filename_match must NOT be set via name-similarity fallback when "
             "a season-pack upload is compared against a single-episode entry"


### PR DESCRIPTION
When uploading a TV season pack, individual-episode entries on the tracker must never be flagged as exact-match dupes via:

1. File comparison path: the pack's filelist contains individual episode files (e.g. S24E13.mkv). If the tracker has a S24E13 entry with that file in its list, the old code set filename_match and returned False (is a dupe) *before* the season/episode exclusion check could reject it. Fixed by breaking out of the file loop for pack-vs-episode pairs, deferring to the season/episode check further down.

2. Name-similarity fallback: S24 vs S24E13 names are near-identical so SequenceMatcher fires. Fixed by skipping the similarity check entirely when is_tv_pack=True and the dupe entry has an episode pattern ([sS]\d+[eE]\d{2}).

Both guards are conditioned on is_tv_pack AND dupe_is_episode so episode-vs-episode and pack-vs-pack comparisons are unaffected.

Tests: four new cases in TestSeasonPackVsEpisodeGuard cover both guard paths plus two regression cases (episode still detected, pack-vs-pack still detected).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate detection for TV season-pack uploads to avoid false positives against individual episode tracker entries, while preserving correct detection of true pack and episode duplicates.
* **Tests**
  * Added regression tests covering season-pack vs. episode matching to prevent regressions and ensure both pack and single-episode detections remain correct.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yippee0903/Upload-Assistant/pull/206?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->