### PR TITLE
fix(IHD): remove non-spec foreign lang prefix from get_name()

### DIFF
--- a/src/trackers/IHD.py
+++ b/src/trackers/IHD.py
@@ -255,7 +255,6 @@ class IHD(UNIT3D):
 
     async def get_name(self, meta: Meta) -> dict[str, str]:
         ihd_name = str(meta.get("name", ""))
-        resolution = str(meta.get("resolution", ""))
 
         # Per IHD naming guide: "Edition" (Remastered, Anniversary Edition, …)
         # is omitted for non-Full Disc releases, but "Cut" (Director's Cut,
@@ -268,15 +267,6 @@ class IHD(UNIT3D):
 
         if not meta.get("language_checked", False):
             await languages_manager.process_desc_language(meta, tracker=self.tracker)
-        audio_languages_value = meta.get("audio_languages", [])
-        audio_languages: list[str] = []
-        if isinstance(audio_languages_value, list):
-            audio_languages_list = cast(list[Any], audio_languages_value)
-            audio_languages = [str(item) for item in audio_languages_list]
-        if audio_languages and not await languages_manager.has_english_language(audio_languages):
-            foreign_lang = str(audio_languages[0]).upper()
-            if resolution and resolution in ihd_name:
-                ihd_name = ihd_name.replace(resolution, f"{foreign_lang} {resolution}", 1)
 
         return {"name": ihd_name}
 

--- a/tests/test_ihd.py
+++ b/tests/test_ihd.py
@@ -198,24 +198,6 @@ class TestIHDGetNameEdition:
         result = self._run_get_name(ihd, meta)
         assert result["name"] == original
 
-    def test_foreign_language_prefix_applied_after_edition_strip(self, ihd):
-        """Language prefix must be inserted at the right position even when edition was stripped."""
-        meta = {
-            "name": "Seven Samurai AKA Shichinin no samurai 1954 RESTORED REPACK 1080p BluRay AAC 1.0 x264-hallowed",
-            "resolution": "1080p",
-            "edition": "RESTORED",
-            "is_disc": None,
-            "type": "ENCODE",
-            "language_checked": True,
-            "audio_languages": ["Japanese"],
-        }
-        with patch("src.trackers.IHD.languages_manager") as mock_lm:
-            mock_lm.process_desc_language = AsyncMock()
-            mock_lm.has_english_language = AsyncMock(return_value=False)
-            result = _run(ihd.get_name(meta))
-        assert "RESTORED" not in result["name"]
-        assert "JAPANESE 1080p" in result["name"]
-
 
 # ═══════════════════════════════════════════════════════════════
 #  get_name() — service token preservation (MGMP / MGM+)


### PR DESCRIPTION
The 4-line block that injected a bare language code (JPN, FRE...) before the resolution string does not correspond to any element in the IHD naming schema.  The 'Dub' tag (Dual-Audio / Dubbed / Multi) is already placed correctly upstream by get_name.py.

Remove the block and its now-dead audio_languages parsing; delete the test that covered the removed behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified naming logic by removing automatic language prefix insertion in tracker naming

* **Tests**
  * Removed a test case related to previous naming behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yippee0903/Upload-Assistant/pull/209?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->