### PR TITLE
Fix(g3mini)/minimum encode settings

### DIFF
--- a/src/trackers/G3MINI.py
+++ b/src/trackers/G3MINI.py
@@ -147,9 +147,8 @@ class G3MINI(FrenchTrackerMixin, UNIT3D):
                     if not isinstance(encoding_settings, str):
                         encoding_settings = str(encoding_settings)
                     if not encoding_settings:
-                        if meta.get("debug", False):
-                            console.print(f"[yellow]{self.tracker}: No Encoded_Library_Settings found — skipping preset check.[/yellow]")
-                        break
+                        console.print(f"[bold red]{self.tracker}: No encoding settings found in mediainfo — cannot verify x264 preset quality (minimum: 'slow').[/bold red]")
+                        return False
 
                     subme_match = re.search(r"\bsubme\s*=\s*(\d+)", encoding_settings, re.IGNORECASE)
                     trellis_match = re.search(r"\btrellis\s*=\s*(\d+)", encoding_settings, re.IGNORECASE)

--- a/src/trackers/G3MINI.py
+++ b/src/trackers/G3MINI.py
@@ -139,7 +139,7 @@ class G3MINI(FrenchTrackerMixin, UNIT3D):
         #   subme : medium=7, slow=8, slower=9, veryslow=10+  → require >= 8
         #   trellis: medium=1, slow=2                          → require >= 2
         # Both conditions must be met to pass (either alone could be a custom override).
-        if not meta.get("is_disc") and meta.get("video_codec") == "x264" and meta.get("type") in {"ENCODE", "WEBRIP"}:
+        if not meta.get("is_disc") and "x264" in meta.get("video_encode", "").lower() and meta.get("type") in {"ENCODE", "WEBRIP"}:
             tracks = meta.get("mediainfo", {}).get("media", {}).get("track", [])
             for track in tracks:
                 if track.get("@type") == "Video":

--- a/tests/test_g3mini.py
+++ b/tests/test_g3mini.py
@@ -621,8 +621,8 @@ class TestG3MINIAdditionalChecksX264Preset:
         assert result is False
 
     def test_medium_preset_subme7_is_rejected(self):
-        """subme=7 (medium) must be rejected."""
-        meta = self._meta(encoding_settings="cabac=1 / ref=5 / subme=7 / trellis=1")
+        """subme=7 alone (trellis meets minimum) must be rejected."""
+        meta = self._meta(encoding_settings="cabac=1 / ref=5 / subme=7 / trellis=2")
         result = asyncio.run(self._g3().get_additional_checks(meta))
         assert result is False
 
@@ -645,8 +645,8 @@ class TestG3MINIAdditionalChecksX264Preset:
         assert result is True
 
     def test_remux_skips_preset_check(self):
-        """REMUX type must not be blocked by the preset check."""
-        meta = self._meta(encoding_settings=None, type="REMUX", video_codec="AVC", video_encode="")
+        """REMUX type must not be blocked by the preset check even with x264 video_encode."""
+        meta = self._meta(encoding_settings=None, type="REMUX", video_codec="AVC", video_encode=" x264")
         result = asyncio.run(self._g3().get_additional_checks(meta))
         assert result is True
 

--- a/tests/test_g3mini.py
+++ b/tests/test_g3mini.py
@@ -590,8 +590,8 @@ class TestG3MINIAdditionalChecksX264Preset:
             video_track["Encoded_Library_Settings"] = encoding_settings
         m = _meta_base(
             type="ENCODE",
-            video_codec="x264",
-            video_encode="x264",
+            video_codec="AVC",
+            video_encode=" x264",
             source="BluRay",
             is_disc=None,
             mediainfo={
@@ -646,7 +646,7 @@ class TestG3MINIAdditionalChecksX264Preset:
 
     def test_remux_skips_preset_check(self):
         """REMUX type must not be blocked by the preset check."""
-        meta = self._meta(encoding_settings=None, type="REMUX", video_codec="HEVC", video_encode="")
+        meta = self._meta(encoding_settings=None, type="REMUX", video_codec="AVC", video_encode="")
         result = asyncio.run(self._g3().get_additional_checks(meta))
         assert result is True
 

--- a/tests/test_g3mini.py
+++ b/tests/test_g3mini.py
@@ -570,3 +570,88 @@ class TestG3MININotagGetName:
         meta = self._base_meta(tag="-NoGrp")
         result = asyncio.run(g3mini.get_name(meta))
         assert result["name"].endswith("-NoGrP")
+
+
+# ═══════════════════════════════════════════════════════════════
+#  get_additional_checks — x264 preset quality gate
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestG3MINIAdditionalChecksX264Preset:
+    """G3MINI rejects x264 encodes that cannot prove ≥ 'slow' preset quality."""
+
+    @staticmethod
+    def _g3() -> G3MINI:
+        return G3MINI(_config())
+
+    def _meta(self, encoding_settings: str | None, **overrides: Any) -> dict[str, Any]:
+        video_track: dict[str, Any] = {"@type": "Video"}
+        if encoding_settings is not None:
+            video_track["Encoded_Library_Settings"] = encoding_settings
+        m = _meta_base(
+            type="ENCODE",
+            video_codec="x264",
+            video_encode="x264",
+            source="BluRay",
+            is_disc=None,
+            mediainfo={
+                "media": {
+                    "track": [
+                        video_track,
+                        {"@type": "Audio", "Language": "fr"},
+                    ]
+                }
+            },
+            audio_languages=["French"],
+            subtitle_languages=[],
+        )
+        m.update(overrides)
+        return m
+
+    def test_no_encoding_settings_is_rejected(self):
+        """Scene releases without Encoded_Library_Settings must be blocked."""
+        meta = self._meta(encoding_settings=None)
+        result = asyncio.run(self._g3().get_additional_checks(meta))
+        assert result is False
+
+    def test_empty_encoding_settings_is_rejected(self):
+        """Empty Encoded_Library_Settings string must be blocked."""
+        meta = self._meta(encoding_settings="")
+        result = asyncio.run(self._g3().get_additional_checks(meta))
+        assert result is False
+
+    def test_medium_preset_subme7_is_rejected(self):
+        """subme=7 (medium) must be rejected."""
+        meta = self._meta(encoding_settings="cabac=1 / ref=5 / subme=7 / trellis=1")
+        result = asyncio.run(self._g3().get_additional_checks(meta))
+        assert result is False
+
+    def test_medium_preset_trellis1_is_rejected(self):
+        """trellis=1 (medium) must be rejected."""
+        meta = self._meta(encoding_settings="subme=8 / trellis=1")
+        result = asyncio.run(self._g3().get_additional_checks(meta))
+        assert result is False
+
+    def test_slow_preset_passes(self):
+        """subme=8, trellis=2 (slow) must pass."""
+        meta = self._meta(encoding_settings="cabac=1 / ref=5 / subme=8 / trellis=2")
+        result = asyncio.run(self._g3().get_additional_checks(meta))
+        assert result is True
+
+    def test_veryslow_preset_passes(self):
+        """subme=10, trellis=2 (veryslow) must pass."""
+        meta = self._meta(encoding_settings="subme=10 / trellis=2 / ref=8")
+        result = asyncio.run(self._g3().get_additional_checks(meta))
+        assert result is True
+
+    def test_remux_skips_preset_check(self):
+        """REMUX type must not be blocked by the preset check."""
+        meta = self._meta(encoding_settings=None, type="REMUX", video_codec="HEVC", video_encode="")
+        result = asyncio.run(self._g3().get_additional_checks(meta))
+        assert result is True
+
+    def test_disc_skips_preset_check(self):
+        """Full disc (is_disc=BDMV) must not be blocked by the preset check."""
+        meta = self._meta(encoding_settings=None, is_disc="BDMV")
+        result = asyncio.run(self._g3().get_additional_checks(meta))
+        assert result is True


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced x264 validation — uploads missing required x264 encoding settings are now rejected instead of being skipped.
  * Stricter preset quality checks — x264 submissions must meet "slow" or "veryslow" preset requirements; medium presets are rejected.

* **Tests**
  * Added tests covering x264 preset enforcement and bypass cases for remuxes and disc sources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yippee0903/Upload-Assistant/pull/213?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->