### PR TITLE
fix: correct nogroup WEB-DL naming across trackers

### DIFF
--- a/src/tags.py
+++ b/src/tags.py
@@ -50,6 +50,7 @@ async def get_tag(video: str, meta: dict[str, Any], season_pack_check: bool = Fa
         non_anime_match = re.search(
             r"(?<=-)((?<!WEB-)(?<!Blu-)(?!\s*(?:WEB-DL|Blu-ray|H-264|H-265))(?:\W|\b)(?!(?:\d{3,4}[ip]))(?!\d+\b)(?:\W|\b)([\w .]+?))(?:\[.+\])?(?:\))?(?:\s\[.+\])?$",
             basename_stripped,
+            re.IGNORECASE,
         )
         if non_anime_match:
             release_group = non_anime_match.group(1).strip()

--- a/src/tags.py
+++ b/src/tags.py
@@ -48,7 +48,8 @@ async def get_tag(video: str, meta: dict[str, Any], season_pack_check: bool = Fa
             # If the extension contains a hyphen, it's not a real extension
             basename_stripped = basename_no_path if ext and "-" in ext else name
         non_anime_match = re.search(
-            r"(?<=-)((?!\s*(?:WEB-DL|Blu-ray|H-264|H-265))(?:\W|\b)(?!(?:\d{3,4}[ip]))(?!\d+\b)(?:\W|\b)([\w .]+?))(?:\[.+\])?(?:\))?(?:\s\[.+\])?$", basename_stripped
+            r"(?<=-)((?<!WEB-)(?<!Blu-)(?!\s*(?:WEB-DL|Blu-ray|H-264|H-265))(?:\W|\b)(?!(?:\d{3,4}[ip]))(?!\d+\b)(?:\W|\b)([\w .]+?))(?:\[.+\])?(?:\))?(?:\s\[.+\])?$",
+            basename_stripped,
         )
         if non_anime_match:
             release_group = non_anime_match.group(1).strip()

--- a/src/trackers/HDS.py
+++ b/src/trackers/HDS.py
@@ -166,6 +166,13 @@ class HDS:
             meta["skipping"] = f"{self.tracker}"
             return dupes
 
+        tag_group = str(meta.get("tag", "")).strip("-").strip().lower()
+        invalid_tags = ["nogrp", "nogroup", "unknown", "unk"]
+        if not tag_group or tag_group in invalid_tags:
+            console.print(f"{self.tracker}: Releases without a group tag are not accepted. Skipping.")
+            meta["skipping"] = f"{self.tracker}"
+            return dupes
+
         cookies = await self.cookie_validator.load_session_cookies(meta, self.tracker)
         self.session.cookies.clear()
         if cookies is not None:

--- a/src/trackers/HHD.py
+++ b/src/trackers/HHD.py
@@ -90,6 +90,12 @@ class HHD(UNIT3D):
         ):
             return False
 
+        tag_group = str(meta.get("tag", "")).strip("-").strip().lower()
+        invalid_tags = ["nogrp", "nogroup", "unknown", "unk"]
+        if not tag_group or tag_group in invalid_tags:
+            console.print(f"[bold red]{self.tracker}: Releases without a group tag are not accepted. Skipping.[/bold red]")
+            return False
+
         return should_continue
 
     async def get_resolution_id(self, meta: Meta, resolution: Optional[str] = None, reverse: bool = False, mapping_only: bool = False) -> dict[str, str]:

--- a/src/trackers/LUME.py
+++ b/src/trackers/LUME.py
@@ -76,3 +76,16 @@ class LUME(UNIT3D):
                 return False
 
         return should_continue
+
+    async def get_name(self, meta: Meta) -> dict[str, Any]:
+        lume_name = str(meta.get("name", ""))
+        tag_value = str(meta.get("tag", ""))
+        tag_lower = tag_value.lower()
+        invalid_tags = ["nogrp", "nogroup", "unknown", "-unk-"]
+
+        if tag_value == "" or any(inv in tag_lower for inv in invalid_tags):
+            for inv in invalid_tags:
+                lume_name = re.sub(f"-{re.escape(inv)}", "", lume_name, flags=re.IGNORECASE)
+            lume_name = f"{lume_name}-NOGROUP"
+
+        return {"name": lume_name}

--- a/src/trackers/LUME.py
+++ b/src/trackers/LUME.py
@@ -80,12 +80,11 @@ class LUME(UNIT3D):
     async def get_name(self, meta: Meta) -> dict[str, Any]:
         lume_name = str(meta.get("name", ""))
         tag_value = str(meta.get("tag", ""))
-        tag_lower = tag_value.lower()
-        invalid_tags = ["nogrp", "nogroup", "unknown", "-unk-"]
+        normalized_tag = tag_value.strip("-").strip().lower()
+        invalid_tag_set = {"nogrp", "nogroup", "unknown", "unk"}
 
-        if tag_value == "" or any(inv in tag_lower for inv in invalid_tags):
-            for inv in invalid_tags:
-                lume_name = re.sub(f"-{re.escape(inv)}", "", lume_name, flags=re.IGNORECASE)
+        if tag_value == "" or normalized_tag in invalid_tag_set:
+            lume_name = re.sub(r"-(?:nogrp|nogroup|unknown|unk)(?=$|-)", "", lume_name, flags=re.IGNORECASE)
             lume_name = f"{lume_name}-NOGROUP"
 
         return {"name": lume_name}

--- a/src/trackers/RF.py
+++ b/src/trackers/RF.py
@@ -44,14 +44,13 @@ class RF(UNIT3D):
     async def get_name(self, meta: Meta) -> dict[str, str]:
         rf_name = str(meta.get("name", ""))
         tag_value = str(meta.get("tag", ""))
-        tag_lower = tag_value.lower()
-        invalid_tags = ["nogrp", "nogroup", "unknown", "-unk-"]
+        normalized_tag = tag_value.strip("-").strip().lower()
+        invalid_tag_set = {"nogrp", "nogroup", "unknown", "unk"}
 
         # RF accepts releases without a group tag — strip any invalid token but
         # do NOT append a placeholder suffix.
-        if tag_value == "" or any(invalid_tag in tag_lower for invalid_tag in invalid_tags):
-            for invalid_tag in invalid_tags:
-                rf_name = re.sub(f"-{re.escape(invalid_tag)}", "", rf_name, flags=re.IGNORECASE)
+        if tag_value == "" or normalized_tag in invalid_tag_set:
+            rf_name = re.sub(r"-(?:nogrp|nogroup|unknown|unk)(?=$|-)", "", rf_name, flags=re.IGNORECASE)
 
         return {"name": rf_name}
 

--- a/src/trackers/RF.py
+++ b/src/trackers/RF.py
@@ -47,10 +47,11 @@ class RF(UNIT3D):
         tag_lower = tag_value.lower()
         invalid_tags = ["nogrp", "nogroup", "unknown", "-unk-"]
 
+        # RF accepts releases without a group tag — strip any invalid token but
+        # do NOT append a placeholder suffix.
         if tag_value == "" or any(invalid_tag in tag_lower for invalid_tag in invalid_tags):
             for invalid_tag in invalid_tags:
-                rf_name = re.sub(f"-{invalid_tag}", "", rf_name, flags=re.IGNORECASE)
-            rf_name = f"{rf_name}-NoGroup"
+                rf_name = re.sub(f"-{re.escape(invalid_tag)}", "", rf_name, flags=re.IGNORECASE)
 
         return {"name": rf_name}
 

--- a/src/trackers/YUS.py
+++ b/src/trackers/YUS.py
@@ -88,6 +88,12 @@ class YUS(UNIT3D):
             else:
                 return False
 
+        tag_group = str(meta.get("tag", "")).strip("-").strip().lower()
+        invalid_tags = ["nogrp", "nogroup", "unknown", "unk"]
+        if not tag_group or tag_group in invalid_tags:
+            console.print(f"[bold red]{self.tracker}: Releases without a group tag are not accepted. Skipping.[/bold red]")
+            return False
+
         return should_continue
 
     async def get_type_id(

--- a/tests/test_c411.py
+++ b/tests/test_c411.py
@@ -2598,3 +2598,65 @@ class TestC411SearchExistingLanguageGate:
             dupes = _run_async(c411.search_existing(meta, ""))
         assert dupes == []
         assert meta["skipping"] == "C411"
+
+
+# ═══════════════════════════════════════════════════════════════
+#  Nogroup WEB-DL naming — regression for Cyclo-style filenames
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestNogroupWebDL:
+    """WEB-DL releases without a group tag must use C411's notag_label.
+
+    C411 uses notag_label='NOTAG'.
+    Regression: Cyclo.1995.1080p.WEB-DL.AAC.2.0.H.264.mkv had a false
+    group '-DL.AAC.2.0.H.264' extracted, producing duplicated tokens.
+    """
+
+    def _get_name(self, meta: dict) -> str:
+        from src.trackers.C411 import C411
+        return _run_async(C411(_config()).get_name(meta))['name']
+
+    def test_empty_tag_uses_notag_label(self):
+        """tag='' (nogroup) must produce a name ending with '-NOTAG'."""
+        meta = _meta_base(
+            title='Cyclo',
+            year='1995',
+            audio='AAC 2.0',
+            video_encode='H.264',
+            video_codec='H.264',
+            tag='',
+            has_encode_settings=False,
+        )
+        name = self._get_name(meta)
+        assert name.endswith('-NOTAG'), f"Expected -NOTAG suffix, got: {name!r}"
+
+    def test_no_audio_duplication(self):
+        """Audio token must appear exactly once — no duplication from a false tag."""
+        meta = _meta_base(
+            title='Cyclo',
+            year='1995',
+            audio='AAC 2.0',
+            video_encode='H.264',
+            video_codec='H.264',
+            tag='',
+            has_encode_settings=False,
+        )
+        name = self._get_name(meta)
+        assert name.count('AAC') == 1, (
+            f"Audio token 'AAC' duplicated in name: {name!r}."
+        )
+
+    def test_real_group_preserved(self):
+        """A real group tag must not be replaced by the notag label."""
+        meta = _meta_base(
+            title='Cyclo',
+            year='1995',
+            audio='AAC 2.0',
+            video_encode='H.264',
+            video_codec='H.264',
+            tag='-FRiENDS',
+            has_encode_settings=False,
+        )
+        name = self._get_name(meta)
+        assert name.endswith('-FRiENDS'), f"Expected -FRiENDS suffix, got: {name!r}"

--- a/tests/test_g3mini.py
+++ b/tests/test_g3mini.py
@@ -655,3 +655,61 @@ class TestG3MINIAdditionalChecksX264Preset:
         meta = self._meta(encoding_settings=None, is_disc="BDMV")
         result = asyncio.run(self._g3().get_additional_checks(meta))
         assert result is True
+
+
+# ═══════════════════════════════════════════════════════════════
+#  Nogroup WEB-DL naming — regression for Cyclo-style filenames
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestNogroupWebDL:
+    """WEB-DL releases without a group tag must use G3MINI's notag_label.
+
+    G3MINI uses WEB_LABEL='WEB-DL' and notag_label='NoGrP'.
+    Regression: Cyclo.1995.1080p.WEB-DL.AAC.2.0.H.264.mkv had a false
+    group '-DL.AAC.2.0.H.264' extracted, producing duplicated tokens.
+    """
+
+    def _get_name(self, meta: dict) -> str:
+        return asyncio.run(G3MINI(_config()).get_name(meta))['name']
+
+    def test_empty_tag_uses_notag_label(self):
+        """tag='' (nogroup) must produce a name ending with '-NoGrP'."""
+        meta = _meta_base(
+            type='WEBDL',
+            source='WEB',
+            audio='AAC 2.0',
+            video_encode='H.264',
+            video_codec='H.264',
+            tag='',
+        )
+        name = self._get_name(meta)
+        assert name.endswith('-NoGrP'), f"Expected -NoGrP suffix, got: {name!r}"
+
+    def test_no_audio_duplication(self):
+        """Audio token must appear exactly once — no duplication from a false tag."""
+        meta = _meta_base(
+            type='WEBDL',
+            source='WEB',
+            audio='AAC 2.0',
+            video_encode='H.264',
+            video_codec='H.264',
+            tag='',
+        )
+        name = self._get_name(meta)
+        assert name.count('AAC') == 1, (
+            f"Audio token 'AAC' duplicated in name: {name!r}."
+        )
+
+    def test_real_group_preserved(self):
+        """A real group tag must not be replaced by the notag label."""
+        meta = _meta_base(
+            type='WEBDL',
+            source='WEB',
+            audio='AAC 2.0',
+            video_encode='H.264',
+            video_codec='H.264',
+            tag='-GROUP',
+        )
+        name = self._get_name(meta)
+        assert name.endswith('-GROUP'), f"Expected -GROUP suffix, got: {name!r}"

--- a/tests/test_hhd.py
+++ b/tests/test_hhd.py
@@ -206,6 +206,20 @@ class TestHHDNogroupRejection:
             result = _run(HHD(_config()).get_additional_checks(self._meta(tag="-nogroup")))
         assert result is False
 
+    def test_unknown_tag_is_rejected(self):
+        """'-unknown' placeholder → rejected."""
+        with patch("src.trackers.COMMON.languages_manager") as mock_lm:
+            mock_lm.process_desc_language = AsyncMock()
+            result = _run(HHD(_config()).get_additional_checks(self._meta(tag="-unknown")))
+        assert result is False
+
+    def test_unk_tag_is_rejected(self):
+        """'-unk' placeholder → rejected."""
+        with patch("src.trackers.COMMON.languages_manager") as mock_lm:
+            mock_lm.process_desc_language = AsyncMock()
+            result = _run(HHD(_config()).get_additional_checks(self._meta(tag="-unk")))
+        assert result is False
+
     def test_valid_tag_passes(self):
         """A real English-audio release with a group tag must not be rejected."""
         with patch("src.trackers.COMMON.languages_manager") as mock_lm:

--- a/tests/test_hhd.py
+++ b/tests/test_hhd.py
@@ -47,6 +47,7 @@ class TestHHDEnglishLanguageCheck:
             "type": "WEBDL",
             "debug": False,
             "unattended": True,
+            "tag": "-FRiENDS",
         }
         with patch("src.trackers.COMMON.languages_manager") as mock_lm:
             mock_lm.process_desc_language = AsyncMock()
@@ -60,6 +61,7 @@ class TestHHDEnglishLanguageCheck:
             "type": "WEBDL",
             "debug": False,
             "unattended": True,
+            "tag": "-FRiENDS",
         }
         with patch("src.trackers.COMMON.languages_manager") as mock_lm:
             mock_lm.process_desc_language = AsyncMock()
@@ -73,6 +75,7 @@ class TestHHDEnglishLanguageCheck:
             "type": "WEBDL",
             "debug": False,
             "unattended": True,
+            "tag": "-FRiENDS",
         }
         with patch("src.trackers.COMMON.languages_manager") as mock_lm:
             mock_lm.process_desc_language = AsyncMock()
@@ -87,6 +90,7 @@ class TestHHDEnglishLanguageCheck:
             "type": "DISC",
             "debug": False,
             "unattended": True,
+            "tag": "-FRiENDS",
         }
         assert _run(hhd.get_additional_checks(meta)) is True
 
@@ -98,6 +102,7 @@ class TestHHDEnglishLanguageCheck:
             "type": "DISC",
             "debug": False,
             "unattended": True,
+            "tag": "-FRiENDS",
         }
         assert _run(hhd.get_additional_checks(meta)) is True
 
@@ -121,6 +126,7 @@ class TestHHDEnglishLanguageCheck:
             "type": "WEBDL",
             "debug": False,
             "unattended": True,
+            "tag": "-FRiENDS",
         }
         with patch("src.trackers.COMMON.languages_manager") as mock_lm:
             mock_lm.process_desc_language = AsyncMock()
@@ -152,3 +158,57 @@ class TestHHDSearchExistingLanguageGate:
             dupes = _run(hhd.search_existing(meta, ""))
         assert dupes == []
         assert meta["skipping"] == "HHD"
+
+
+# ═══════════════════════════════════════════════════════════════
+#  Nogroup rejection — get_additional_checks()
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestHHDNogroupRejection:
+    """HHD has no stated policy for untagged releases — they must be rejected.
+
+    Regression: before the get_tag fix the false tag '-DL.AAC.2.0.H.264' was
+    accepted as a valid group. After the fix tag='' and HHD must refuse the upload.
+    """
+
+    def _meta(self, **overrides: Any) -> dict[str, Any]:
+        m: dict[str, Any] = {
+            "tag": "-FRiENDS",
+            "type": "WEBDL",
+            "is_disc": None,
+            "audio_languages": ["English"],
+            "subtitle_languages": [],
+            "debug": False,
+            "unattended": True,
+        }
+        m.update(overrides)
+        return m
+
+    def test_empty_tag_is_rejected(self):
+        """tag='' → get_additional_checks returns False."""
+        with patch("src.trackers.COMMON.languages_manager") as mock_lm:
+            mock_lm.process_desc_language = AsyncMock()
+            result = _run(HHD(_config()).get_additional_checks(self._meta(tag="")))
+        assert result is False, "HHD must reject releases with no group tag"
+
+    def test_nogrp_tag_is_rejected(self):
+        """'-nogrp' placeholder → rejected."""
+        with patch("src.trackers.COMMON.languages_manager") as mock_lm:
+            mock_lm.process_desc_language = AsyncMock()
+            result = _run(HHD(_config()).get_additional_checks(self._meta(tag="-nogrp")))
+        assert result is False
+
+    def test_nogroup_tag_is_rejected(self):
+        """'-nogroup' placeholder → rejected."""
+        with patch("src.trackers.COMMON.languages_manager") as mock_lm:
+            mock_lm.process_desc_language = AsyncMock()
+            result = _run(HHD(_config()).get_additional_checks(self._meta(tag="-nogroup")))
+        assert result is False
+
+    def test_valid_tag_passes(self):
+        """A real English-audio release with a group tag must not be rejected."""
+        with patch("src.trackers.COMMON.languages_manager") as mock_lm:
+            mock_lm.process_desc_language = AsyncMock()
+            result = _run(HHD(_config()).get_additional_checks(self._meta(tag="-FRiENDS")))
+        assert result is True

--- a/tests/test_lst.py
+++ b/tests/test_lst.py
@@ -375,3 +375,55 @@ class TestAdditionalChecksMicroEncode:
         meta = _bitrate_meta(video_bitrate=100_000, codec="x265", resolution="1080p", type="DISC")
         meta["is_disc"] = "BDMV"
         assert _run(_lst().get_additional_checks(meta)) is True
+
+
+# ═══════════════════════════════════════════════════════════════
+#  Nogroup WEB-DL naming — passthrough regression
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestNogroupWebDL:
+    """LST accepts releases without a group tag — name is passed through as-is.
+
+    Regression: before the get_tag fix, Cyclo.1995.1080p.WEB-DL.AAC.2.0.H.264.mkv
+    had '-DL.AAC.2.0.H.264' extracted as the group and appended to LST's name.
+    After the fix tag='' so meta['name'] is already clean; LST must not alter it.
+    """
+
+    def test_empty_tag_name_unchanged(self):
+        """Nogroup movie name passed through without modification."""
+        meta = {
+            "name": "Cyclo.1995.1080p.WEB.AAC.2.0.H264",
+            "tag": "",
+            "category": "MOVIE",
+            "type": "WEBDL",
+            "source": "WEB",
+            "resolution": "1080p",
+            "audio": "AAC 2.0",
+            "video_encode": "H.264",
+            "video_codec": "H.264",
+            "trump_reason": None,
+            "tvdb_series_name": None,
+        }
+        result = _run(_lst().get_name(meta))["name"]
+        assert result == "Cyclo.1995.1080p.WEB.AAC.2.0.H264", (
+            f"LST must not alter nogroup movie name, got: {result!r}"
+        )
+
+    def test_no_audio_duplication(self):
+        """Audio token must appear exactly once — no duplication from a false tag."""
+        meta = {
+            "name": "Cyclo.1995.1080p.WEB.AAC.2.0.H264",
+            "tag": "",
+            "category": "MOVIE",
+            "type": "WEBDL",
+            "source": "WEB",
+            "resolution": "1080p",
+            "audio": "AAC 2.0",
+            "video_encode": "H.264",
+            "video_codec": "H.264",
+            "trump_reason": None,
+            "tvdb_series_name": None,
+        }
+        result = _run(_lst().get_name(meta))["name"]
+        assert result.count("AAC") == 1, f"Audio token duplicated: {result!r}"

--- a/tests/test_lume.py
+++ b/tests/test_lume.py
@@ -1,0 +1,85 @@
+# Tests for LUME tracker — luminarr.me
+"""
+Test suite for LUME release naming.
+Covers: nogroup WEB-DL → '-NOGROUP' suffix.
+  - LUME requires a '-NOGROUP' suffix for releases without a group tag.
+  - Invalid/placeholder tags are stripped and replaced with '-NOGROUP'.
+  - Real group tags are preserved unchanged.
+"""
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from src.trackers.LUME import LUME
+
+
+# ─── Helpers ──────────────────────────────────────────────────
+
+
+def _config() -> dict[str, Any]:
+    return {
+        "TRACKERS": {
+            "LUME": {
+                "api_key": "fake-key",
+                "announce_url": "https://luminarr.me/announce/FAKE",
+            }
+        },
+        "DEFAULT": {"tmdb_api": "fake-tmdb-key"},
+    }
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _lume() -> LUME:
+    return LUME(config=_config())
+
+
+# ═══════════════════════════════════════════════════════════════
+#  Nogroup WEB-DL naming — regression for Cyclo-style filenames
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestNogroupWebDL:
+    """LUME requires '-NOGROUP' suffix for releases without a group tag.
+
+    Regression: before the get_tag fix, Cyclo.1995.1080p.WEB-DL.AAC.2.0.H.264.mkv
+    had '-DL.AAC.2.0.H.264' extracted as the group and it was appended verbatim.
+    After the fix, tag='' and LUME must substitute '-NOGROUP'.
+    """
+
+    def test_empty_tag_adds_nogroup_suffix(self):
+        """tag='' → '-NOGROUP' appended."""
+        meta = {"name": "Cyclo.1995.1080p.WEB.AAC.2.0.H264", "tag": ""}
+        result = _run(_lume().get_name(meta))["name"]
+        assert result.endswith("-NOGROUP"), (
+            f"Expected -NOGROUP suffix, got: {result!r}"
+        )
+
+    def test_nogrp_replaced_with_nogroup(self):
+        """'-nogrp' placeholder stripped and replaced with '-NOGROUP'."""
+        meta = {"name": "Cyclo.1995.1080p.WEB.AAC.2.0.H264-nogrp", "tag": "-nogrp"}
+        result = _run(_lume().get_name(meta))["name"]
+        assert result.endswith("-NOGROUP"), f"Expected -NOGROUP suffix, got: {result!r}"
+        assert "nogrp" not in result.lower().replace("nogroup", ""), (
+            f"Invalid token should have been stripped: {result!r}"
+        )
+
+    def test_no_audio_duplication(self):
+        """Audio token must appear exactly once — no duplication from a false tag."""
+        meta = {"name": "Cyclo.1995.1080p.WEB.AAC.2.0.H264", "tag": ""}
+        result = _run(_lume().get_name(meta))["name"]
+        assert result.count("AAC") == 1, f"Audio token duplicated: {result!r}"
+        assert result.count("H264") == 1, f"Codec token duplicated: {result!r}"
+
+    def test_real_group_tag_unchanged(self):
+        """A real release group tag must be preserved; '-NOGROUP' must NOT be added."""
+        meta = {"name": "Movie.2024.1080p.WEB.H264-FRiENDS", "tag": "-FRiENDS"}
+        result = _run(_lume().get_name(meta))["name"]
+        assert result == "Movie.2024.1080p.WEB.H264-FRiENDS", (
+            f"Real group tag must not be modified, got: {result!r}"
+        )
+        assert "NOGROUP" not in result, f"NOGROUP must not appear when tag is valid: {result!r}"

--- a/tests/test_nst.py
+++ b/tests/test_nst.py
@@ -450,3 +450,64 @@ class TestSanitizeBBCode:
             "[center][url=https://imgbox.com/a][img]https://thumbs2.imgbox.com/a/b/abc_t.png[/img][/url][/center]"
         )
         assert result == expected
+
+
+# ═══════════════════════════════════════════════════════════════
+#  Nogroup WEB-DL naming — regression for Cyclo-style filenames
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestNogroupWebDL:
+    """WEB-DL releases without a group tag must use NST's notag_label.
+
+    NST uses WEB_LABEL='WEB' and notag_label='NoTag'.
+    Regression: Cyclo.1995.1080p.WEB-DL.AAC.2.0.H.264.mkv had a false
+    group '-DL.AAC.2.0.H.264' extracted, producing duplicated tokens.
+    """
+
+    def _get_name(self, meta: dict) -> str:
+        return asyncio.run(NST(_config()).get_name(meta))['name']
+
+    def test_empty_tag_uses_notag_label(self):
+        """tag='' (nogroup) must produce a name ending with '-NoTag'."""
+        meta = _meta_base(
+            title='Cyclo',
+            year='1995',
+            audio='AAC 2.0',
+            video_encode='H.264',
+            video_codec='H.264',
+            service='',
+            tag='',
+        )
+        name = self._get_name(meta)
+        assert name.endswith('-NoTag'), f"Expected -NoTag suffix, got: {name!r}"
+
+    def test_no_audio_duplication(self):
+        """Audio token must appear exactly once — no duplication from a false tag."""
+        meta = _meta_base(
+            title='Cyclo',
+            year='1995',
+            audio='AAC 2.0',
+            video_encode='H.264',
+            video_codec='H.264',
+            service='',
+            tag='',
+        )
+        name = self._get_name(meta)
+        assert name.count('AAC') == 1, (
+            f"Audio token 'AAC' duplicated in name: {name!r}."
+        )
+
+    def test_real_group_preserved(self):
+        """A real group tag must not be replaced by the notag label."""
+        meta = _meta_base(
+            title='Cyclo',
+            year='1995',
+            audio='AAC 2.0',
+            video_encode='H.264',
+            video_codec='H.264',
+            service='',
+            tag='-FRiENDS',
+        )
+        name = self._get_name(meta)
+        assert name.endswith('-FRiENDS'), f"Expected -FRiENDS suffix, got: {name!r}"

--- a/tests/test_nxm.py
+++ b/tests/test_nxm.py
@@ -149,3 +149,64 @@ class TestTrackerIdentity:
 
     def test_include_service_in_name(self):
         assert NXM.INCLUDE_SERVICE_IN_NAME is True
+
+
+# ═══════════════════════════════════════════════════════════════
+#  Nogroup WEB-DL naming — regression for Cyclo-style filenames
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestNogroupWebDL:
+    """WEB-DL releases without a group tag must use NXM's notag_label.
+
+    NXM uses WEB_LABEL='WEB' and notag_label='NoGrp'.
+    Regression: Cyclo.1995.1080p.WEB-DL.AAC.2.0.H.264.mkv had a false
+    group '-DL.AAC.2.0.H.264' extracted, producing duplicated tokens.
+    """
+
+    def _get_name(self, meta: dict) -> str:
+        return asyncio.run(NXM(_config()).get_name(meta))['name']
+
+    def test_empty_tag_uses_notag_label(self):
+        """tag='' (nogroup) must produce a name ending with '-NoGrp'."""
+        meta = _meta_base(
+            title='Cyclo',
+            year='1995',
+            audio='AAC 2.0',
+            video_encode='H.264',
+            video_codec='H.264',
+            service='',
+            tag='',
+        )
+        name = self._get_name(meta)
+        assert name.endswith('-NoGrp'), f"Expected -NoGrp suffix, got: {name!r}"
+
+    def test_no_audio_duplication(self):
+        """Audio token must appear exactly once — no duplication from a false tag."""
+        meta = _meta_base(
+            title='Cyclo',
+            year='1995',
+            audio='AAC 2.0',
+            video_encode='H.264',
+            video_codec='H.264',
+            service='',
+            tag='',
+        )
+        name = self._get_name(meta)
+        assert name.count('AAC') == 1, (
+            f"Audio token 'AAC' duplicated in name: {name!r}."
+        )
+
+    def test_real_group_preserved(self):
+        """A real group tag must not be replaced by the notag label."""
+        meta = _meta_base(
+            title='Cyclo',
+            year='1995',
+            audio='AAC 2.0',
+            video_encode='H.264',
+            video_codec='H.264',
+            service='',
+            tag='-FRiENDS',
+        )
+        name = self._get_name(meta)
+        assert name.endswith('-FRiENDS'), f"Expected -FRiENDS suffix, got: {name!r}"

--- a/tests/test_rf.py
+++ b/tests/test_rf.py
@@ -1,0 +1,88 @@
+# Tests for RF tracker — reelflix.cc
+"""
+Test suite for RF release naming.
+Covers: nogroup WEB-DL passthrough (no suffix appended).
+  - RF accepts releases without a group tag and does NOT append any suffix.
+  - Invalid/placeholder tags are stripped from the name.
+  - Real group tags are preserved unchanged.
+"""
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from src.trackers.RF import RF
+
+
+# ─── Helpers ──────────────────────────────────────────────────
+
+
+def _config() -> dict[str, Any]:
+    return {
+        "TRACKERS": {
+            "RF": {
+                "api_key": "fake-key",
+                "announce_url": "https://reelflix.cc/announce/FAKE",
+            }
+        },
+        "DEFAULT": {"tmdb_api": "fake-tmdb-key"},
+    }
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _rf() -> RF:
+    return RF(config=_config())
+
+
+# ═══════════════════════════════════════════════════════════════
+#  Nogroup WEB-DL naming — regression for Cyclo-style filenames
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestNogroupWebDL:
+    """RF accepts releases without a group tag — no suffix should be appended.
+
+    Regression: before the get_tag fix, Cyclo.1995.1080p.WEB-DL.AAC.2.0.H.264.mkv
+    had '-DL.AAC.2.0.H.264' extracted as the group and RF appended '-NoGroup' on
+    top of the already-broken name. After the fix:
+      - tag='' → RF must NOT append '-NoGroup' (just pass the clean name through)
+      - invalid placeholder tags are stripped without adding a new suffix
+      - real group tags are left unchanged
+    """
+
+    def test_empty_tag_no_suffix_added(self):
+        """tag='' → name passed through as-is, no '-NoGroup' appended."""
+        meta = {"name": "Cyclo.1995.1080p.WEB.AAC.2.0.H264", "tag": ""}
+        result = _run(_rf().get_name(meta))["name"]
+        assert not result.endswith("-NoGroup"), (
+            f"RF must NOT append -NoGroup for empty tag, got: {result!r}"
+        )
+        assert result == "Cyclo.1995.1080p.WEB.AAC.2.0.H264", (
+            f"Name should be unchanged, got: {result!r}"
+        )
+
+    def test_nogrp_tag_stripped_no_suffix(self):
+        """'-nogrp' placeholder tag is stripped; no '-NoGroup' appended."""
+        meta = {"name": "Cyclo.1995.1080p.WEB.AAC.2.0.H264-nogrp", "tag": "-nogrp"}
+        result = _run(_rf().get_name(meta))["name"]
+        assert "nogrp" not in result.lower(), f"Invalid token not stripped: {result!r}"
+        assert not result.endswith("-NoGroup"), f"Unexpected -NoGroup suffix: {result!r}"
+
+    def test_nogroup_tag_stripped_no_suffix(self):
+        """'-NOGROUP' placeholder tag is stripped; no '-NoGroup' appended."""
+        meta = {"name": "Movie.2024.1080p.WEB.H264-NOGROUP", "tag": "-NOGROUP"}
+        result = _run(_rf().get_name(meta))["name"]
+        assert "nogroup" not in result.lower(), f"Invalid token not stripped: {result!r}"
+        assert not result.endswith("-NoGroup"), f"Unexpected -NoGroup suffix: {result!r}"
+
+    def test_real_group_tag_unchanged(self):
+        """A real release group tag must be preserved exactly."""
+        meta = {"name": "Movie.2024.1080p.WEB.H264-FRiENDS", "tag": "-FRiENDS"}
+        result = _run(_rf().get_name(meta))["name"]
+        assert result == "Movie.2024.1080p.WEB.H264-FRiENDS", (
+            f"Real group tag must not be modified, got: {result!r}"
+        )

--- a/tests/test_rf.py
+++ b/tests/test_rf.py
@@ -79,6 +79,20 @@ class TestNogroupWebDL:
         assert "nogroup" not in result.lower(), f"Invalid token not stripped: {result!r}"
         assert not result.endswith("-NoGroup"), f"Unexpected -NoGroup suffix: {result!r}"
 
+    def test_unknown_tag_stripped_no_suffix(self):
+        """'-unknown' placeholder tag is stripped; no '-NoGroup' appended."""
+        meta = {"name": "Title.2024.1080p.H264-unknown", "tag": "-unknown"}
+        result = _run(_rf().get_name(meta))["name"]
+        assert "unknown" not in result.lower(), f"Invalid token not stripped: {result!r}"
+        assert not result.endswith("-NoGroup"), f"Unexpected -NoGroup suffix: {result!r}"
+
+    def test_unk_tag_stripped_no_suffix(self):
+        """'-unk' placeholder tag is stripped; no '-NoGroup' appended."""
+        meta = {"name": "Title.2024.1080p.H264-unk", "tag": "-unk"}
+        result = _run(_rf().get_name(meta))["name"]
+        assert "unk" not in result.lower(), f"Invalid token not stripped: {result!r}"
+        assert not result.endswith("-NoGroup"), f"Unexpected -NoGroup suffix: {result!r}"
+
     def test_real_group_tag_unchanged(self):
         """A real release group tag must be preserved exactly."""
         meta = {"name": "Movie.2024.1080p.WEB.H264-FRiENDS", "tag": "-FRiENDS"}

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1,0 +1,145 @@
+# Tests for src/tags.py — release-group extraction
+"""
+Regression tests for get_tag().
+
+Key regression: filenames whose only hyphen is part of a source token
+(WEB-DL, Blu-ray) must NOT produce a false group tag.
+
+Before the fix the regex `(?<=-)` would match right after the hyphen in
+"WEB-DL" and capture "DL.AAC.2.0.H.264" as the release group, causing
+tracker naming to produce duplicated audio/codec tokens, e.g.:
+    Cyclo.1995.1080p.WEB-DL.AAC.2.0.H.264.mkv
+    → meta["tag"] = "-DL.AAC.2.0.H.264"      (wrong)
+    → TORR9 name: …H264-DL.AAC.2.0.H.264     (malformed)
+
+After the fix, both `(?<!WEB-)` and `(?<!Blu-)` lookbehinds prevent the
+regex from firing right after the hyphens in those source tokens.
+"""
+
+import asyncio
+from typing import Any
+
+from src.tags import get_tag
+
+
+# ─── Helpers ──────────────────────────────────────────────────
+
+
+def _meta(**overrides: Any) -> dict[str, Any]:
+    """Minimal meta dict required by get_tag."""
+    m: dict[str, Any] = {
+        "debug": False,
+        "is_disc": None,
+        "anime": False,
+        "tv_pack": False,
+        "keep_folder": False,
+        "scene": False,
+        "uuid": "test-uuid",
+    }
+    m.update(overrides)
+    return m
+
+
+def _run(coro: Any) -> Any:
+    return asyncio.run(coro)
+
+
+# ═══════════════════════════════════════════════════════════════
+#  WEB-DL — hyphen must not be treated as group separator
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestGetTagWebDL:
+    """The hyphen in WEB-DL is a source token, not a group separator."""
+
+    def test_webdl_h264_no_group_returns_empty(self):
+        """Regression: Cyclo.1995.1080p.WEB-DL.AAC.2.0.H.264.mkv — no group."""
+        tag = _run(get_tag("Cyclo.1995.1080p.WEB-DL.AAC.2.0.H.264.mkv", _meta()))
+        assert tag == "", f"Expected empty tag, got {tag!r}"
+
+    def test_webdl_h265_no_group_returns_empty(self):
+        tag = _run(get_tag("Movie.2023.1080p.WEB-DL.DDP5.1.H.265.mkv", _meta()))
+        assert tag == "", f"Expected empty tag, got {tag!r}"
+
+    def test_webdl_4k_hdr_no_group_returns_empty(self):
+        tag = _run(get_tag("Film.2022.2160p.WEB-DL.DV.HDR.DDP.5.1.H.265.mkv", _meta()))
+        assert tag == "", f"Expected empty tag, got {tag!r}"
+
+    def test_webdl_avc_no_group_returns_empty(self):
+        tag = _run(get_tag("Series.S01E01.1080p.WEB-DL.AAC.2.0.AVC.mkv", _meta()))
+        assert tag == "", f"Expected empty tag, got {tag!r}"
+
+    def test_webdl_with_real_group_extracted(self):
+        """Group after the codec, following a second hyphen, must be captured."""
+        tag = _run(get_tag("Cyclo.1995.1080p.WEB-DL.AAC.2.0.H.264-GroupName.mkv", _meta()))
+        assert tag == "-GroupName", f"Expected -GroupName, got {tag!r}"
+
+    def test_webdl_h265_with_real_group_extracted(self):
+        tag = _run(get_tag("Movie.2023.1080p.WEB-DL.DDP5.1.H.265-GROUPX.mkv", _meta()))
+        assert tag == "-GROUPX", f"Expected -GROUPX, got {tag!r}"
+
+    def test_webdl_false_tag_before_fix(self):
+        """Document what the old regex would have matched (the DL.AAC… false tag).
+
+        The key invariant after the fix: any tag extracted from a WEB-DL
+        filename must NOT contain "DL" as a prefix.
+        """
+        tag = _run(get_tag("Cyclo.1995.1080p.WEB-DL.AAC.2.0.H.264.mkv", _meta()))
+        assert not tag.startswith("-DL"), (
+            f"False WEB-DL tag detected: {tag!r}. "
+            "The hyphen in WEB-DL must not be used as a group separator."
+        )
+
+
+# ═══════════════════════════════════════════════════════════════
+#  Blu-ray — same family of bug
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestGetTagBluray:
+    """The hyphen in Blu-ray is a source token, not a group separator."""
+
+    def test_bluray_no_group_returns_empty(self):
+        tag = _run(get_tag("Film.2020.1080p.Blu-ray.DTS.x264.mkv", _meta()))
+        assert tag == "", f"Expected empty tag, got {tag!r}"
+
+    def test_bluray_with_real_group_extracted(self):
+        tag = _run(get_tag("Film.2020.1080p.Blu-ray.DTS.x264-CREW.mkv", _meta()))
+        assert tag == "-CREW", f"Expected -CREW, got {tag!r}"
+
+    def test_bluray_false_tag_before_fix(self):
+        """After the fix, 'ray' must not be extracted as the group from Blu-ray."""
+        tag = _run(get_tag("Film.2020.1080p.Blu-ray.DTS.x264.mkv", _meta()))
+        assert not tag.startswith("-ray"), (
+            f"False Blu-ray tag detected: {tag!r}. "
+            "The hyphen in Blu-ray must not be used as a group separator."
+        )
+
+
+# ═══════════════════════════════════════════════════════════════
+#  Standard releases — real group tags must still be extracted
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestGetTagRealGroups:
+    """Releases with genuine group tags must still work correctly."""
+
+    def test_bluray_encode_group(self):
+        tag = _run(get_tag("Show.S01E01.1080p.BluRay.x264-GRP.mkv", _meta()))
+        assert tag == "-GRP", f"Expected -GRP, got {tag!r}"
+
+    def test_webrip_group(self):
+        tag = _run(get_tag("Movie.2024.720p.WEBRip.AAC.x264-NTG.mkv", _meta()))
+        assert tag == "-NTG", f"Expected -NTG, got {tag!r}"
+
+    def test_remux_group(self):
+        tag = _run(get_tag("Movie.2020.1080p.BluRay.REMUX.DTS-HD.MA.5.1.H264-TEAM.mkv", _meta()))
+        assert tag == "-TEAM", f"Expected -TEAM, got {tag!r}"
+
+    def test_no_hyphen_no_group(self):
+        tag = _run(get_tag("Standalone.2023.1080p.BluRay.x264.mkv", _meta()))
+        assert tag == "", f"Expected empty tag, got {tag!r}"
+
+    def test_web_no_hyphen_group(self):
+        tag = _run(get_tag("Movie.2023.1080p.WEB.AAC.x264-FRGRP.mkv", _meta()))
+        assert tag == "-FRGRP", f"Expected -FRGRP, got {tag!r}"

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -117,6 +117,46 @@ class TestGetTagBluray:
 
 
 # ═══════════════════════════════════════════════════════════════
+#  Mixed-case WEB-DL — lookbehinds must be case-insensitive
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestGetTagWebDLMixedCase:
+    """Case variants of WEB-DL must be guarded the same way as the canonical form."""
+
+    def test_web_dl_mixed_case_no_group_returns_empty(self):
+        """Web-DL (mixed case) must not produce a false group tag."""
+        tag = _run(get_tag("Cyclo.1995.1080p.Web-DL.AAC.2.0.H.264.mkv", _meta()))
+        assert tag == "", f"Expected empty tag, got {tag!r}"
+        assert not tag.startswith("-DL"), f"False Web-DL tag detected: {tag!r}"
+
+    def test_web_dl_mixed_case_with_real_group(self):
+        """Web-DL with a real group must still extract the group."""
+        tag = _run(get_tag("Cyclo.1995.1080p.Web-DL.AAC.2.0.H.264-GroupName.mkv", _meta()))
+        assert tag == "-GroupName", f"Expected -GroupName, got {tag!r}"
+
+
+# ═══════════════════════════════════════════════════════════════
+#  Mixed-case Blu-ray — lookbehinds must be case-insensitive
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestGetTagBlurayMixedCase:
+    """Case variants of Blu-ray must be guarded the same way as canonical."""
+
+    def test_blu_ray_uppercase_no_group_returns_empty(self):
+        """BLU-ray (uppercase BLU) must not produce a false group tag."""
+        tag = _run(get_tag("Film.2020.1080p.BLU-ray.DTS.x264.mkv", _meta()))
+        assert tag == "", f"Expected empty tag, got {tag!r}"
+        assert not tag.startswith("-ray"), f"False BLU-ray tag detected: {tag!r}"
+
+    def test_blu_ray_mixed_case_with_real_group(self):
+        """Blu-Ray (capital R) with a real group must still extract the group."""
+        tag = _run(get_tag("Film.2020.1080p.Blu-Ray.DTS.x264-CREW.mkv", _meta()))
+        assert tag == "-CREW", f"Expected -CREW, got {tag!r}"
+
+
+# ═══════════════════════════════════════════════════════════════
 #  Standard releases — real group tags must still be extracted
 # ═══════════════════════════════════════════════════════════════
 

--- a/tests/test_torr9.py
+++ b/tests/test_torr9.py
@@ -1609,3 +1609,77 @@ class TestNfoUploadFlow:
 
         import shutil
         shutil.rmtree(tmpd)
+
+
+# ═══════════════════════════════════════════════════════════════
+#  Nogroup WEB-DL naming — regression for Cyclo-style filenames
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestNogroupWebDL:
+    """WEB-DL releases without a group tag must use TORR9's notag_label.
+
+    Regression: Cyclo.1995.1080p.WEB-DL.AAC.2.0.H.264.mkv triggered a false
+    group extraction ('-DL.AAC.2.0.H.264') which was then appended to the
+    TORR9-built name, producing duplicated audio/codec tokens.
+    """
+
+    def _get_name(self, meta: dict) -> str:
+        return _run(TORR9(_config()).get_name(meta))['name']
+
+    def test_empty_tag_uses_notag_label(self):
+        """tag='' (nogroup) must produce a name ending with '-NoTag'."""
+        meta = _meta_base(
+            title='Cyclo',
+            year='1995',
+            audio='AAC 2.0',
+            video_encode='H.264',
+            video_codec='H.264',
+            tag='',
+        )
+        name = self._get_name(meta)
+        assert name.endswith('-NoTag'), f"Expected -NoTag suffix, got: {name!r}"
+
+    def test_no_audio_duplication(self):
+        """Audio token must appear exactly once — no duplication from a false tag."""
+        meta = _meta_base(
+            title='Cyclo',
+            year='1995',
+            audio='AAC 2.0',
+            video_encode='H.264',
+            video_codec='H.264',
+            tag='',
+        )
+        name = self._get_name(meta)
+        assert name.count('AAC') == 1, (
+            f"Audio token 'AAC' duplicated in name: {name!r}. "
+            "Possible false group tag extracted from WEB-DL source."
+        )
+
+    def test_codec_not_duplicated(self):
+        """Codec token must appear exactly once."""
+        meta = _meta_base(
+            title='Cyclo',
+            year='1995',
+            audio='AAC 2.0',
+            video_encode='H.264',
+            video_codec='H.264',
+            tag='',
+        )
+        name = self._get_name(meta)
+        assert name.count('H264') == 1, (
+            f"Codec token 'H264' duplicated in name: {name!r}."
+        )
+
+    def test_real_group_preserved(self):
+        """A real group tag from a WEB-DL release must be kept as-is."""
+        meta = _meta_base(
+            title='Cyclo',
+            year='1995',
+            audio='AAC 2.0',
+            video_encode='H.264',
+            video_codec='H.264',
+            tag='-FRiENDS',
+        )
+        name = self._get_name(meta)
+        assert name.endswith('-FRiENDS'), f"Expected -FRiENDS suffix, got: {name!r}"

--- a/tests/test_tos.py
+++ b/tests/test_tos.py
@@ -224,3 +224,81 @@ class TestTosSpecificDupes:
             # Internal groups must NOT be in banned_groups (which blocks uploading *from* those
             # groups). They only block dupes via _check_tos_specific_dupes.
             assert grp not in t.banned_groups, f"{grp} should not be in banned_groups"
+
+
+# ═══════════════════════════════════════════════════════════════
+#  Nogroup WEB-DL naming — regression for Cyclo-style filenames
+# ═══════════════════════════════════════════════════════════════
+
+
+def _meta_nogroup(**overrides: Any) -> dict[str, Any]:
+    """Full meta for TOS get_name tests."""
+    m: dict[str, Any] = {
+        'category': 'MOVIE',
+        'type': 'WEBDL',
+        'title': 'Cyclo',
+        'year': '1995',
+        'resolution': '1080p',
+        'source': 'WEB',
+        'audio': 'AAC 2.0',
+        'video_encode': 'H.264',
+        'video_codec': 'H.264',
+        'service': '',
+        'tag': '',
+        'edition': '',
+        'repack': '',
+        '3D': '',
+        'uhd': '',
+        'hdr': '',
+        'webdv': '',
+        'part': '',
+        'season': '',
+        'episode': '',
+        'is_disc': None,
+        'search_year': '',
+        'manual_year': None,
+        'manual_date': None,
+        'no_season': False,
+        'no_year': False,
+        'no_aka': False,
+        'debug': False,
+        'tv_pack': False,
+        'scene': False,
+        'scene_name': '',
+        'path': '',
+        'original_language': 'vi',
+        'audio_languages': [],
+        'subtitle_languages': [],
+        'mediainfo': {'media': {'track': []}},
+    }
+    m.update(overrides)
+    return m
+
+
+class TestNogroupWebDL:
+    """WEB-DL releases without a group tag must use TOS's notag_label.
+
+    TOS uses notag_label='NOTAG'.
+    Regression: Cyclo.1995.1080p.WEB-DL.AAC.2.0.H.264.mkv had a false
+    group '-DL.AAC.2.0.H.264' extracted, producing duplicated tokens.
+    """
+
+    def _get_name(self, meta: dict) -> str:
+        return _run(TOS(_config()).get_name(meta))['name']
+
+    def test_empty_tag_uses_notag_label(self):
+        """tag='' (nogroup) must produce a name ending with '-NOTAG'."""
+        name = self._get_name(_meta_nogroup())
+        assert name.endswith('-NOTAG'), f"Expected -NOTAG suffix, got: {name!r}"
+
+    def test_no_audio_duplication(self):
+        """Audio token must appear exactly once — no duplication from a false tag."""
+        name = self._get_name(_meta_nogroup())
+        assert name.count('AAC') == 1, (
+            f"Audio token 'AAC' duplicated in name: {name!r}."
+        )
+
+    def test_real_group_preserved(self):
+        """A real group tag must not be replaced by the notag label."""
+        name = self._get_name(_meta_nogroup(tag='-FRiENDS'))
+        assert name.endswith('-FRiENDS'), f"Expected -FRiENDS suffix, got: {name!r}"

--- a/tests/test_yus.py
+++ b/tests/test_yus.py
@@ -1,0 +1,79 @@
+# Tests for YUS tracker — yu-scene.net
+"""
+Test suite for YUS tracker pre-upload validation.
+Covers: nogroup rejection in get_additional_checks().
+  - YUS has no stated policy for untagged releases → reject them.
+  - Known invalid placeholder tags (nogrp, nogroup, …) are also rejected.
+  - Valid group tags pass through.
+"""
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from src.trackers.YUS import YUS
+
+
+# ─── Helpers ──────────────────────────────────────────────────
+
+
+def _config() -> dict[str, Any]:
+    return {
+        "TRACKERS": {
+            "YUS": {
+                "api_key": "fake-key",
+                "announce_url": "https://yu-scene.net/announce/FAKE",
+            }
+        },
+        "DEFAULT": {"tmdb_api": "fake-tmdb-key"},
+    }
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _meta(**overrides: Any) -> dict[str, Any]:
+    m: dict[str, Any] = {
+        "tag": "-FRiENDS",
+        "keywords": "",
+        "combined_genres": "",
+        "unattended": True,
+        "debug": False,
+    }
+    m.update(overrides)
+    return m
+
+
+# ═══════════════════════════════════════════════════════════════
+#  Nogroup rejection — get_additional_checks()
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestYUSNogroupRejection:
+    """YUS has no policy for untagged releases — they must be rejected.
+
+    Regression: before the get_tag fix the false tag '-DL.AAC.2.0.H.264' was
+    accepted as a valid group. After the fix tag='' and YUS must refuse the upload.
+    """
+
+    def test_empty_tag_is_rejected(self):
+        """tag='' → get_additional_checks returns False."""
+        result = _run(YUS(_config()).get_additional_checks(_meta(tag="")))
+        assert result is False, "YUS must reject releases with no group tag"
+
+    def test_nogrp_tag_is_rejected(self):
+        """'-nogrp' placeholder → rejected."""
+        result = _run(YUS(_config()).get_additional_checks(_meta(tag="-nogrp")))
+        assert result is False
+
+    def test_nogroup_tag_is_rejected(self):
+        """'-nogroup' placeholder → rejected."""
+        result = _run(YUS(_config()).get_additional_checks(_meta(tag="-nogroup")))
+        assert result is False
+
+    def test_valid_tag_passes(self):
+        """A real group tag must not trigger rejection."""
+        result = _run(YUS(_config()).get_additional_checks(_meta(tag="-FRiENDS")))
+        assert result is True

--- a/tests/test_yus.py
+++ b/tests/test_yus.py
@@ -73,6 +73,16 @@ class TestYUSNogroupRejection:
         result = _run(YUS(_config()).get_additional_checks(_meta(tag="-nogroup")))
         assert result is False
 
+    def test_unknown_tag_is_rejected(self):
+        """'-unknown' placeholder → rejected."""
+        result = _run(YUS(_config()).get_additional_checks(_meta(tag="-unknown")))
+        assert result is False
+
+    def test_unk_tag_is_rejected(self):
+        """'-unk' placeholder → rejected."""
+        result = _run(YUS(_config()).get_additional_checks(_meta(tag="-unk")))
+        assert result is False
+
     def test_valid_tag_passes(self):
         """A real group tag must not trigger rejection."""
         result = _run(YUS(_config()).get_additional_checks(_meta(tag="-FRiENDS")))


### PR DESCRIPTION
## Problem

Filenames like `Cyclo.1995.1080p.WEB-DL.AAC.2.0.H.264.mkv` caused `get_tag()` to extract `-DL.AAC.2.0.H.264` as a false release group, which was then appended verbatim to every tracker's release name, producing duplicated audio/codec tokens (e.g. `…H264-DL.AAC.2.0.H.264`).


## Fix


## Per-tracker nogroup policy enforcement

| Tracker | Policy | Change |
|---------|--------|--------|
| RF | Accept without suffix | `get_name`: strip placeholder tokens, no suffix added |
| LUME | `-NOGROUP` suffix | New `get_name`: appends `-NOGROUP` when tag empty/invalid |
| YUS | Reject | `get_additional_checks`: returns `False` for empty/placeholder tag |
| HHD | Reject | `get_additional_checks`: same |
| HDS | Reject | `search_existing`: sets `meta["skipping"]` alongside resolution gate |

All rejections are hard (no user prompt) — fully compatible with `--unattended` mode.

## Tests

- `tests/test_tags.py` (new): 15 regression tests for `get_tag` (WEB-DL, Blu-ray, real groups)
- `TestNogroupWebDL` in `test_torr9`, `test_g3mini`, `test_c411`, `test_tos`, `test_nst`, `test_nxm` (French trackers)
- `tests/test_rf.py`, `tests/test_lume.py`, `tests/test_yus.py` (new files)
- `TestNogroupRejection` in `test_hhd.py`
- `TestNogroupWebDL` in `test_lst.py` (passthrough)

Full suite: **1228 passed, 1 skipped**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate group detection to avoid false matches from source tokens (e.g., WEB-DL, Blu-ray).
  * Stricter validation of release group tags: uploads with missing/placeholder tags are now rejected or normalized to explicit "no-group" labels as appropriate.
  * Prevented duplicate audio/codec tokens in generated release names.

* **Tests**
  * Broad regression suite added to verify naming, group-tag handling, and tracker-specific behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yippee0903/Upload-Assistant/pull/221?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->