### PR TITLE
fix(C411): strip Criterion Collection edition token from release name

### DIFF
--- a/src/trackers/C411.py
+++ b/src/trackers/C411.py
@@ -128,12 +128,16 @@ class C411(FrenchTrackerMixin):
         - WEB **without** Encoded_Library_Settings → H264 / H265 / AV1
         - WEB **with** Encoded_Library_Settings   → x264 / x265
         """
-        result = await super().get_name(meta)
-
         # C411's server rejects "CRITERION" as a banned streaming-platform token.
         # "Criterion" here is the Criterion Collection (a physical-media label),
-        # not a streaming service — strip it so the upload is accepted.
-        result["name"] = re.sub(r"\.Criterion(?:\.Collection)?", "", result["name"], flags=re.IGNORECASE)
+        # not a streaming service.  Strip it from the edition field *before*
+        # building the name so the regex cannot accidentally remove "Criterion"
+        # from a movie title (e.g. a film literally titled "Criterion ...").
+        meta = dict(meta)
+        edition = meta.get("edition", "") or ""
+        meta["edition"] = re.sub(r"\bCriterion(?:\s+Collection)?\b", "", edition, flags=re.IGNORECASE).strip()
+
+        result = await super().get_name(meta)
 
         release_type = str(meta.get("type", "")).upper()
         if release_type in ("WEBDL", "WEBRIP"):

--- a/src/trackers/C411.py
+++ b/src/trackers/C411.py
@@ -129,6 +129,12 @@ class C411(FrenchTrackerMixin):
         - WEB **with** Encoded_Library_Settings   → x264 / x265
         """
         result = await super().get_name(meta)
+
+        # C411's server rejects "CRITERION" as a banned streaming-platform token.
+        # "Criterion" here is the Criterion Collection (a physical-media label),
+        # not a streaming service — strip it so the upload is accepted.
+        result["name"] = re.sub(r"\.Criterion(?:\.Collection)?", "", result["name"], flags=re.IGNORECASE)
+
         release_type = str(meta.get("type", "")).upper()
         if release_type in ("WEBDL", "WEBRIP"):
             if meta.get("has_encode_settings", False):

--- a/tests/test_c411.py
+++ b/tests/test_c411.py
@@ -2660,3 +2660,77 @@ class TestNogroupWebDL:
         )
         name = self._get_name(meta)
         assert name.endswith('-FRiENDS'), f"Expected -FRiENDS suffix, got: {name!r}"
+
+
+# ═══════════════════════════════════════════════════════════════
+#  Criterion Collection edition stripping
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestC411CriterionStripping:
+    """C411's server rejects 'CRITERION' as a banned streaming-platform token.
+
+    Regression: L'argent.1983.Criterion.1080p.BluRay.FLAC.x264-BMF.mkv
+    had edition='Criterion' which landed in the release name and caused a
+    server-side upload rejection.  C411.get_name must strip it.
+    """
+
+    def _get_name(self, meta: dict) -> str:
+        return _run_async(C411(_config()).get_name(meta))['name']
+
+    def test_criterion_edition_stripped(self):
+        """edition='Criterion' must be removed from the C411 release name."""
+        meta = _meta_base(
+            title="L'Argent",
+            year='1983',
+            type='ENCODE',
+            source='BluRay',
+            resolution='1080p',
+            audio='FLAC',
+            video_encode='x264',
+            video_codec='H.264',
+            edition='Criterion',
+            tag='-BMF',
+            has_encode_settings=True,
+        )
+        name = self._get_name(meta)
+        assert 'Criterion' not in name, f"'Criterion' must be stripped, got: {name!r}"
+        assert 'criterion' not in name.lower(), f"'criterion' must be stripped (case-insensitive), got: {name!r}"
+
+    def test_criterion_collection_stripped(self):
+        """edition='Criterion Collection' must also be stripped."""
+        meta = _meta_base(
+            title="L'Argent",
+            year='1983',
+            type='ENCODE',
+            source='BluRay',
+            resolution='1080p',
+            audio='FLAC',
+            video_encode='x264',
+            video_codec='H.264',
+            edition='Criterion Collection',
+            tag='-BMF',
+            has_encode_settings=True,
+        )
+        name = self._get_name(meta)
+        assert 'criterion' not in name.lower(), f"'Criterion Collection' must be stripped, got: {name!r}"
+
+    def test_real_edition_unaffected(self):
+        """Other edition tokens (e.g. Director's Cut) must not be stripped."""
+        meta = _meta_base(
+            title='Blade Runner',
+            year='1982',
+            type='ENCODE',
+            source='BluRay',
+            resolution='1080p',
+            audio='DTS-HD MA 5.1',
+            video_encode='x264',
+            video_codec='H.264',
+            edition="Director's Cut",
+            tag='-GRP',
+            has_encode_settings=True,
+        )
+        name = self._get_name(meta)
+        assert 'Director' in name or 'director' in name.lower(), (
+            f"Edition token must be preserved, got: {name!r}"
+        )

--- a/tests/test_c411.py
+++ b/tests/test_c411.py
@@ -2734,3 +2734,23 @@ class TestC411CriterionStripping:
         assert 'Director' in name or 'director' in name.lower(), (
             f"Edition token must be preserved, got: {name!r}"
         )
+
+    def test_criterion_in_title_not_stripped(self):
+        """A movie whose title contains 'Criterion' must not be mangled."""
+        meta = _meta_base(
+            title='Criterion Something',
+            year='2000',
+            type='ENCODE',
+            source='BluRay',
+            resolution='1080p',
+            audio='FLAC',
+            video_encode='x264',
+            video_codec='H.264',
+            edition='',
+            tag='-GRP',
+            has_encode_settings=True,
+        )
+        name = self._get_name(meta)
+        assert 'criterion' in name.lower(), (
+            f"Title word 'Criterion' must not be stripped, got: {name!r}"
+        )


### PR DESCRIPTION
## Problem

Uploading a Criterion Collection Blu-ray release fails with:

> C411 — Erreur de nommage : Les noms de plateforme de streaming (CRITERION) ne doivent pas apparaître dans le nom de release.

**Root cause:** `guessit` parses `Criterion` from filenames like `L'argent.1983.Criterion.1080p.BluRay.FLAC.x264-BMF.mkv` as `edition="Criterion"`. This token then lands verbatim in the constructed release name, and C411's server has `CRITERION` in its banned streaming-platform list.

The Criterion Collection is a physical-media distributor, not a streaming service — but the server-side check cannot distinguish the two.

## Fix

In `C411.get_name`, after the parent class builds the name, strip `.Criterion` and `.Criterion.Collection` (case-insensitive) before returning:

```python
result["name"] = re.sub(r"\.Criterion(?:\.Collection)?", "", result["name"], flags=re.IGNORECASE)
```

Other edition tokens (Director's Cut, IMAX, etc.) are unaffected.

## Tests

`TestC411CriterionStripping` (3 tests):
- `edition='Criterion'` is stripped from the name
- `edition='Criterion Collection'` is also stripped
- Other edition tokens (Director's Cut) are preserved unchanged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Release-name generation now strips "Criterion" and "Criterion Collection" from edition labels, preserving other edition tokens.

* **Tests**
  * Added regression tests verifying edition-token stripping is case-insensitive, does not remove other editions, and doesn't strip "Criterion" when it's part of the title.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yippee0903/Upload-Assistant/pull/222?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->