### PR TITLE
fix: suppress verbose language-check messages in --unattended mode

### DIFF
--- a/src/trackers/COMMON.py
+++ b/src/trackers/COMMON.py
@@ -3230,11 +3230,12 @@ class COMMON:
                         console.print(f"[blue]Debug: Original language expanded candidates: {', '.join(sorted(original_language_expanded)) or 'None'}[/blue]")
 
             if original_required and not original_ok:
-                console.print(
-                    f"[red]Original language requirement not met for [bold]{tracker}[/bold].[/red]\n"
-                    f"[yellow]Required original audio language:[/yellow] {language_display}\n"
-                    f"[cyan]Found Audio Languages:[/cyan] {', '.join(audio_languages) or 'None'}"
-                )
+                if not meta.get("unattended") or meta.get("debug"):
+                    console.print(
+                        f"[red]Original language requirement not met for [bold]{tracker}[/bold].[/red]\n"
+                        f"[yellow]Required original audio language:[/yellow] {language_display}\n"
+                        f"[cyan]Found Audio Languages:[/cyan] {', '.join(audio_languages) or 'None'}"
+                    )
                 return not meta.get("unattended") and cli_ui.ask_yes_no("Do you want to upload anyway?", default=False)
 
             audio_ok = not check_audio or any(lang in audio_languages for lang in languages_to_check)
@@ -3250,14 +3251,15 @@ class COMMON:
                 if subtitle_ok:
                     return subtitle_ok
                 else:
-                    console.print(
-                        f"[red]Language requirement not met for [bold]{tracker}[/bold].[/red]\n"
-                        f"[yellow]Required subtitles in one of the following with an original audio track:[/yellow] "
-                        f"{', '.join(languages_to_check)}\n"
-                        f"[cyan]Found Audio:[/cyan] {', '.join(audio_languages) or 'None'}\n"
-                        f"[cyan]Found Subtitles:[/cyan] {', '.join(subtitle_languages) or 'None'}\n"
-                        f"[cyan]Original Audio Language:[/cyan] {language_display}"
-                    )
+                    if not meta.get("unattended") or meta.get("debug"):
+                        console.print(
+                            f"[red]Language requirement not met for [bold]{tracker}[/bold].[/red]\n"
+                            f"[yellow]Required subtitles in one of the following with an original audio track:[/yellow] "
+                            f"{', '.join(languages_to_check)}\n"
+                            f"[cyan]Found Audio:[/cyan] {', '.join(audio_languages) or 'None'}\n"
+                            f"[cyan]Found Subtitles:[/cyan] {', '.join(subtitle_languages) or 'None'}\n"
+                            f"[cyan]Original Audio Language:[/cyan] {language_display}"
+                        )
                     return False
 
             if require_both:
@@ -3271,7 +3273,7 @@ class COMMON:
             else:
                 final_ok = True
 
-            if not final_ok:
+            if not final_ok and (not meta.get("unattended") or meta.get("debug")):
                 if require_both:
                     console.print(
                         f"[red]Language requirement not met for [bold]{tracker}[/bold].[/red]\n"

--- a/src/trackers/G3MINI.py
+++ b/src/trackers/G3MINI.py
@@ -148,7 +148,10 @@ class G3MINI(FrenchTrackerMixin, UNIT3D):
                     if not isinstance(encoding_settings, str):
                         encoding_settings = str(encoding_settings)
                     if not encoding_settings:
-                        console.print(f"[bold red]{self.tracker}: No encoding settings found in mediainfo — cannot verify x264 preset quality (minimum: 'slow').[/bold red]")
+                        if not meta.get("unattended") or meta.get("debug"):
+                            console.print(
+                                f"[bold red]{self.tracker}: No encoding settings found in mediainfo — cannot verify x264 preset quality (minimum: 'slow').[/bold red]"
+                            )
                         return False
 
                     subme_match = re.search(r"\bsubme\s*=\s*(\d+)", encoding_settings, re.IGNORECASE)
@@ -166,7 +169,8 @@ class G3MINI(FrenchTrackerMixin, UNIT3D):
                             details.append(f"subme={subme} (minimum 8 for 'slow')")
                         if trellis is not None and trellis < 2:
                             details.append(f"trellis={trellis} (minimum 2 for 'slow')")
-                        console.print(f"[bold red]{self.tracker}: x264 encode quality is below the 'slow' preset minimum: {', '.join(details)}.[/bold red]")
+                        if not meta.get("unattended") or meta.get("debug"):
+                            console.print(f"[bold red]{self.tracker}: x264 encode quality is below the 'slow' preset minimum: {', '.join(details)}.[/bold red]")
                         return False
                     break
 


### PR DESCRIPTION
## Problem

In `--unattended` mode, `check_language_requirements` in `COMMON.py` was unconditionally printing verbose "Language requirement not met for …" messages for every skipped tracker. This produced noisy output like:

```
[red]Language requirement not met for TRACKER[/red]
Required at least one of the following: fr, french
Found Audio: en
Found Subtitles: None
Skipped due to specific tracker conditions: TRACKER
```

`trackerstatus.py` already prints the clean "Skipped due to specific tracker conditions: TRACKER" summary after all trackers finish — the verbose detail was redundant noise.

## Fix

Guard all three `console.print` sites in `check_language_requirements` with:

```python
if not meta.get("unattended") or meta.get("debug"):
```

## Behaviour after fix

| Mode | Output |
|---|---|
| Interactive | Full verbose messages (unchanged) |
| `--unattended` | Silent — only `trackerstatus.py` summary appears |
| `--unattended --debug` | Full verbose messages restored |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Diagnostic messages for language requirement checks are now suppressed in unattended runs unless debug is enabled, reducing noisy output during non-interactive workflows.
  * x264 quality validation and related error messages are similarly suppressed in unattended mode unless debug is on, while validation outcomes remain unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yippee0903/Upload-Assistant/pull/223?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->