### PR TITLE
fix(G3MINI): strip UHD token for sub-4K releases

### DIFF
--- a/src/trackers/G3MINI.py
+++ b/src/trackers/G3MINI.py
@@ -212,6 +212,10 @@ class G3MINI(FrenchTrackerMixin, UNIT3D):
         tag = meta.get("tag", "")
         source = meta.get("source", "")
         uhd = meta.get("uhd", "")
+        # G3MINI: "1080p UHD BluRay" is not a valid token combination — UHD
+        # denotes a 2160p source; strip it when resolution is not 2160p.
+        if resolution and resolution != "2160p":
+            uhd = ""
         hdr = meta.get("hdr", "")
         hybrid = str(meta.get("webdv", "")) if meta.get("webdv", "") else ""
         # Ensure the following variables are always defined

--- a/tests/test_g3mini.py
+++ b/tests/test_g3mini.py
@@ -713,3 +713,65 @@ class TestNogroupWebDL:
         )
         name = self._get_name(meta)
         assert name.endswith('-GROUP'), f"Expected -GROUP suffix, got: {name!r}"
+
+
+# ---------------------------------------------------------------------------
+# Tests – 1080p + UHD stripping
+# ---------------------------------------------------------------------------
+
+
+class TestG3MINIUhdStripping:
+    """G3MINI rejects '1080p.UHD.BluRay' — UHD is only valid at 2160p.
+
+    When the release is 1080p (or any non-4K resolution), the UHD token
+    must be stripped from the name even if meta['uhd'] is set.
+    """
+
+    def _get_name(self, meta: dict) -> str:
+        return asyncio.run(G3MINI(_config()).get_name(meta))['name']
+
+    def test_1080p_remux_uhd_stripped(self):
+        """1080p BluRay REMUX with uhd='UHD' must not contain 'UHD' in the name."""
+        meta = _meta_base(
+            resolution='1080p',
+            uhd='UHD',
+            type='REMUX',
+            source='BluRay',
+        )
+        name = self._get_name(meta)
+        assert 'UHD' not in name, f"'UHD' must be stripped for 1080p, got: {name!r}"
+
+    def test_1080p_encode_uhd_stripped(self):
+        """1080p ENCODE with uhd='UHD' must not contain 'UHD' in the name."""
+        meta = _meta_base(
+            resolution='1080p',
+            uhd='UHD',
+            type='ENCODE',
+            source='BluRay',
+            video_encode='x265',
+            video_codec='H.265',
+        )
+        name = self._get_name(meta)
+        assert 'UHD' not in name, f"'UHD' must be stripped for 1080p ENCODE, got: {name!r}"
+
+    def test_2160p_remux_uhd_preserved(self):
+        """2160p BluRay REMUX must keep 'UHD' in the name."""
+        meta = _meta_base(
+            resolution='2160p',
+            uhd='UHD',
+            type='REMUX',
+            source='BluRay',
+        )
+        name = self._get_name(meta)
+        assert 'UHD' in name, f"'UHD' must be preserved for 2160p, got: {name!r}"
+
+    def test_1080p_without_uhd_unaffected(self):
+        """1080p release with uhd='' must not have 'UHD' introduced."""
+        meta = _meta_base(
+            resolution='1080p',
+            uhd='',
+            type='REMUX',
+            source='BluRay',
+        )
+        name = self._get_name(meta)
+        assert 'UHD' not in name, f"'UHD' must not appear, got: {name!r}"


### PR DESCRIPTION
## Problem

G3MINI was including the `UHD` token in release names for 1080p (and other sub-4K) encodes — producing invalid combinations like:

```
Movie.2025.1080p.UHD.BluRay.VFF.FLAC.x265-GRP
```

`UHD` is a source qualifier denoting a 2160p-capable disc, not a resolution modifier. It makes no sense alongside `1080p` and is not accepted by G3MINI.

## Fix

In `G3MINI.get_name`, zero out `uhd` before building the name string when `resolution != '2160p'`:

```python
if resolution and resolution != "2160p":
    uhd = ""
```

This produces the correct `1080p.BluRay` without the spurious `UHD` token.

## Tests

`TestG3MINIUhdStripping` (4 cases):
- 1080p REMUX `uhd='UHD'` → `UHD` stripped
- 1080p ENCODE `uhd='UHD'` → `UHD` stripped
- 2160p REMUX `uhd='UHD'` → `UHD` preserved
- 1080p `uhd=''` → no `UHD` introduced


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed invalid UHD marker appearing in 1080p release names; UHD now correctly appears only in 2160p releases.

* **Tests**
  * Added comprehensive test coverage for UHD token handling across different resolutions and formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yippee0903/Upload-Assistant/pull/224?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->