### PR TITLE
test(TOS): add coverage for Scene release NFO requirement

### DIFF
--- a/tests/test_tos.py
+++ b/tests/test_tos.py
@@ -302,3 +302,63 @@ class TestNogroupWebDL:
         """A real group tag must not be replaced by the notag label."""
         name = self._get_name(_meta_nogroup(tag='-FRiENDS'))
         assert name.endswith('-FRiENDS'), f"Expected -FRiENDS suffix, got: {name!r}"
+
+
+# ---------------------------------------------------------------------------
+# Tests – Scene release NFO requirement
+# ---------------------------------------------------------------------------
+
+
+class TestTosSceneNfoRequirement:
+    """TOS requires a NFO file for Scene releases.
+
+    get_additional_checks must return False when meta['scene'] is True and
+    neither meta['nfo'] nor meta['auto_nfo'] is set.
+    """
+
+    def _patch_lang_ok(self, t: TOS) -> None:
+        t.common.check_language_requirements = AsyncMock(return_value=True)  # type: ignore[assignment]
+
+    def test_scene_without_nfo_rejected(self):
+        """Scene release with no NFO must be rejected."""
+        t = TOS(_config())
+        self._patch_lang_ok(t)
+        meta = _additional_checks_meta("/tmp/Some.Movie.2025.1080p.BluRay.x264-GRP")
+        meta["scene"] = True
+        meta["nfo"] = False
+        meta["auto_nfo"] = False
+        result = _run(t.get_additional_checks(meta))
+        assert result is False
+
+    def test_scene_with_nfo_accepted(self):
+        """Scene release with a NFO file must pass the NFO check."""
+        t = TOS(_config())
+        self._patch_lang_ok(t)
+        meta = _additional_checks_meta("/tmp/Some.Movie.2025.1080p.BluRay.x264-GRP")
+        meta["scene"] = True
+        meta["nfo"] = True
+        meta["auto_nfo"] = False
+        result = _run(t.get_additional_checks(meta))
+        assert result is True
+
+    def test_scene_with_auto_nfo_accepted(self):
+        """Scene release with auto-generated NFO must also pass."""
+        t = TOS(_config())
+        self._patch_lang_ok(t)
+        meta = _additional_checks_meta("/tmp/Some.Movie.2025.1080p.BluRay.x264-GRP")
+        meta["scene"] = True
+        meta["nfo"] = False
+        meta["auto_nfo"] = True
+        result = _run(t.get_additional_checks(meta))
+        assert result is True
+
+    def test_non_scene_without_nfo_accepted(self):
+        """Non-scene release without NFO must not be rejected by the NFO check."""
+        t = TOS(_config())
+        self._patch_lang_ok(t)
+        meta = _additional_checks_meta("/tmp/Some.Movie.2025.1080p.BluRay.x264-GRP")
+        meta["scene"] = False
+        meta["nfo"] = False
+        meta["auto_nfo"] = False
+        result = _run(t.get_additional_checks(meta))
+        assert result is True


### PR DESCRIPTION
## Context

TOS requires a NFO file for Scene releases (`get_additional_checks`, line 445).
The check was already implemented but had zero test coverage.

## Change

Adds `TestTosSceneNfoRequirement` (4 tests) to `tests/test_tos.py`:

| `scene` | `nfo` | `auto_nfo` | Expected |
|---------|-------|------------|----------|
| True    | False | False      | rejected |
| True    | True  | False      | accepted |
| True    | False | True       | accepted |
| False   | False | False      | accepted |

No production code changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for Terms of Service NFO requirements validation for Scene releases, ensuring proper handling of NFO and auto-NFO metadata conditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yippee0903/Upload-Assistant/pull/225?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->