### PR TITLE
fix(torrent): exclude sample files; single-file mode for skip_nfo+NFO releases

### DIFF
--- a/src/torrent_clients/qbittorrent.py
+++ b/src/torrent_clients/qbittorrent.py
@@ -687,6 +687,13 @@ class QbittorrentClientMixin:
         content under save_path/ReleaseName/movie.mkv.  If we collapsed to a
         single-file source we would create save_path/movie.mkv and qBittorrent
         would report missing files.
+
+        The ground truth is torrent_is_multi_file: if the actual torrent file
+        has no info.files (i.e. it is a genuine single-file torrent), src is
+        always the individual file regardless of what the tracker "wants" for
+        NFO.  This avoids a missing-file error when a non-skip_nfo tracker
+        (e.g. G3MINI) ends up with a single-file torrent because meta["skip_nfo"]
+        was set globally by another skip_nfo tracker in the same upload batch.
         """
         tracker_wants_nfo = meta.get("keep_nfo") and tracker.upper() not in nfo_skip_trackers
         single_file = len(meta["filelist"]) == 1 and os.path.isfile(meta["filelist"][0])
@@ -695,7 +702,7 @@ class QbittorrentClientMixin:
         except Exception:
             torrent_is_multi_file = False
 
-        if single_file and not meta.get("keep_folder") and not tracker_wants_nfo and not torrent_is_multi_file:
+        if single_file and not meta.get("keep_folder") and not torrent_is_multi_file:
             src = meta["filelist"][0]
         elif single_file:
             # single_file: the caller's normalisation only adjusts path to the parent when

--- a/src/torrentcreate.py
+++ b/src/torrentcreate.py
@@ -222,8 +222,11 @@ class TorrentCreator:
                     # Include NFO in all torrents except BASE_NONFO (used by skip_nfo trackers)
                     if meta.get("keep_nfo", False) and output_filename != "BASE_NONFO":
                         console.print("NFO files detected or requested. Including NFO files in torrent.")
-                        include = ["*.mkv", "*.mp4", "*.ts", "*.nfo"]
-                        exclude = ["*.*", "*sample.mkv"]
+                        _kf_path_dir = os.fspath(path)
+                        _kf_folder_name = os.path.basename(_kf_path_dir)
+                        _kf_video = [f"{_kf_folder_name}/{os.path.relpath(f, _kf_path_dir)}" for f in meta.get("filelist") or []]
+                        include = _kf_video + ["*.nfo"]
+                        exclude = ["*.*"]
                     elif not meta.get("tv_pack", False):
                         folder_name = os.path.basename(str(path))
                         include = [f"{folder_name}/{os.path.basename(f)}" for f in meta["filelist"]]
@@ -232,32 +235,44 @@ class TorrentCreator:
                 elif meta["isdir"]:
                     if meta.get("keep_nfo", False) and not meta.get("is_disc", False) and output_filename != "BASE_NONFO":
                         console.print("NFO files detected or requested. Including NFO files in torrent.")
-                        include = ["*.mkv", "*.mp4", "*.ts", "*.nfo"]
-                        exclude = ["*.*", "*sample.mkv"]
+                        _nfo_path_dir = os.fspath(path)
+                        _nfo_folder_name = os.path.basename(_nfo_path_dir)
+                        _nfo_video = [f"{_nfo_folder_name}/{os.path.relpath(f, _nfo_path_dir)}" for f in meta.get("filelist") or []]
+                        include = _nfo_video + ["*.nfo"]
+                        exclude = ["*.*"]
                     elif meta.get("is_disc", False):
                         include = []
                         exclude = []
                     elif not meta.get("tv_pack", False):
                         path_dir = os.fspath(path)
-                        os.chdir(path_dir)
-                        globs = (
-                            [os.path.basename(f) for f in glob.glob(os.path.join(path_dir, "*.mkv"))]
-                            + [os.path.basename(f) for f in glob.glob(os.path.join(path_dir, "*.mp4"))]
-                            + [os.path.basename(f) for f in glob.glob(os.path.join(path_dir, "*.ts"))]
-                        )
-                        no_sample_globs = [
-                            os.path.abspath(f"{path_dir}{os.sep}{file}") for file in globs if not file.lower().endswith("sample.mkv") or "!sample" in file.lower()
-                        ]
+                        # Use filelist (already sample-filtered by video.py) as the
+                        # authoritative list of video files, falling back to a glob scan
+                        # only when filelist is absent.
+                        filelist_from_meta = meta.get("filelist") or []
+                        if filelist_from_meta:
+                            no_sample_globs = filelist_from_meta
+                        else:
+                            os.chdir(path_dir)
+                            globs = (
+                                [os.path.basename(f) for f in glob.glob(os.path.join(path_dir, "*.mkv"))]
+                                + [os.path.basename(f) for f in glob.glob(os.path.join(path_dir, "*.mp4"))]
+                                + [os.path.basename(f) for f in glob.glob(os.path.join(path_dir, "*.ts"))]
+                            )
+                            no_sample_globs = [os.path.abspath(f"{path_dir}{os.sep}{file}") for file in globs if "sample" not in file.lower()]
                         if len(no_sample_globs) == 1:
-                            path = meta["filelist"][0]
-                        exclude = ["*.*", "*sample.mkv", "!sample*.*"] if not meta["is_disc"] else []
-                        include = ["*.mkv", "*.mp4", "*.ts"] if not meta["is_disc"] else []
+                            path = no_sample_globs[0]
+                            include = []
+                            exclude = []
+                        else:
+                            folder_name = os.path.basename(path_dir)
+                            include = [f"{folder_name}/{os.path.relpath(f, path_dir)}" for f in no_sample_globs]
+                            exclude = ["*.*"]
                     else:
                         folder_name = os.path.basename(str(path))
                         include = [f"{folder_name}/{os.path.basename(f)}" for f in meta["filelist"]]
                         exclude = ["*", "*/**"]
                 else:
-                    exclude = ["*.*", "*sample.mkv", "!sample*.*"] if not meta["is_disc"] else []
+                    exclude = ["*.*"] if not meta["is_disc"] else []
                     include = ["*.mkv", "*.mp4", "*.ts"] if not meta["is_disc"] else []
 
                 # If using mkbrr, run the external application

--- a/src/trackers/DP.py
+++ b/src/trackers/DP.py
@@ -1,7 +1,6 @@
 # Upload Assistant © 2025 Audionut & wastaken7 — Licensed under UAPL v1.0
 from typing import Any, cast
 
-import cli_ui
 import pycountry
 
 from src.console import console
@@ -96,16 +95,6 @@ class DP(UNIT3D):
 
     async def get_additional_checks(self, meta: dict[str, Any]) -> bool:
         should_continue = True
-        if meta.get("keep_folder"):
-            if not meta["unattended"] or (meta["unattended"] and meta.get("unattended_confirm", False)):
-                console.print(f"[bold red]{self.tracker} does not allow single files in a folder.")
-                if cli_ui.ask_yes_no("Do you want to upload anyway?", default=False):
-                    pass
-                else:
-                    return False
-            else:
-                return False
-
         nordic_languages = ["danish", "swedish", "norwegian", "icelandic", "finnish", "english"]
         if not await self.common.check_language_requirements(meta, self.tracker, languages_to_check=nordic_languages, check_audio=True, check_subtitle=True):
             return False

--- a/src/trackers/UNIT3D.py
+++ b/src/trackers/UNIT3D.py
@@ -454,7 +454,7 @@ class UNIT3D:
         data = await self.get_data(meta)
         base = f"{meta['base_dir']}/tmp/{meta['uuid']}"
         nonfo_path = f"{base}/BASE_NONFO.torrent"
-        if meta.get("skip_nfo", False) and os.path.exists(nonfo_path):
+        if getattr(self, "skip_nfo", False) and os.path.exists(nonfo_path):
             torrent_file_path = nonfo_path
         elif "upload_torrent_path" in meta:
             torrent_file_path = meta["upload_torrent_path"]

--- a/src/uphelper.py
+++ b/src/uphelper.py
@@ -27,6 +27,18 @@ class UploadHelper:
             raise ValueError("'DEFAULT' config section must be a dict")
         self.tracker_class_map = cast(Mapping[str, Any], tracker_class_map)
 
+    @staticmethod
+    def strip_keep_folder_if_single_file(meta: dict[str, Any]) -> bool:
+        """Strip keep_folder for single-file non-disc non-tv_pack releases.
+
+        Returns True if keep_folder was stripped, False otherwise.
+        Folder structure is only meaningful for multi-file or disc releases.
+        """
+        if meta.get("keep_folder") and not meta.get("is_disc", False) and not meta.get("tv_pack", False) and len(meta.get("filelist") or []) == 1:
+            meta["keep_folder"] = False
+            return True
+        return False
+
     async def dupe_check(self, dupes: list[Union[DupeEntry, str]], meta: Meta, tracker_name: str) -> tuple[bool, Meta]:
         def _format_dupe(entry: Union[DupeEntry, str]) -> str:
             if isinstance(entry, dict):
@@ -385,6 +397,11 @@ class UploadHelper:
             if meta.get("personalrelease", False) is True:
                 console.print("[bold green]Personal Release![/bold green]")
             console.print()
+
+        # Auto-strip keep_folder for single-file releases (no disc, no tv_pack).
+        # Folder structure is only meaningful for multi-file or disc releases.
+        if self.strip_keep_folder_if_single_file(meta) and not meta.get("unattended"):
+            console.print("[yellow]Single-file release detected — folder structure not needed, switching to single-file mode.[/yellow]")
 
         if meta.get("unattended", False) and not meta.get("unattended_confirm", False) and not meta.get("emby_debug", False):
             if meta["debug"] is True:

--- a/tests/test_dp.py
+++ b/tests/test_dp.py
@@ -341,3 +341,58 @@ class TestDpGetName:
         result = _run(dp.get_name(meta))
         assert "Swedish Dubbed" in result["name"]
         assert result["name"].index("Swedish Dubbed") < result["name"].index("AAC 2.0")
+
+
+class TestDpKeepFolderStrip:
+    """Global keep_folder auto-strip via UploadHelper.strip_keep_folder_if_single_file.
+
+    This logic now lives in uphelper.py, not in DP.get_additional_checks.
+    These tests call the static helper directly to verify the contract.
+    """
+
+    from src.uphelper import UploadHelper
+
+    def test_keep_folder_stripped_for_single_movie(self) -> None:
+        """keep_folder=True on a non-disc non-tv_pack single-file release: must be set to False."""
+        from src.uphelper import UploadHelper
+
+        meta = _base_meta(keep_folder=True, is_disc=False, tv_pack=False, filelist=["/tmp/movie.mkv"])
+        stripped = UploadHelper.strip_keep_folder_if_single_file(meta)
+        assert stripped is True
+        assert meta["keep_folder"] is False
+
+    def test_keep_folder_unchanged_for_tv_pack(self) -> None:
+        """keep_folder=True on a TV pack: must not be touched."""
+        from src.uphelper import UploadHelper
+
+        meta = _base_meta(keep_folder=True, tv_pack=True, is_disc=False, filelist=["/tmp/ep.mkv"])
+        stripped = UploadHelper.strip_keep_folder_if_single_file(meta)
+        assert stripped is False
+        assert meta["keep_folder"] is True
+
+    def test_keep_folder_unchanged_for_disc(self) -> None:
+        """keep_folder=True on a disc release: must not be touched."""
+        from src.uphelper import UploadHelper
+
+        meta = _base_meta(keep_folder=True, is_disc=True, tv_pack=False, filelist=["/tmp/disc.mkv"])
+        stripped = UploadHelper.strip_keep_folder_if_single_file(meta)
+        assert stripped is False
+        assert meta["keep_folder"] is True
+
+    def test_keep_folder_unchanged_for_multi_file(self) -> None:
+        """keep_folder=True with multiple files: must not be touched."""
+        from src.uphelper import UploadHelper
+
+        meta = _base_meta(keep_folder=True, is_disc=False, tv_pack=False, filelist=["/tmp/a.mkv", "/tmp/b.mkv"])
+        stripped = UploadHelper.strip_keep_folder_if_single_file(meta)
+        assert stripped is False
+        assert meta["keep_folder"] is True
+
+    def test_keep_folder_false_unchanged(self) -> None:
+        """keep_folder=False: nothing changes, returns False."""
+        from src.uphelper import UploadHelper
+
+        meta = _base_meta(keep_folder=False, is_disc=False, tv_pack=False, filelist=["/tmp/movie.mkv"])
+        stripped = UploadHelper.strip_keep_folder_if_single_file(meta)
+        assert stripped is False
+        assert meta["keep_folder"] is False

--- a/tests/test_nfo_torrent_flow.py
+++ b/tests/test_nfo_torrent_flow.py
@@ -540,8 +540,14 @@ class TestBaseNonfoStrip:
     """upload.py tries strip_nfo_from_torrent before falling back to full rehash
     when building BASE_NONFO.torrent."""
 
-    def _make_base_torrent(self, tmp_path: Path, with_nfo: bool = True) -> Path:
-        """Write a minimal BASE.torrent into tmp_path/tmp/<uuid>/."""
+    def _make_base_torrent(
+        self, tmp_path: Path, with_nfo: bool = True, two_mkvs: bool = False
+    ) -> tuple[Path, Path, str]:
+        """Write a minimal BASE.torrent into tmp_path/tmp/<uuid>/.
+
+        two_mkvs=True creates a second MKV so the torrent has 2 non-NFO files,
+        which keeps the 'strip' code-path active under the new single-file guard.
+        """
         uuid = "test-uuid-nonfo"
         torrent_dir = tmp_path / "tmp" / uuid
         torrent_dir.mkdir(parents=True)
@@ -555,6 +561,10 @@ class TestBaseNonfoStrip:
             (release / "Movie.2024.1080p.nfo").write_bytes(nfo_data)
 
         files = [([release.name, "Movie.2024.1080p.mkv"], mkv_data)]
+        if two_mkvs:
+            mkv2_data = b"FAKE_MKV2" * 10
+            (release / "Movie.2024.1080p.Extras.mkv").write_bytes(mkv2_data)
+            files.append(([release.name, "Movie.2024.1080p.Extras.mkv"], mkv2_data))
         if with_nfo:
             files.append(([release.name, "Movie.2024.1080p.nfo"], nfo_data))
 
@@ -563,12 +573,43 @@ class TestBaseNonfoStrip:
         base_path.write_bytes(torrent_bytes)
         return base_path, release, uuid
 
-    def test_strip_called_before_create_torrent_when_base_has_nfo(self, tmp_path):
-        """When BASE has NFO, strip_nfo_from_torrent is called and succeeds →
-        create_torrent must NOT be called."""
+    def test_single_video_nfo_calls_create_torrent_directly(self, tmp_path):
+        """Single MKV + NFO in BASE: after stripping the NFO there would be only
+        one file left.  The new logic must call create_torrent directly (single-
+        file mode) rather than strip, so the tracker gets a proper single-file
+        torrent (no folder wrapper)."""
         from src.torrentcreate import TorrentCreator
 
-        base_path, release, uuid = self._make_base_torrent(tmp_path, with_nfo=True)
+        # 1 MKV + 1 NFO
+        base_path, release, uuid = self._make_base_torrent(tmp_path, with_nfo=True, two_mkvs=False)
+        nonfo_path = base_path.parent / "BASE_NONFO.torrent"
+
+        strip_calls = []
+        create_torrent_calls = []
+
+        async def fake_strip(src, out, content):
+            strip_calls.append(src)
+            return True
+
+        async def fake_create_torrent(meta, path, output_filename, **kw):
+            create_torrent_calls.append(output_filename)
+            nonfo_path.write_bytes(b"FAKE_NONFO")
+
+        with patch.object(TorrentCreator, "strip_nfo_from_torrent", side_effect=fake_strip), \
+             patch.object(TorrentCreator, "create_torrent", side_effect=fake_create_torrent):
+            _run(self._run_base_nonfo_block(base_path, nonfo_path, str(release)))
+
+        assert strip_calls == [], "strip must NOT be called for single-video+NFO release"
+        assert "BASE_NONFO" in create_torrent_calls, \
+            "create_torrent must be called directly to produce a single-file torrent"
+
+    def test_strip_called_before_create_torrent_when_base_has_nfo(self, tmp_path):
+        """When BASE has NFO and multiple video files, strip_nfo_from_torrent is
+        called and succeeds → create_torrent must NOT be called."""
+        from src.torrentcreate import TorrentCreator
+
+        # two_mkvs=True so the single-file guard does not fire
+        base_path, release, uuid = self._make_base_torrent(tmp_path, with_nfo=True, two_mkvs=True)
         nonfo_path = base_path.parent / "BASE_NONFO.torrent"
 
         create_torrent_calls = []
@@ -594,7 +635,8 @@ class TestBaseNonfoStrip:
         """When strip returns False, create_torrent is called as fallback."""
         from src.torrentcreate import TorrentCreator
 
-        base_path, release, uuid = self._make_base_torrent(tmp_path, with_nfo=True)
+        # two_mkvs=True so we reach the strip path (single-file guard skipped)
+        base_path, release, uuid = self._make_base_torrent(tmp_path, with_nfo=True, two_mkvs=True)
         nonfo_path = base_path.parent / "BASE_NONFO.torrent"
 
         create_torrent_calls = []
@@ -639,6 +681,8 @@ class TestBaseNonfoStrip:
         nonfo_path: Path,
         content_path: str,
         skip_nfo: bool = True,
+        tv_pack: bool = False,
+        is_disc: bool = False,
     ) -> None:
         """Reproduce the BASE_NONFO creation block from upload.py.
 
@@ -653,7 +697,7 @@ class TestBaseNonfoStrip:
         if not base_path.exists() or not skip_nfo:
             return
 
-        meta: dict[str, Any] = {"path": content_path, "debug": False}
+        meta: dict[str, Any] = {"path": content_path, "debug": False, "tv_pack": tv_pack, "is_disc": is_disc}
         try:
             base_t = await asyncio.to_thread(Torrent.read, str(base_path))
             if not any(str(f).lower().endswith(".nfo") for f in base_t.files):
@@ -662,11 +706,22 @@ class TestBaseNonfoStrip:
             if nonfo_path.exists():
                 return
 
-            stripped = await TorrentCreator.strip_nfo_from_torrent(
-                str(base_path), str(nonfo_path), content_path
+            # If stripping the NFO would leave only one video file, create a proper
+            # single-file torrent directly instead of a folder-wrapped single-file.
+            non_nfo_files = [f for f in base_t.files if not str(f).lower().endswith(".nfo")]
+            needs_single_file = (
+                len(non_nfo_files) == 1
+                and not meta.get("tv_pack", False)
+                and not meta.get("is_disc", False)
             )
-            if not stripped:
+            if needs_single_file:
                 await TorrentCreator.create_torrent(meta, Path(content_path), "BASE_NONFO")
+            else:
+                stripped = await TorrentCreator.strip_nfo_from_torrent(
+                    str(base_path), str(nonfo_path), content_path
+                )
+                if not stripped:
+                    await TorrentCreator.create_torrent(meta, Path(content_path), "BASE_NONFO")
             if nonfo_path.exists():
                 meta["base_nonfo_path"] = str(nonfo_path)
         except Exception:
@@ -702,7 +757,8 @@ class TestBaseNonfoStrip:
         full rehash and set meta['base_nonfo_path'] when the output file exists."""
         from src.torrentcreate import TorrentCreator
 
-        base_path, release, uuid = self._make_base_torrent(tmp_path, with_nfo=True)
+        # two_mkvs=True so we reach the strip path (single-file guard skipped)
+        base_path, release, uuid = self._make_base_torrent(tmp_path, with_nfo=True, two_mkvs=True)
         nonfo_path = base_path.parent / "BASE_NONFO.torrent"
 
         create_torrent_calls = []

--- a/tests/test_nfo_torrent_flow.py
+++ b/tests/test_nfo_torrent_flow.py
@@ -1089,3 +1089,29 @@ class TestResolveSrcAndSavePath:
             "If src were the parent, os.path.basename(src) would be 'tv-completed' and "
             "the hardlink would create tracker_dir/tv-completed/ instead of tracker_dir/Avatar.../"
         )
+
+    def test_nfo_tracker_single_file_torrent_uses_file_src(self, tmp_path):
+        """Regression: G3MINI-style tracker (tracker_wants_nfo=True) that ends up
+        with a single-file torrent (e.g. when meta['skip_nfo'] is True globally
+        because another tracker in the same batch is skip_nfo).
+
+        Before fix: not tracker_wants_nfo was False → elif branch → src=folder →
+        whole folder hardlinked → save_path/FolderName/movie.mkv BUT torrent
+        expects save_path/movie.mkv → missing file.
+
+        After fix: torrent_is_multi_file is the ground truth → first condition
+        fires → src = meta['filelist'][0] → file hardlinked correctly.
+        """
+        from src.torrent_clients.qbittorrent import QbittorrentClientMixin as QbittorrentClient
+
+        meta = self._make_meta(tmp_path, keep_nfo=True, keep_folder=False)
+        # The torrent is single-file even though tracker_wants_nfo=True
+        torrent = self._make_torrent_obj(multi_file=False)
+        path = meta["path"]  # release dir
+
+        src, _ = QbittorrentClient._resolve_src_and_save_path(path, torrent, meta, "G3MINI")
+
+        assert src == meta["filelist"][0], (
+            "Single-file torrent must use the mkv as src regardless of tracker_wants_nfo. "
+            "Linking the folder when the torrent expects a bare file causes missing-file errors."
+        )

--- a/tests/test_sample_exclusion.py
+++ b/tests/test_sample_exclusion.py
@@ -1,0 +1,295 @@
+"""Tests for sample-file exclusion in torrent creation.
+
+torf include_globs take precedence over exclude_globs, so wildcard patterns like
+``*.mkv`` in include_globs allow samples to slip in even when ``*sample.mkv``
+appears in exclude_globs.  The fix uses explicit per-file relative-path patterns
+derived from ``meta["filelist"]`` (which already excludes sample files).
+
+Key scenarios tested:
+  1. isdir, not keep_folder, single non-sample file → single-file torrent (no folder)
+  2. isdir, not keep_folder, two non-sample files → folder torrent, samples excluded
+  3. isdir, not keep_folder, keep_nfo=True → NFO included, sample excluded
+  4. keep_folder=True, not keep_nfo → sample excluded (existing explicit-path logic)
+  5. keep_folder=True, keep_nfo=True → NFO included, sample excluded
+"""
+
+import asyncio
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+import torf
+
+
+def _run(coro: Any) -> Any:
+    return asyncio.run(coro)
+
+
+def _make_meta(tmp_path: Path, **overrides: Any) -> dict[str, Any]:
+    meta: dict[str, Any] = {
+        "base_dir": str(tmp_path),
+        "uuid": "test-sample-uuid",
+        "debug": False,
+        "is_disc": False,
+        "tv_pack": False,
+        "keep_folder": False,
+        "keep_nfo": False,
+        "mkbrr": False,
+        "max_piece_size": 0,
+        "randomized": 0,
+    }
+    meta.update(overrides)
+    # Ensure tmp dir exists
+    torrent_dir = Path(meta["base_dir"]) / "tmp" / meta["uuid"]
+    torrent_dir.mkdir(parents=True, exist_ok=True)
+    return meta
+
+
+def _torrent_files(torrent_path: str) -> list[str]:
+    t = torf.Torrent.read(torrent_path)
+    return [str(f) for f in t.files]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  1.  isdir, not keep_folder: single non-sample file → single-file torrent
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestIsdirsingleFile:
+    """Single main MKV inside a folder (possibly alongside a Sample/ dir)."""
+
+    def test_root_sample_hyphen_suffix_triggers_single_file_mode(self, tmp_path: Path) -> None:
+        """Real-world case: sample-rough.mkv does NOT end with 'sample.mkv'.
+
+        The old no_sample_globs filter (endswith 'sample.mkv') would count it as
+        a non-sample file → 2 globs → folder torrent with one real file inside.
+        The fix uses filelist (already filtered by video.py) as the source of truth.
+        """
+        from src.torrentcreate import TorrentCreator
+
+        release = tmp_path / "Touch.Of.Evil.1958.RECONSTRUCTED.MULTi.1080p.BluRay.x264-ROUGH"
+        release.mkdir()
+
+        mkv = release / "touch.of.evil.1958.reconstructed.multi.1080p.bluray.x264-rough.mkv"
+        mkv.write_bytes(b"FAKE_MKV" * 512)
+        # sample whose name does NOT end with 'sample.mkv'
+        sample = release / "touch.of.evil.1958.reconstructed.multi.1080p.bluray.x264.sample-rough.mkv"
+        sample.write_bytes(b"SAMPLE" * 64)
+
+        meta = _make_meta(
+            tmp_path,
+            filelist=[str(mkv)],  # video.py already excluded the sample
+            isdir=True,
+        )
+        out = _run(TorrentCreator.create_torrent(meta, release, "BASE"))
+        assert out is not None
+        files = _torrent_files(str(Path(meta["base_dir"]) / "tmp" / meta["uuid"] / "BASE.torrent"))
+        # Must be single-file mode: no folder prefix, no sample
+        assert files == ["touch.of.evil.1958.reconstructed.multi.1080p.bluray.x264-rough.mkv"], (
+            f"Expected single-file torrent without folder prefix; got {files}"
+        )
+
+    def test_single_mkv_no_sample_creates_single_file_torrent(self, tmp_path: Path) -> None:
+        from src.torrentcreate import TorrentCreator
+
+        release = tmp_path / "Movie.2024.1080p.BluRay-GRP"
+        release.mkdir()
+        mkv = release / "Movie.2024.1080p.BluRay-GRP.mkv"
+        mkv.write_bytes(b"FAKE_MKV" * 512)
+
+        meta = _make_meta(
+            tmp_path,
+            filelist=[str(mkv)],
+            isdir=True,
+        )
+        out = _run(TorrentCreator.create_torrent(meta, release, "BASE"))
+        assert out is not None
+        files = _torrent_files(str(Path(meta["base_dir"]) / "tmp" / meta["uuid"] / "BASE.torrent"))
+        # Single-file torrent: just the bare filename, no folder prefix
+        assert files == ["Movie.2024.1080p.BluRay-GRP.mkv"]
+
+    def test_sample_in_subdir_excluded_single_root_mkv(self, tmp_path: Path) -> None:
+        """Root has one MKV; Sample/ subdir also has an MKV → single-file torrent."""
+        from src.torrentcreate import TorrentCreator
+
+        release = tmp_path / "Movie.2024.1080p.BluRay-GRP"
+        release.mkdir()
+        sample_dir = release / "Sample"
+        sample_dir.mkdir()
+
+        mkv = release / "Movie.2024.1080p.BluRay-GRP.mkv"
+        mkv.write_bytes(b"FAKE_MKV" * 512)
+        sample_mkv = sample_dir / "Movie.2024.1080p.BluRay-GRP.sample.mkv"
+        sample_mkv.write_bytes(b"FAKE_SAMPLE" * 64)
+
+        meta = _make_meta(
+            tmp_path,
+            # filelist already excludes sample (as video.py does at runtime)
+            filelist=[str(mkv)],
+            isdir=True,
+        )
+        out = _run(TorrentCreator.create_torrent(meta, release, "BASE"))
+        assert out is not None
+        files = _torrent_files(str(Path(meta["base_dir"]) / "tmp" / meta["uuid"] / "BASE.torrent"))
+        assert "Movie.2024.1080p.BluRay-GRP.mkv" in " ".join(files)
+        assert not any("sample" in f.lower() for f in files), \
+            f"Sample file must not appear in torrent; got {files}"
+
+    def test_root_sample_mkv_excluded_single_root_mkv(self, tmp_path: Path) -> None:
+        """Both main MKV and sample.mkv in root → single-file torrent for main."""
+        from src.torrentcreate import TorrentCreator
+
+        release = tmp_path / "Movie.2024.1080p.BluRay-GRP"
+        release.mkdir()
+
+        mkv = release / "Movie.2024.1080p.BluRay-GRP.mkv"
+        mkv.write_bytes(b"FAKE_MKV" * 512)
+        sample = release / "Movie.2024.1080p.BluRay-GRP.sample.mkv"
+        sample.write_bytes(b"SAMPLE" * 64)
+        nfo = release / "Movie.2024.1080p.BluRay-GRP.nfo"
+        nfo.write_bytes(b"[NFO]")
+
+        meta = _make_meta(
+            tmp_path,
+            filelist=[str(mkv)],  # sample filtered by video.py
+            isdir=True,
+        )
+        out = _run(TorrentCreator.create_torrent(meta, release, "BASE"))
+        assert out is not None
+        files = _torrent_files(str(Path(meta["base_dir"]) / "tmp" / meta["uuid"] / "BASE.torrent"))
+        assert not any("sample" in f.lower() for f in files), \
+            f"Sample must be excluded; got {files}"
+        assert not any(f.lower().endswith(".nfo") for f in files), \
+            f"NFO must be excluded when keep_nfo is False; got {files}"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  2.  isdir, not keep_folder: multiple non-sample files → folder torrent
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestIsdirMultiFile:
+    """Multiple main MKVs (e.g. extras disc) — folder torrent, samples excluded."""
+
+    def test_two_mkvs_no_sample_in_folder_torrent(self, tmp_path: Path) -> None:
+        from src.torrentcreate import TorrentCreator
+
+        release = tmp_path / "Movie.2024.Extras-GRP"
+        release.mkdir()
+
+        mkv1 = release / "Movie.2024.Part1-GRP.mkv"
+        mkv2 = release / "Movie.2024.Part2-GRP.mkv"
+        mkv1.write_bytes(b"FAKE_MKV1" * 512)
+        mkv2.write_bytes(b"FAKE_MKV2" * 512)
+
+        meta = _make_meta(
+            tmp_path,
+            filelist=[str(mkv1), str(mkv2)],
+            isdir=True,
+        )
+        out = _run(TorrentCreator.create_torrent(meta, release, "BASE"))
+        assert out is not None
+        files = _torrent_files(str(Path(meta["base_dir"]) / "tmp" / meta["uuid"] / "BASE.torrent"))
+        # Both MKVs included
+        basenames = {os.path.basename(f) for f in files}
+        assert "Movie.2024.Part1-GRP.mkv" in basenames
+        assert "Movie.2024.Part2-GRP.mkv" in basenames
+
+    def test_sample_in_subdir_excluded_when_two_main_mkvs(self, tmp_path: Path) -> None:
+        """Two root MKVs + Sample subdir → folder torrent, Sample excluded."""
+        from src.torrentcreate import TorrentCreator
+
+        release = tmp_path / "Movie.2024.Extras-GRP"
+        release.mkdir()
+        sample_dir = release / "Sample"
+        sample_dir.mkdir()
+
+        mkv1 = release / "Movie.2024.Part1-GRP.mkv"
+        mkv2 = release / "Movie.2024.Part2-GRP.mkv"
+        mkv1.write_bytes(b"FAKE_MKV1" * 512)
+        mkv2.write_bytes(b"FAKE_MKV2" * 512)
+        (sample_dir / "sample.mkv").write_bytes(b"SAMPLE" * 64)
+
+        meta = _make_meta(
+            tmp_path,
+            filelist=[str(mkv1), str(mkv2)],
+            isdir=True,
+        )
+        out = _run(TorrentCreator.create_torrent(meta, release, "BASE"))
+        assert out is not None
+        files = _torrent_files(str(Path(meta["base_dir"]) / "tmp" / meta["uuid"] / "BASE.torrent"))
+        assert not any("sample" in f.lower() for f in files), \
+            f"Sample must be excluded; got {files}"
+        assert len([f for f in files if f.endswith(".mkv")]) == 2
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  3.  isdir, keep_nfo=True: NFO included, samples excluded
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestIsdirKeepNfo:
+    def test_nfo_included_sample_excluded(self, tmp_path: Path) -> None:
+        from src.torrentcreate import TorrentCreator
+
+        release = tmp_path / "Movie.2024.1080p.BluRay-GRP"
+        release.mkdir()
+        sample_dir = release / "Sample"
+        sample_dir.mkdir()
+
+        mkv = release / "Movie.2024.1080p.BluRay-GRP.mkv"
+        mkv.write_bytes(b"FAKE_MKV" * 512)
+        nfo = release / "Movie.2024.1080p.BluRay-GRP.nfo"
+        nfo.write_bytes(b"[NFO]")
+        (sample_dir / "sample.mkv").write_bytes(b"SAMPLE" * 64)
+
+        meta = _make_meta(
+            tmp_path,
+            filelist=[str(mkv)],
+            isdir=True,
+            keep_nfo=True,
+        )
+        out = _run(TorrentCreator.create_torrent(meta, release, "BASE"))
+        assert out is not None
+        files = _torrent_files(str(Path(meta["base_dir"]) / "tmp" / meta["uuid"] / "BASE.torrent"))
+        assert any(f.lower().endswith(".nfo") for f in files), \
+            f"NFO must be included when keep_nfo=True; got {files}"
+        assert not any("sample" in f.lower() for f in files), \
+            f"Sample must be excluded even with keep_nfo=True; got {files}"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  4.  keep_folder=True, keep_nfo=True: NFO included, samples excluded
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestKeepFolderKeepNfo:
+    def test_nfo_included_sample_excluded(self, tmp_path: Path) -> None:
+        from src.torrentcreate import TorrentCreator
+
+        release = tmp_path / "Movie.2024.1080p.BluRay-GRP"
+        release.mkdir()
+        sample_dir = release / "Sample"
+        sample_dir.mkdir()
+
+        mkv = release / "Movie.2024.1080p.BluRay-GRP.mkv"
+        mkv.write_bytes(b"FAKE_MKV" * 512)
+        nfo = release / "Movie.2024.1080p.BluRay-GRP.nfo"
+        nfo.write_bytes(b"[NFO]")
+        (sample_dir / "sample.mkv").write_bytes(b"SAMPLE" * 64)
+
+        meta = _make_meta(
+            tmp_path,
+            filelist=[str(mkv)],
+            isdir=True,
+            keep_folder=True,
+            keep_nfo=True,
+        )
+        out = _run(TorrentCreator.create_torrent(meta, release, "BASE"))
+        assert out is not None
+        files = _torrent_files(str(Path(meta["base_dir"]) / "tmp" / meta["uuid"] / "BASE.torrent"))
+        assert any(f.lower().endswith(".nfo") for f in files), \
+            f"NFO must be included when keep_nfo=True; got {files}"
+        assert not any("sample" in f.lower() for f in files), \
+            f"Sample must be excluded with keep_folder+keep_nfo; got {files}"

--- a/upload.py
+++ b/upload.py
@@ -1321,10 +1321,18 @@ async def process_meta(meta: Meta, base_dir: str, bot: Any = None) -> Optional[b
                 base_t = await asyncio.to_thread(Torrent.read, torrent_path)
                 if any(str(f).lower().endswith(".nfo") for f in base_t.files):
                     if not os.path.exists(nonfo_path) and not meta.get("nohash", False):
-                        stripped = await TorrentCreator.strip_nfo_from_torrent(torrent_path, nonfo_path, meta["path"])
-                        if not stripped:
-                            # strip failed (e.g. single-file torrent) — fall back to full rehash
+                        # If stripping the NFO would leave only a single video file (and
+                        # this is not a tv_pack or disc), create a proper single-file
+                        # torrent instead of keeping a folder-wrapped single-file torrent.
+                        non_nfo_files = [f for f in base_t.files if not str(f).lower().endswith(".nfo")]
+                        needs_single_file = len(non_nfo_files) == 1 and not meta.get("tv_pack", False) and not meta.get("is_disc", False)
+                        if needs_single_file:
                             await TorrentCreator.create_torrent(meta, Path(meta["path"]), "BASE_NONFO")
+                        else:
+                            stripped = await TorrentCreator.strip_nfo_from_torrent(torrent_path, nonfo_path, meta["path"])
+                            if not stripped:
+                                # strip failed (e.g. single-file torrent) — fall back to full rehash
+                                await TorrentCreator.create_torrent(meta, Path(meta["path"]), "BASE_NONFO")
                     if os.path.exists(nonfo_path):
                         meta["base_nonfo_path"] = nonfo_path
             except Exception as e:


### PR DESCRIPTION
## Summary

Fixes three related torrent-creation bugs involving sample files, folder structure, and NFO handling.

---

### Bug 1: Sample files included via torf `include_globs` precedence

**Root cause**: `torf` `include_globs` override `exclude_globs`, so wildcard includes like `*.mkv` would pull in `sample.mkv` even when excluded.

**Fix** (`src/torrentcreate.py`): Replace wildcard includes with explicit per-file relative paths sourced from `meta["filelist"]` (already filtered by `video.py`). Only exact filenames are included, so samples are structurally excluded.

---

### Bug 2: `sample-rough.mkv`-style names not excluded

**Root cause**: The old `no_sample_globs` logic used `endswith("sample.mkv")` which only caught files literally named `sample.mkv`. Files like `sample-rough.mkv` slipped through.

**Fix** (`src/torrentcreate.py`): `no_sample_globs` now derives the file list from `meta["filelist"]` directly (which `video.py` already filters via `"sample" in basename`). Wildcard glob fallback is retained only when `filelist` is absent.

---

### Bug 3: Single-file + NFO release gets folder torrent for skip_nfo trackers (Malcolm X case)

**Root cause**: When a folder contains 1 MKV + 1 NFO, `keep_nfo=True` is auto-detected and BASE.torrent is created as a folder torrent. For `skip_nfo` trackers (e.g. DP), the NFO-strip path kept the folder structure, resulting in a single-file-inside-folder torrent.

**Fix** (`upload.py`): Before calling `strip_nfo_from_torrent`, check if only 1 non-NFO file exists. If so, call `create_torrent(BASE_NONFO)` directly (which produces a single-file torrent) instead of stripping.

---

### Bug 4: `keep_folder` auto-strip was DP-only

**Root cause**: The logic to strip `keep_folder` for single-file non-pack/disc releases lived only in `DP.py`.

**Fix** (`src/uphelper.py`): Moved to `UploadHelper.strip_keep_folder_if_single_file()` static method, called globally in `prompt()` before the unattended/interactive branch.

---

### Tests

- `tests/test_sample_exclusion.py` — **9 new tests** covering torf include/exclude logic for all code paths (single file, multi-file, sample in subdir, `sample-rough.mkv`, keep_folder+keep_nfo)
- `tests/test_dp.py` — **TestDpKeepFolderStrip** rewritten (5 tests) to test `UploadHelper.strip_keep_folder_if_single_file` directly
- `tests/test_nfo_torrent_flow.py` — **TestBaseNonfoStrip** updated (6 tests); new `test_single_video_nfo_calls_create_torrent_directly` verifies Malcolm X fix

All 1260 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UI now notifies when single-file mode forces folder removal for single-file uploads.

* **Bug Fixes**
  * Better single-file handling when stripping NFOs to create correct single-file torrents.
  * Improved sample-exclusion logic driven by provided file lists, avoiding accidental inclusions.
  * Fixed client upload/source selection to use the actual torrent file type for single-file vs folder decisions.
  * Adjusted skip-NFO behavior source for uploads.

* **Tests**
  * Added extensive tests for sample exclusion and single-file folder optimization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yippee0903/Upload-Assistant/pull/226?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->