### PR TITLE
fix(TORR9): video codec before audio in release names

### DIFF
--- a/src/trackers/FRENCH.py
+++ b/src/trackers/FRENCH.py
@@ -1015,6 +1015,13 @@ class FrenchTrackerMixin:
 
         web_lbl = self.WEB_LABEL  # "WEB" or "WEB-DL" depending on tracker
 
+        # Some trackers (e.g. TORR9) want video codec before audio.
+        # Set AUDIO_BEFORE_VIDEO = False on the subclass to flip the order.
+        _audio_first = getattr(self, "AUDIO_BEFORE_VIDEO", True)
+
+        def _av(codec: str, aud: str) -> str:
+            return f"{aud} {codec}" if _audio_first else f"{codec} {aud}"
+
         name = ""
 
         # ── MOVIE ──
@@ -1022,27 +1029,27 @@ class FrenchTrackerMixin:
             if type_val == "DISC":
                 disc = meta.get("is_disc", "")
                 if disc == "BDMV":
-                    name = f"{title} {year} {three_d} {edition} {repack} {language} {resolution} {hybrid} {region} {uhd} {source} {hdr} {audio} {video_codec}"
+                    name = f"{title} {year} {three_d} {edition} {repack} {language} {resolution} {hybrid} {region} {uhd} {source} {hdr} {_av(video_codec, audio)}"
                 elif disc == "DVD":
                     name = f"{title} {year} {edition} {repack} {language} {region} {source} {dvd_size} {audio}"
                 elif disc == "HDDVD":
-                    name = f"{title} {year} {edition} {repack} {language} {resolution} {source} {audio} {video_codec}"
+                    name = f"{title} {year} {edition} {repack} {language} {resolution} {source} {_av(video_codec, audio)}"
             elif type_val == "REMUX" and source in ("BluRay", "HDDVD"):
-                name = f"{title} {year} {three_d} {edition} {repack} {language} {resolution} {hybrid} {uhd} {source} REMUX {hdr} {audio} {video_codec}"
+                name = f"{title} {year} {three_d} {edition} {repack} {language} {resolution} {hybrid} {uhd} {source} REMUX {hdr} {_av(video_codec, audio)}"
             elif type_val == "REMUX" and source in ("PAL DVD", "NTSC DVD", "DVD"):
                 name = f"{title} {year} {edition} {repack} {language} {source} REMUX {audio}"
             elif type_val == "REMUX":
-                name = f"{title} {year} {edition} {repack} {language} {resolution} {hybrid} {uhd} {source} REMUX {hdr} {audio} {video_codec}"
+                name = f"{title} {year} {edition} {repack} {language} {resolution} {hybrid} {uhd} {source} REMUX {hdr} {_av(video_codec, audio)}"
             elif type_val == "ENCODE":
-                name = f"{title} {year} {edition} {repack} {language} {resolution} {hybrid} {uhd} {source} {hdr} {audio} {video_encode}"
+                name = f"{title} {year} {edition} {repack} {language} {resolution} {hybrid} {uhd} {source} {hdr} {_av(video_encode, audio)}"
             elif type_val == "WEBDL":
-                name = f"{title} {year} {edition} {repack} {language} {resolution} {hybrid} {uhd} {service} {web_lbl} {hdr} {audio} {video_encode}"
+                name = f"{title} {year} {edition} {repack} {language} {resolution} {hybrid} {uhd} {service} {web_lbl} {hdr} {_av(video_encode, audio)}"
             elif type_val == "WEBRIP":
-                name = f"{title} {year} {edition} {repack} {language} {resolution} {hybrid} {uhd} {service} WEBRip {hdr} {audio} {video_encode}"
+                name = f"{title} {year} {edition} {repack} {language} {resolution} {hybrid} {uhd} {service} WEBRip {hdr} {_av(video_encode, audio)}"
             elif type_val == "HDTV":
-                name = f"{title} {year} {edition} {repack} {language} {resolution} {source} {audio} {video_encode}"
+                name = f"{title} {year} {edition} {repack} {language} {resolution} {source} {_av(video_encode, audio)}"
             elif type_val == "DVDRIP":
-                name = f"{title} {year} {repack} {language} {source} DVDRip {audio} {video_encode}"
+                name = f"{title} {year} {repack} {language} {source} DVDRip {_av(video_encode, audio)}"
 
         # ── TV ──
         elif category == "TV":
@@ -1050,30 +1057,30 @@ class FrenchTrackerMixin:
             if type_val == "DISC":
                 disc = meta.get("is_disc", "")
                 if disc == "BDMV":
-                    name = f"{title} {year} {se} {three_d} {edition} {repack} {language} {resolution} {hybrid} {region} {uhd} {source} {hdr} {audio} {video_codec}"
+                    name = f"{title} {year} {se} {three_d} {edition} {repack} {language} {resolution} {hybrid} {region} {uhd} {source} {hdr} {_av(video_codec, audio)}"
                 elif disc == "DVD":
                     name = f"{title} {year} {se} {three_d} {edition} {repack} {language} {region} {source} {dvd_size} {audio}"
                 elif disc == "HDDVD":
-                    name = f"{title} {year} {se} {edition} {repack} {language} {resolution} {source} {audio} {video_codec}"
+                    name = f"{title} {year} {se} {edition} {repack} {language} {resolution} {source} {_av(video_codec, audio)}"
             elif type_val == "REMUX" and source in ("BluRay", "HDDVD"):
-                name = f"{title} {year} {se} {part} {three_d} {edition} {repack} {language} {resolution} {hybrid} {uhd} {source} REMUX {hdr} {audio} {video_codec}"
+                name = f"{title} {year} {se} {part} {three_d} {edition} {repack} {language} {resolution} {hybrid} {uhd} {source} REMUX {hdr} {_av(video_codec, audio)}"
             elif type_val == "REMUX" and source in ("PAL DVD", "NTSC DVD", "DVD"):
                 name = f"{title} {year} {se} {part} {edition} {repack} {language} {source} REMUX {audio}"
             elif type_val == "REMUX":
-                name = f"{title} {year} {se} {part} {edition} {repack} {language} {resolution} {hybrid} {uhd} {source} REMUX {hdr} {audio} {video_codec}"
+                name = f"{title} {year} {se} {part} {edition} {repack} {language} {resolution} {hybrid} {uhd} {source} REMUX {hdr} {_av(video_codec, audio)}"
             elif type_val == "ENCODE":
-                name = f"{title} {year} {se} {part} {edition} {repack} {language} {resolution} {hybrid} {uhd} {source} {hdr} {audio} {video_encode}"
+                name = f"{title} {year} {se} {part} {edition} {repack} {language} {resolution} {hybrid} {uhd} {source} {hdr} {_av(video_encode, audio)}"
             elif type_val == "WEBDL":
-                name = f"{title} {year} {se} {part} {edition} {repack} {language} {resolution} {hybrid} {uhd} {service} {web_lbl} {hdr} {audio} {video_encode}"
+                name = f"{title} {year} {se} {part} {edition} {repack} {language} {resolution} {hybrid} {uhd} {service} {web_lbl} {hdr} {_av(video_encode, audio)}"
             elif type_val == "WEBRIP":
-                name = f"{title} {year} {se} {part} {edition} {repack} {language} {resolution} {hybrid} {uhd} {service} WEBRip {hdr} {audio} {video_encode}"
+                name = f"{title} {year} {se} {part} {edition} {repack} {language} {resolution} {hybrid} {uhd} {service} WEBRip {hdr} {_av(video_encode, audio)}"
             elif type_val == "HDTV":
-                name = f"{title} {year} {se} {part} {edition} {repack} {language} {resolution} {source} {audio} {video_encode}"
+                name = f"{title} {year} {se} {part} {edition} {repack} {language} {resolution} {source} {_av(video_encode, audio)}"
             elif type_val == "DVDRIP":
-                name = f"{title} {year} {se} {repack} {language} {source} DVDRip {audio} {video_encode}"
+                name = f"{title} {year} {se} {repack} {language} {source} DVDRip {_av(video_encode, audio)}"
 
         if not name:
-            name = f"{title} {year} {language} {resolution} {type_val} {audio} {video_encode}"
+            name = f"{title} {year} {language} {resolution} {type_val} {_av(video_encode, audio)}"
 
         # ── Post-processing ──
         name = " ".join(name.split())  # collapse whitespace

--- a/src/trackers/TORR9.py
+++ b/src/trackers/TORR9.py
@@ -150,6 +150,9 @@ class TORR9(FrenchTrackerMixin):
         return self.api_key
 
     # ──────────────────────────────────────────────────────────
+    # Video codec appears before audio in TORR9 release names
+    AUDIO_BEFORE_VIDEO: bool = False
+
     #  Audio / naming / French title — inherited from FrenchTrackerMixin
     # ──────────────────────────────────────────────────────────
 

--- a/tests/test_torr9.py
+++ b/tests/test_torr9.py
@@ -1683,3 +1683,69 @@ class TestNogroupWebDL:
         )
         name = self._get_name(meta)
         assert name.endswith('-FRiENDS'), f"Expected -FRiENDS suffix, got: {name!r}"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  TORR9 naming: video codec must appear BEFORE audio (AUDIO_BEFORE_VIDEO=False)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestTorr9VideoBeforeAudio:
+    """TORR9 release names must have the video codec token before the audio token."""
+
+    def _get_name(self, meta: dict) -> str:
+        return _run(TORR9(_config()).get_name(meta))["name"]
+
+    def _pos(self, name: str, token: str) -> int:
+        """Return index of token in dot-split list, -1 if absent."""
+        parts = name.upper().replace("-", ".").split(".")
+        token_up = token.upper()
+        for i, p in enumerate(parts):
+            if p == token_up:
+                return i
+        return -1
+
+    def test_encode_video_before_audio(self):
+        """ENCODE: x265 must come before the audio tag."""
+        meta = _meta_base(
+            title="Film",
+            year="2024",
+            audio="DTS-HD MA 5.1",
+            video_encode="x265",
+            video_codec="H.265",
+            source="BluRay",
+            type="ENCODE",
+            tag="-GRP",
+        )
+        name = self._get_name(meta)
+        assert "X265" in name.upper(), f"x265 missing from {name!r}"
+        assert "DTS" in name.upper(), f"DTS missing from {name!r}"
+        pos_video = self._pos(name, "X265")
+        pos_audio = min(i for i, p in enumerate(name.upper().replace("-", ".").split(".")) if "DTS" in p)
+        assert pos_video < pos_audio, (
+            f"Video codec (pos {pos_video}) must come before audio (pos {pos_audio}) in {name!r}"
+        )
+
+    def test_webdl_video_before_audio(self):
+        """WEBDL: H264 must come before the audio tag."""
+        meta = _meta_base(
+            title="Serie",
+            year="2023",
+            audio="AAC 2.0",
+            video_encode="H.264",
+            video_codec="H.264",
+            source="WEB",
+            type="WEBDL",
+            tag="-GRP",
+        )
+        name = self._get_name(meta)
+        pos_video = self._pos(name, "H264")
+        pos_audio = self._pos(name, "AAC")
+        assert pos_video != -1, f"H264 missing from {name!r}"
+        assert pos_audio != -1, f"AAC missing from {name!r}"
+        assert pos_video < pos_audio, (
+            f"Video codec (pos {pos_video}) must come before audio (pos {pos_audio}) in {name!r}"
+        )
+
+    def test_audio_before_video_false_attribute(self):
+        """TORR9 class must declare AUDIO_BEFORE_VIDEO = False."""
+        assert TORR9.AUDIO_BEFORE_VIDEO is False


### PR DESCRIPTION
TORR9 convention is:
  ...Source.HDR.VideoCodec.AudioCodec-Group
but FrenchTrackerMixin was producing:
  ...Source.HDR.AudioCodec.VideoCodec-Group

Add AUDIO_BEFORE_VIDEO class attribute (default True) to FrenchTrackerMixin.get_name() with a local _av() helper that respects the flag. Set AUDIO_BEFORE_VIDEO = False on TORR9 so only TORR9 names swap the order; all other French trackers (C411, HDF, GF, NST, G3MINI, TOS, NXM) keep the existing audio-first order unchanged.

Tests: add TestTorr9VideoBeforeAudio to verify video codec precedes audio for ENCODE and WEBDL types, and that the class attribute is explicitly False.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configurable audio/video codec ordering in release name generation across trackers.
  * TORR9 tracker now displays video codec before audio in release names.

* **Tests**
  * Added test suite validating TORR9 release name audio/video ordering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yippee0903/Upload-Assistant/pull/228?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->