### PR TITLE
fix: four bug fixes — TV pack NFO torrent, accent normalization, NOTA…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 > **⚠️ This is a fork of [Upload Assistant](https://github.com/Audionut/Upload-Assistant), originally created by [Audionut](https://github.com/Audionut) and [L4G](https://github.com/L4GSP1KE).**
 >
-> This fork contains **experimental features** and is primarily focused on adding **compatibility with French trackers**: C411, TORR9, G3MINI, NST, TOS, NXM. HDF and GF are also included but not recommended since there are known issues with their implementation. 
+> This fork contains **experimental features** and is primarily focused on adding **compatibility with French trackers**: C411, TORR9, G3MINI, NST, TOS, NXM. HDF and GF are also included but not recommended since there are known issues with their implementation.
 >
 > For the original project, please refer to the [upstream repository](https://github.com/Audionut/Upload-Assistant).
 

--- a/src/audio.py
+++ b/src/audio.py
@@ -496,8 +496,16 @@ async def _get_audio_v2(
                     has_audiodesc = False
                     has_compatibility = False
                     has_coms = [t for t in tracks if "commentary" in str(t.get("Title") or "").lower()]
-                    has_ad = [t for t in tracks if AD_TRACK_RE.search(str(t.get("Title") or ""))]
                     has_compat = [t for t in tracks if "compatibility" in str(t.get("Title") or "").lower()]
+                    # Scope AD detection to Audio-typed, non-commentary, non-compat
+                    # tracks so that an "Audio Description commentary" does not
+                    # falsely trigger the AD-only flag.
+                    _non_special_audio = [
+                        t
+                        for t in tracks
+                        if t.get("@type") == "Audio" and "commentary" not in str(t.get("Title") or "").lower() and "compatibility" not in str(t.get("Title") or "").lower()
+                    ]
+                    has_ad = [t for t in _non_special_audio if AD_TRACK_RE.search(str(t.get("Title") or ""))]
                     if has_coms:
                         has_commentary = True
                     if has_ad:
@@ -508,19 +516,13 @@ async def _get_audio_v2(
                         console.print(f"DEBUG: Found {len(has_coms)} commentary tracks, has_commentary = {has_commentary}")
                         console.print(f"DEBUG: Found {len(has_ad)} audio description, has_audiodesc = {has_audiodesc}")
                         console.print(f"DEBUG: Found {len(has_compat)} compatibility tracks, has_compatibility = {has_compatibility}")
-                    audio_tracks = [
-                        t
-                        for t in tracks
-                        if t.get("@type") == "Audio"
-                        and "commentary" not in str(t.get("Title") or "").lower()
-                        and "compatibility" not in str(t.get("Title") or "").lower()
-                        and not AD_TRACK_RE.search(str(t.get("Title") or ""))
-                    ]
-                    # If every non-commentary/non-compat audio track is an AD
-                    # track the release is almost certainly mis-identified; flag
-                    # it so the caller can warn the user and skip unattended uploads.
+                    audio_tracks = [t for t in _non_special_audio if not AD_TRACK_RE.search(str(t.get("Title") or ""))]
+                    # Explicitly set/clear ad_only_audio so stale values from a
+                    # previous gather_prep run cannot carry over and block uploads.
                     if has_ad and not audio_tracks:
                         meta["ad_only_audio"] = True
+                    else:
+                        meta["ad_only_audio"] = False
                     audio_language = None
                     if meta["debug"]:
                         console.print(f"DEBUG: Audio Tracks (not commentary)= {len(audio_tracks)}")

--- a/src/audio.py
+++ b/src/audio.py
@@ -516,6 +516,11 @@ async def _get_audio_v2(
                         and "compatibility" not in str(t.get("Title") or "").lower()
                         and not AD_TRACK_RE.search(str(t.get("Title") or ""))
                     ]
+                    # If every non-commentary/non-compat audio track is an AD
+                    # track the release is almost certainly mis-identified; flag
+                    # it so the caller can warn the user and skip unattended uploads.
+                    if has_ad and not audio_tracks:
+                        meta["ad_only_audio"] = True
                     audio_language = None
                     if meta["debug"]:
                         console.print(f"DEBUG: Audio Tracks (not commentary)= {len(audio_tracks)}")

--- a/src/tags.py
+++ b/src/tags.py
@@ -40,7 +40,14 @@ async def get_tag(video: str, meta: dict[str, Any], season_pack_check: bool = Fa
             # If video is a directory, use the directory name as basename
             basename_stripped = os.path.basename(os.path.normpath(video))
         elif (meta.get("tv_pack", False) or meta.get("keep_folder", False)) and not season_pack_check:
-            basename_stripped = meta["uuid"]
+            # For TV packs: use the parent folder name as the primary tag source.
+            # When the folder itself carries no group tag (e.g. "Bon Appetit Your
+            # Majesty/"), the episode filename is tried as a fallback so that
+            # releases where only the per-episode filenames carry a tag are not
+            # incorrectly labelled NOTAG.
+            _tv_parent = os.path.dirname(video) if not os.path.isdir(video) else video
+            _tv_folder = os.path.basename(os.path.normpath(_tv_parent)) if _tv_parent else ""
+            basename_stripped = _tv_folder if _tv_folder else meta["uuid"]
         else:
             # If video is a file, use the filename without extension
             basename_no_path = os.path.basename(video)
@@ -60,6 +67,27 @@ async def get_tag(video: str, meta: dict[str, Any], season_pack_check: bool = Fa
                 release_group = None
             if meta["debug"]:
                 console.print(f"Non-anime regex match: {release_group}")
+
+        # If the folder name yielded no tag for a TV-pack file, retry with the
+        # episode filename itself (the group tag may live on individual files, not
+        # on the parent folder — e.g. "Bon Appetit Your Majesty/…-FW.mkv").
+        if not release_group and not os.path.isdir(video) and (meta.get("tv_pack", False) or meta.get("keep_folder", False)) and not season_pack_check:
+            _fb_basename = os.path.basename(video)
+            _fb_name, _fb_ext = os.path.splitext(_fb_basename)
+            _fb_stripped = _fb_basename if _fb_ext and "-" in _fb_ext else _fb_name
+            _fb_match = re.search(
+                r"(?<=-)((?<!WEB-)(?<!Blu-)(?!\s*(?:WEB-DL|Blu-ray|H-264|H-265))(?:\W|\b)(?!(?:\d{3,4}[ip]))(?!\d+\b)(?:\W|\b)([\w .]+?))(?:\[.+\])?(?:\))?(?:\s\[.+\])?$",
+                _fb_stripped,
+                re.IGNORECASE,
+            )
+            if _fb_match:
+                release_group = _fb_match.group(1).strip()
+                if "Z0N3" in release_group:
+                    release_group = release_group.replace("Z0N3", "D-Z0N3")
+                if not meta.get("scene", False) and release_group and len(release_group) > 25:
+                    release_group = None
+                if meta["debug"]:
+                    console.print(f"TV-pack file-fallback tag: {release_group}")
 
     # If regex patterns didn't work, fall back to guessit
     if not release_group and meta.get("is_disc"):

--- a/src/torrentcreate.py
+++ b/src/torrentcreate.py
@@ -229,8 +229,18 @@ class TorrentCreator:
                             _kf_video = [f"{_kf_folder_name}/{os.path.relpath(f, _kf_path_dir)}" for f in _kf_filelist]
                             include = _kf_video + ["*.nfo"]
                         else:
-                            # No explicit filelist – fall back to extension globs to avoid an NFO-only torrent.
-                            include = ["*.mkv", "*.mp4", "*.ts", "*.nfo"]
+                            # No explicit filelist – walk the tree so nested episode
+                            # folders are included, not just top-level files.
+                            _kf_discovered: list[str] = []
+                            _video_exts = {".mkv", ".mp4", ".ts"}
+                            for _root, _dirs, _fnames in os.walk(_kf_path_dir):
+                                _dirs.sort()
+                                for _fname in sorted(_fnames):
+                                    _ext = os.path.splitext(_fname)[1].lower()
+                                    if _ext in _video_exts or _fname.lower().endswith(".nfo"):
+                                        _abs = os.path.join(_root, _fname)
+                                        _kf_discovered.append(f"{_kf_folder_name}/{os.path.relpath(_abs, _kf_path_dir)}")
+                            include = _kf_discovered if _kf_discovered else ["*.mkv", "*.mp4", "*.ts", "*.nfo"]
                         exclude = ["*.*"]
                     elif not meta.get("tv_pack", False):
                         folder_name = os.path.basename(str(path))
@@ -247,8 +257,18 @@ class TorrentCreator:
                             _nfo_video = [f"{_nfo_folder_name}/{os.path.relpath(f, _nfo_path_dir)}" for f in _nfo_filelist]
                             include = _nfo_video + ["*.nfo"]
                         else:
-                            # No explicit filelist – fall back to extension globs to avoid an NFO-only torrent.
-                            include = ["*.mkv", "*.mp4", "*.ts", "*.nfo"]
+                            # No explicit filelist – walk the tree so nested episode
+                            # folders are included, not just top-level files.
+                            _nfo_discovered: list[str] = []
+                            _video_exts_nfo = {".mkv", ".mp4", ".ts"}
+                            for _root, _dirs, _fnames in os.walk(_nfo_path_dir):
+                                _dirs.sort()
+                                for _fname in sorted(_fnames):
+                                    _ext = os.path.splitext(_fname)[1].lower()
+                                    if _ext in _video_exts_nfo or _fname.lower().endswith(".nfo"):
+                                        _abs = os.path.join(_root, _fname)
+                                        _nfo_discovered.append(f"{_nfo_folder_name}/{os.path.relpath(_abs, _nfo_path_dir)}")
+                            include = _nfo_discovered if _nfo_discovered else ["*.mkv", "*.mp4", "*.ts", "*.nfo"]
                         exclude = ["*.*"]
                     elif meta.get("is_disc", False):
                         include = []

--- a/src/torrentcreate.py
+++ b/src/torrentcreate.py
@@ -224,8 +224,13 @@ class TorrentCreator:
                         console.print("NFO files detected or requested. Including NFO files in torrent.")
                         _kf_path_dir = os.fspath(path)
                         _kf_folder_name = os.path.basename(_kf_path_dir)
-                        _kf_video = [f"{_kf_folder_name}/{os.path.relpath(f, _kf_path_dir)}" for f in meta.get("filelist") or []]
-                        include = _kf_video + ["*.nfo"]
+                        _kf_filelist = meta.get("filelist") or []
+                        if _kf_filelist:
+                            _kf_video = [f"{_kf_folder_name}/{os.path.relpath(f, _kf_path_dir)}" for f in _kf_filelist]
+                            include = _kf_video + ["*.nfo"]
+                        else:
+                            # No explicit filelist – fall back to extension globs to avoid an NFO-only torrent.
+                            include = ["*.mkv", "*.mp4", "*.ts", "*.nfo"]
                         exclude = ["*.*"]
                     elif not meta.get("tv_pack", False):
                         folder_name = os.path.basename(str(path))
@@ -237,8 +242,13 @@ class TorrentCreator:
                         console.print("NFO files detected or requested. Including NFO files in torrent.")
                         _nfo_path_dir = os.fspath(path)
                         _nfo_folder_name = os.path.basename(_nfo_path_dir)
-                        _nfo_video = [f"{_nfo_folder_name}/{os.path.relpath(f, _nfo_path_dir)}" for f in meta.get("filelist") or []]
-                        include = _nfo_video + ["*.nfo"]
+                        _nfo_filelist = meta.get("filelist") or []
+                        if _nfo_filelist:
+                            _nfo_video = [f"{_nfo_folder_name}/{os.path.relpath(f, _nfo_path_dir)}" for f in _nfo_filelist]
+                            include = _nfo_video + ["*.nfo"]
+                        else:
+                            # No explicit filelist – fall back to extension globs to avoid an NFO-only torrent.
+                            include = ["*.mkv", "*.mp4", "*.ts", "*.nfo"]
                         exclude = ["*.*"]
                     elif meta.get("is_disc", False):
                         include = []

--- a/src/trackers/FRENCH.py
+++ b/src/trackers/FRENCH.py
@@ -1139,6 +1139,14 @@ class FrenchTrackerMixin:
         the apostrophe becomes a space while preserving the original case:
         ``l'autre`` → ``l autre``, ``L'Ordre`` → ``L Ordre``.
         """
+        import unicodedata
+
+        # Normalise to NFC first so that combining-character sequences
+        # (e.g. U+0065 U+0301 for "é") are collapsed into their
+        # precomposed form before unidecode sees them.  Without this,
+        # unidecode turns the bare combining accent (U+0301) into an
+        # empty string, silently dropping the following vowel.
+        text = unicodedata.normalize("NFC", text)
         for char, repl in FrenchTrackerMixin._TITLE_CHAR_MAP.items():
             text = text.replace(char, repl)
         text = unidecode(text)

--- a/src/trackersetup.py
+++ b/src/trackersetup.py
@@ -1505,4 +1505,12 @@ def determine_keep_nfo(meta: dict, tracker_status: dict, target_trackers: list) 
             return True
         _recursive = [p for p in glob.glob(os.path.join(content_path_str, "**", "*"), recursive=True) if os.path.basename(p).lower().endswith(".nfo")]
         return bool(_recursive)
-    return os.path.isfile(os.path.splitext(content_path_str)[0] + ".nfo")
+    # Single-file: check for a sidecar NFO with the same stem, case-insensitively.
+    _stem = os.path.splitext(content_path_str)[0]
+    _base_stem = os.path.basename(_stem)
+    _sib_dir = os.path.dirname(content_path_str)
+    return (
+        any(os.path.splitext(f)[0] == _base_stem and os.path.splitext(f)[1].lower() == ".nfo" for f in os.listdir(_sib_dir) if os.path.isfile(os.path.join(_sib_dir, f)))
+        if os.path.isdir(_sib_dir)
+        else False
+    )

--- a/src/trackersetup.py
+++ b/src/trackersetup.py
@@ -1492,7 +1492,11 @@ def determine_keep_nfo(meta: dict, tracker_status: dict, target_trackers: list) 
     if not auto_nfo_confirmed:
         return False
 
+    import glob
+
     content_path_str = str(meta.get("path", ""))
     if os.path.isdir(content_path_str):
-        return any(f.lower().endswith(".nfo") for f in os.listdir(content_path_str))
+        # Search top-level first (fast), then recurse into sub-directories so
+        # that TV packs with episode-level NFOs are also detected.
+        return bool(glob.glob(os.path.join(content_path_str, "*.nfo")) or glob.glob(os.path.join(content_path_str, "**", "*.nfo"), recursive=True))
     return os.path.isfile(os.path.splitext(content_path_str)[0] + ".nfo")

--- a/src/trackersetup.py
+++ b/src/trackersetup.py
@@ -1498,5 +1498,11 @@ def determine_keep_nfo(meta: dict, tracker_status: dict, target_trackers: list) 
     if os.path.isdir(content_path_str):
         # Search top-level first (fast), then recurse into sub-directories so
         # that TV packs with episode-level NFOs are also detected.
-        return bool(glob.glob(os.path.join(content_path_str, "*.nfo")) or glob.glob(os.path.join(content_path_str, "**", "*.nfo"), recursive=True))
+        # Post-filter with .lower() to catch ".NFO" / ".Nfo" on case-sensitive
+        # filesystems (glob patterns are case-sensitive on Linux).
+        _top = [p for p in glob.glob(os.path.join(content_path_str, "*")) if os.path.basename(p).lower().endswith(".nfo")]
+        if _top:
+            return True
+        _recursive = [p for p in glob.glob(os.path.join(content_path_str, "**", "*"), recursive=True) if os.path.basename(p).lower().endswith(".nfo")]
+        return bool(_recursive)
     return os.path.isfile(os.path.splitext(content_path_str)[0] + ".nfo")

--- a/tests/test_fr_nfc.py
+++ b/tests/test_fr_nfc.py
@@ -1,0 +1,52 @@
+# Tests for _fr_clean NFC normalization regression
+"""
+Regression for Bug: "Bon Appétit" → "Bon.Apptit" when TMDB provides the
+title in NFD form (e.g. U+0065 + combining accent U+0301) instead of the
+precomposed NFC form (U+00E9).
+
+Before the fix, unidecode() would see the bare combining accent U+0301 and
+return an empty string for it, silently dropping the following vowel:
+    NFD: 'e' + U+0301 → unidecode(U+0301) == '' → 'App' + '' + 'tit'
+
+After the fix, the first line of _fr_clean() normalises to NFC so that
+both inputs produce the same "Appetit".
+"""
+
+import unicodedata
+
+
+class TestFrCleanNFC:
+    """_fr_clean must produce the same output for NFC and NFD input."""
+
+    def test_bon_appetit_nfc(self):
+        from src.trackers.FRENCH import FrenchTrackerMixin
+
+        nfc = "Bon App\u00e9tit Your Majesty"
+        result = FrenchTrackerMixin._fr_clean(nfc)
+        assert "Appetit" in result, f"Expected 'Appetit' in {result!r}"
+        assert "Apptit" not in result, f"Got broken 'Apptit' in {result!r}"
+
+    def test_bon_appetit_nfd(self):
+        """NFD form (combining accent) must produce the same result as NFC."""
+        from src.trackers.FRENCH import FrenchTrackerMixin
+
+        nfd = unicodedata.normalize("NFD", "Bon App\u00e9tit Your Majesty")
+        result = FrenchTrackerMixin._fr_clean(nfd)
+        assert "Appetit" in result, f"Expected 'Appetit' in {result!r} (NFD input)"
+        assert "Apptit" not in result, f"Got broken 'Apptit' in {result!r} (NFD input)"
+
+    def test_nfc_nfd_produce_same_output(self):
+        """NFC and NFD forms of the same string must produce identical output."""
+        from src.trackers.FRENCH import FrenchTrackerMixin
+
+        title = "Naïve Café Résumé"
+        nfc = unicodedata.normalize("NFC", title)
+        nfd = unicodedata.normalize("NFD", title)
+        assert FrenchTrackerMixin._fr_clean(nfc) == FrenchTrackerMixin._fr_clean(nfd)
+
+    def test_plain_ascii_unchanged(self):
+        """Pure ASCII input must still pass through without corruption."""
+        from src.trackers.FRENCH import FrenchTrackerMixin
+
+        result = FrenchTrackerMixin._fr_clean("The Dark Knight")
+        assert result == "The Dark Knight", f"Got {result!r}"

--- a/tests/test_french_audio_desc.py
+++ b/tests/test_french_audio_desc.py
@@ -244,4 +244,3 @@ class TestFrenchAudioDescriptionAcrossTrackers:
             ], [_sub_track("fr")]),
         )
         assert _run(tracker._build_audio_string(meta)) == "AD.VOSTFR"
-

--- a/tests/test_keep_nfo_empty_filelist.py
+++ b/tests/test_keep_nfo_empty_filelist.py
@@ -157,5 +157,6 @@ class TestKeepNfoEmptyFilelist:
             mkv_files = [n for n in names if n.endswith(".mkv")]
             nfo_files = [n for n in names if n.endswith(".nfo")]
 
-            assert len(mkv_files) == 2, f"Expected 2 nested MKV files, got: {names}"
-            assert len(nfo_files) == 1, f"Expected 1 NFO file, got: {names}"
+            assert any(n.endswith("Season 01/Show.S01E01.mkv") for n in mkv_files), f"S01E01 not found in: {names}"
+            assert any(n.endswith("Season 01/Show.S01E02.mkv") for n in mkv_files), f"S01E02 not found in: {names}"
+            assert any(n.endswith(f"{pack_name}.nfo") for n in nfo_files), f"NFO not found in: {names}"

--- a/tests/test_keep_nfo_empty_filelist.py
+++ b/tests/test_keep_nfo_empty_filelist.py
@@ -1,0 +1,106 @@
+# Tests for torrentcreate.py keep_nfo + empty filelist regression
+"""
+Regression for Bug: Chicago.Fire.S12 TV pack results in NFO-only torrent
+when meta["filelist"] is empty.
+
+Before the fix, the keep_nfo branch built:
+    include = [] + ["*.nfo"]   →  only NFO included
+    exclude = ["*.*"]          →  all other extensions excluded
+
+After the fix, when filelist is empty the branch falls back to extension
+globs so that all video files + NFO are included.
+"""
+
+import asyncio
+import os
+import tempfile
+import uuid
+from pathlib import Path
+
+import pytest
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _make_pack(tmpdir: str) -> tuple[str, list[str]]:
+    """Create a minimal TV-pack directory with two MKVs and one NFO."""
+    pack_dir = os.path.join(tmpdir, "Chicago.Fire.S12.MULTi.1080p.WEB.H264-FW")
+    os.makedirs(pack_dir)
+    files = []
+    for name in ("Chicago.Fire.S12E01.mkv", "Chicago.Fire.S12E02.mkv"):
+        fpath = os.path.join(pack_dir, name)
+        with open(fpath, "wb") as fh:
+            fh.write(b"x" * 1024)
+        files.append(fpath)
+    with open(os.path.join(pack_dir, "Chicago.Fire.S12.nfo"), "w") as fh:
+        fh.write("NFO")
+    return pack_dir, files
+
+
+def _base_meta(tmpdir: str, pack_dir: str, filelist: list) -> dict:
+    run_uuid = str(uuid.uuid4())
+    tmp_dir = os.path.join(tmpdir, "tmp", run_uuid)
+    os.makedirs(tmp_dir)
+    return {
+        "uuid": run_uuid,
+        "base_dir": tmpdir,
+        "tv_pack": 1,
+        "isdir": True,
+        "is_disc": False,
+        "keep_folder": False,
+        "keep_nfo": True,
+        "path": pack_dir,
+        "filelist": filelist,
+        "mkbrr": False,
+        "debug": False,
+        "max_piece_size": 0,
+        "bloated_trackers": [],
+    }
+
+
+class TestKeepNfoEmptyFilelist:
+    """keep_nfo=True with empty filelist must fall back to extension globs."""
+
+    def test_empty_filelist_includes_video_files(self):
+        """Regression: empty filelist must NOT produce an NFO-only torrent."""
+        from src.torrentcreate import TorrentCreator
+        from torf import Torrent
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pack_dir, _ = _make_pack(tmpdir)
+            meta = _base_meta(tmpdir, pack_dir, filelist=[])
+            _run(TorrentCreator.create_torrent(meta, Path(pack_dir), "BASE"))
+
+            torrent_path = os.path.join(tmpdir, "tmp", meta["uuid"], "BASE.torrent")
+            assert os.path.exists(torrent_path), "BASE.torrent was not created"
+
+            t = Torrent.read(torrent_path)
+            names = [str(f) for f in t.files]
+            mkv_files = [n for n in names if n.endswith(".mkv")]
+            nfo_files = [n for n in names if n.endswith(".nfo")]
+
+            assert len(mkv_files) == 2, f"Expected 2 MKV files, got: {names}"
+            assert len(nfo_files) == 1, f"Expected 1 NFO file, got: {names}"
+
+    def test_populated_filelist_includes_video_files(self):
+        """Sanity: populated filelist must still include all video files + NFO."""
+        from src.torrentcreate import TorrentCreator
+        from torf import Torrent
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pack_dir, real_files = _make_pack(tmpdir)
+            meta = _base_meta(tmpdir, pack_dir, filelist=real_files)
+            _run(TorrentCreator.create_torrent(meta, Path(pack_dir), "BASE"))
+
+            torrent_path = os.path.join(tmpdir, "tmp", meta["uuid"], "BASE.torrent")
+            assert os.path.exists(torrent_path), "BASE.torrent was not created"
+
+            t = Torrent.read(torrent_path)
+            names = [str(f) for f in t.files]
+            mkv_files = [n for n in names if n.endswith(".mkv")]
+            nfo_files = [n for n in names if n.endswith(".nfo")]
+
+            assert len(mkv_files) == 2, f"Expected 2 MKV files, got: {names}"
+            assert len(nfo_files) == 1, f"Expected 1 NFO file, got: {names}"

--- a/tests/test_keep_nfo_empty_filelist.py
+++ b/tests/test_keep_nfo_empty_filelist.py
@@ -104,3 +104,58 @@ class TestKeepNfoEmptyFilelist:
 
             assert len(mkv_files) == 2, f"Expected 2 MKV files, got: {names}"
             assert len(nfo_files) == 1, f"Expected 1 NFO file, got: {names}"
+
+    def test_empty_filelist_nested_episodes_included(self):
+        """Regression: MKV files inside a Season sub-folder must be in the torrent.
+
+        Before the recursive-walk fix, the flat extension glob ``*.mkv`` only
+        matched top-level files, so episode files placed under a ``Season 01/``
+        sub-directory were silently omitted from the torrent.
+        """
+        from src.torrentcreate import TorrentCreator
+        from torf import Torrent
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pack_name = "Show.S01.1080p.WEB.H264-GRP"
+            pack_dir = os.path.join(tmpdir, pack_name)
+            season_dir = os.path.join(pack_dir, "Season 01")
+            os.makedirs(season_dir)
+
+            for name in ("Show.S01E01.mkv", "Show.S01E02.mkv"):
+                with open(os.path.join(season_dir, name), "wb") as fh:
+                    fh.write(b"x" * 512)
+
+            with open(os.path.join(pack_dir, f"{pack_name}.nfo"), "w") as fh:
+                fh.write("NFO")
+
+            run_uuid = str(uuid.uuid4())
+            tmp_dir = os.path.join(tmpdir, "tmp", run_uuid)
+            os.makedirs(tmp_dir)
+            meta = {
+                "uuid": run_uuid,
+                "base_dir": tmpdir,
+                "tv_pack": 1,
+                "isdir": True,
+                "is_disc": False,
+                "keep_folder": False,
+                "keep_nfo": True,
+                "path": pack_dir,
+                "filelist": [],
+                "mkbrr": False,
+                "debug": False,
+                "max_piece_size": 0,
+                "bloated_trackers": [],
+            }
+
+            _run(TorrentCreator.create_torrent(meta, Path(pack_dir), "BASE"))
+
+            torrent_path = os.path.join(tmp_dir, "BASE.torrent")
+            assert os.path.exists(torrent_path), "BASE.torrent was not created"
+
+            t = Torrent.read(torrent_path)
+            names = [str(f) for f in t.files]
+            mkv_files = [n for n in names if n.endswith(".mkv")]
+            nfo_files = [n for n in names if n.endswith(".nfo")]
+
+            assert len(mkv_files) == 2, f"Expected 2 nested MKV files, got: {names}"
+            assert len(nfo_files) == 1, f"Expected 1 NFO file, got: {names}"

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -183,3 +183,54 @@ class TestGetTagRealGroups:
     def test_web_no_hyphen_group(self):
         tag = _run(get_tag("Movie.2023.1080p.WEB.AAC.x264-FRGRP.mkv", _meta()))
         assert tag == "-FRGRP", f"Expected -FRGRP, got {tag!r}"
+
+
+# ═══════════════════════════════════════════════════════════════
+#  TV-pack tag: folder has no group tag but files do
+#  Regression for the NOTAG bug where tv_pack path fell back to
+#  meta["uuid"] instead of trying the episode filename.
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestGetTagTVPackFallback:
+    """TV packs: fall back to the episode filename when folder has no tag."""
+
+    def test_folder_no_tag_file_has_group(self):
+        """Bug: folder name has no tag → should extract group from episode file."""
+        tag = _run(
+            get_tag(
+                "/downloads/Bon Appetit Your Majesty/S01E01.1080p.WEB-DL.AAC.2.0.H.264-FW.mkv",
+                _meta(tv_pack=1),
+            )
+        )
+        assert tag == "-FW", f"Expected -FW, got {tag!r}"
+
+    def test_folder_has_tag_is_preferred(self):
+        """When the folder itself carries the tag, that takes precedence."""
+        tag = _run(
+            get_tag(
+                "/downloads/Chicago.Fire.S12.MULTi.1080p.WEB.H264-FW/E01.mkv",
+                _meta(tv_pack=1),
+            )
+        )
+        assert tag == "-FW", f"Expected -FW, got {tag!r}"
+
+    def test_no_tag_on_folder_or_file_returns_empty(self):
+        """No tag on either folder or file → empty tag."""
+        tag = _run(
+            get_tag(
+                "/downloads/Show S01/Episode01.1080p.WEB.mkv",
+                _meta(tv_pack=1),
+            )
+        )
+        assert tag == "", f"Expected empty tag, got {tag!r}"
+
+    def test_keep_folder_fallback(self):
+        """Same fallback applies when keep_folder is set instead of tv_pack."""
+        tag = _run(
+            get_tag(
+                "/downloads/Movie Collection/Movie.2024.1080p.BluRay.x264-CREW.mkv",
+                _meta(keep_folder=True),
+            )
+        )
+        assert tag == "-CREW", f"Expected -CREW, got {tag!r}"

--- a/upload.py
+++ b/upload.py
@@ -1296,11 +1296,18 @@ async def process_meta(meta: Meta, base_dir: str, bot: Any = None) -> Optional[b
                 if not has_nfo:
                     # Check if there actually are NFO files on disk
                     content_path = str(meta.get("path", ""))
-                    nfo_on_disk = (
-                        bool(glob.glob(os.path.join(content_path, "*.nfo")) or glob.glob(os.path.join(content_path, "**", "*.nfo"), recursive=True))
-                        if os.path.isdir(content_path)
-                        else False
-                    )
+                    if os.path.isdir(content_path):
+                        # Case-insensitive post-filter mirrors determine_keep_nfo().
+                        _top_nfo = [p for p in glob.glob(os.path.join(content_path, "*")) if os.path.basename(p).lower().endswith(".nfo")]
+                        _rec_nfo = (
+                            [p for p in glob.glob(os.path.join(content_path, "**", "*"), recursive=True) if os.path.basename(p).lower().endswith(".nfo")]
+                            if not _top_nfo
+                            else []
+                        )
+                        nfo_on_disk = bool(_top_nfo or _rec_nfo)
+                    else:
+                        # Single-file upload: check for a sidecar .nfo with the same stem.
+                        nfo_on_disk = os.path.isfile(os.path.splitext(content_path)[0] + ".nfo")
                     if nfo_on_disk:
                         console.print("[yellow]BASE.torrent is missing NFO files required by --keep-nfo. Removing stale torrent...[/yellow]")
                         os.remove(torrent_path)

--- a/upload.py
+++ b/upload.py
@@ -4,6 +4,7 @@ import asyncio
 import contextlib
 import filecmp
 import gc
+import glob
 import json
 import os
 import platform
@@ -501,6 +502,28 @@ async def process_meta(meta: Meta, base_dir: str, bot: Any = None) -> Optional[b
         await nfo_link_manager.nfo_link(meta)
         meta["we_are_uploading"] = False
         return
+
+    # Warn when the release appears to have ONLY Audio Description tracks.
+    # AD tracks are accessibility-only audio for visually impaired viewers;
+    # uploading them as if they were the main audio is almost always wrong.
+    if meta.get("ad_only_audio", False):
+        console.print("[bold yellow]⚠  WARNING: This release appears to contain ONLY Audio Description (AD) audio.[/bold yellow]")
+        console.print("[yellow]AD tracks are accessibility audio for visually impaired viewers — not the main programme audio.[/yellow]")
+        if meta.get("unattended", False):
+            console.print("[yellow]Unattended mode: skipping upload (AD-only audio).[/yellow]")
+            meta["we_are_uploading"] = False
+            return
+        try:
+            ad_confirm = cli_ui.ask_yes_no("Proceed with AD-only audio upload?", default=False)
+        except EOFError:
+            console.print("\n[red]Exiting on user request (Ctrl+C)[/red]")
+            await cleanup_manager.cleanup()
+            cleanup_manager.reset_terminal()
+            sys.exit(1)
+        if not ad_confirm:
+            console.print("[red]Upload cancelled due to AD-only audio.[/red]")
+            meta["we_are_uploading"] = False
+            return
 
     parser = Args(config)
     helper = UploadHelper(config)
@@ -1273,7 +1296,11 @@ async def process_meta(meta: Meta, base_dir: str, bot: Any = None) -> Optional[b
                 if not has_nfo:
                     # Check if there actually are NFO files on disk
                     content_path = str(meta.get("path", ""))
-                    nfo_on_disk = any(f.lower().endswith(".nfo") for f in os.listdir(content_path)) if os.path.isdir(content_path) else False
+                    nfo_on_disk = (
+                        bool(glob.glob(os.path.join(content_path, "*.nfo")) or glob.glob(os.path.join(content_path, "**", "*.nfo"), recursive=True))
+                        if os.path.isdir(content_path)
+                        else False
+                    )
                     if nfo_on_disk:
                         console.print("[yellow]BASE.torrent is missing NFO files required by --keep-nfo. Removing stale torrent...[/yellow]")
                         os.remove(torrent_path)

--- a/upload.py
+++ b/upload.py
@@ -1306,8 +1306,20 @@ async def process_meta(meta: Meta, base_dir: str, bot: Any = None) -> Optional[b
                         )
                         nfo_on_disk = bool(_top_nfo or _rec_nfo)
                     else:
-                        # Single-file upload: check for a sidecar .nfo with the same stem.
-                        nfo_on_disk = os.path.isfile(os.path.splitext(content_path)[0] + ".nfo")
+                        # Single-file upload: check for a sidecar NFO with the
+                        # same stem, case-insensitively (catches .NFO / .Nfo).
+                        _stem = os.path.splitext(content_path)[0]
+                        _base_stem = os.path.basename(_stem)
+                        _sib_dir = os.path.dirname(content_path)
+                        nfo_on_disk = (
+                            any(
+                                os.path.splitext(f)[0] == _base_stem and os.path.splitext(f)[1].lower() == ".nfo"
+                                for f in os.listdir(_sib_dir)
+                                if os.path.isfile(os.path.join(_sib_dir, f))
+                            )
+                            if os.path.isdir(_sib_dir)
+                            else False
+                        )
                     if nfo_on_disk:
                         console.print("[yellow]BASE.torrent is missing NFO files required by --keep-nfo. Removing stale torrent...[/yellow]")
                         os.remove(torrent_path)


### PR DESCRIPTION
…G fallback, AD-only audio

Bug 1 – NFO-only torrent (torrentcreate.py, trackersetup.py, upload.py)
  - keep_nfo branch with empty filelist fell back to include=['*.nfo'] only; fix: fall back to extension globs (*.mkv, *.mp4, *.ts, *.nfo) when filelist is empty.
  - determine_keep_nfo() used os.listdir() (non-recursive); fix: use glob with recursive=True so NFO files in TV-pack episode sub-folders are detected.
  - Stale BASE.torrent check in upload.py had the same os.listdir() deficiency; replaced with the same recursive glob pattern.

Bug 2 – 'Bon Appétit' → 'Bon.Apptit' in _fr_clean (trackers/FRENCH.py)
  - TMDB sometimes returns titles in NFD unicode form (combining accents). unidecode() turned the bare combining accent U+0301 into '' silently.
  - Fix: add unicodedata.normalize('NFC', text) as the very first step of _fr_clean() so that both NFC and NFD inputs produce the same output.

Bug 2b – NOTAG when TV-pack folder has no group tag (tags.py)
  - tv_pack path used meta['uuid'] as basename_stripped → regex never matched.
  - Fix: use the parent folder name first; if that yields no tag AND the release is a tv_pack or keep_folder file, retry with the episode filename as a fallback so that per-episode group tags are correctly detected.

Bug 3 – AD-only audio: warn + skip in unattended mode (audio.py, upload.py)
  - When every non-commentary/non-compat audio track is an Audio Description track, meta['ad_only_audio'] = True is set in _get_audio_v2().
  - upload.py checks the flag early: prints a prominent warning, skips automatically in unattended mode, and prompts for confirmation otherwise.

Tests: added TestGetTagTVPackFallback (test_tags.py), TestFrCleanNFC (test_fr_nfc.py), TestKeepNfoEmptyFilelist (test_keep_nfo_empty_filelist.py). 1278 passed, 1 skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audio-description–only releases are now detected; uploads require confirmation and are skipped in unattended mode
  * Improved TV-pack group-tag detection with folder→file fallback
  * Enhanced discovery of nested .nfo files for uploads and torrent creation

* **Bug Fixes**
  * French text normalization now handles Unicode NFC correctly
  * Torrent include selection corrected when metadata file lists are missing/empty

* **Tests**
  * Added regression tests for French normalization, AD handling, TV-pack tags, and .nfo detection
<!-- end of auto-generated comment: release notes by coderabbit.ai -->