### PR TITLE
fix: correct season list from guessit and add AD fallback via release…

### DIFF
--- a/src/audio.py
+++ b/src/audio.py
@@ -522,7 +522,20 @@ async def _get_audio_v2(
                     if has_ad and not audio_tracks:
                         meta["ad_only_audio"] = True
                     else:
-                        meta["ad_only_audio"] = False
+                        # Fallback: if no AD tracks were detected by title but the
+                        # release folder name contains "Audio Description" (a common
+                        # convention for ATVP/streamer releases where track Title
+                        # fields may be empty), and there is only one audio track,
+                        # treat it as AD-only so the upload is flagged.
+                        release_basename = os.path.basename(str(meta.get("path") or ""))
+                        path_has_ad = bool(AD_TRACK_RE.search(release_basename.replace(".", " ")))
+                        if path_has_ad and len(_non_special_audio) == 1:
+                            meta["ad_only_audio"] = True
+                            has_audiodesc = True
+                            if meta["debug"]:
+                                console.print(f"DEBUG: AD-only flagged via release name: {release_basename}")
+                        else:
+                            meta["ad_only_audio"] = False
                     audio_language = None
                     if meta["debug"]:
                         console.print(f"DEBUG: Audio Tracks (not commentary)= {len(audio_tracks)}")

--- a/src/audio.py
+++ b/src/audio.py
@@ -527,7 +527,7 @@ async def _get_audio_v2(
                         # convention for ATVP/streamer releases where track Title
                         # fields may be empty), and there is only one audio track,
                         # treat it as AD-only so the upload is flagged.
-                        release_basename = os.path.basename(str(meta.get("path") or ""))
+                        release_basename = os.path.basename(os.path.normpath(str(meta.get("path") or "")))
                         path_has_ad = bool(AD_TRACK_RE.search(release_basename.replace(".", " ")))
                         if path_has_ad and len(_non_special_audio) == 1:
                             meta["ad_only_audio"] = True

--- a/src/getseasonep.py
+++ b/src/getseasonep.py
@@ -89,7 +89,16 @@ class SeasonEpisodeManager:
                             guess_year = ""
                         try:
                             guess_data = _guessit_data(video)
-                            season_guess = str(guess_data.get("season") or "")
+                            raw_season = guess_data.get("season")
+                            # guessit may return a list when words like "Seasons" in the
+                            # title and a year both parse as season candidates
+                            # (e.g. "The.Four.Seasons.2025.S02" → [2025, 2]).
+                            # Normalise: strip year-valued entries and take the first remainder.
+                            if isinstance(raw_season, list):
+                                year_int = int(guess_year) if guess_year.isdigit() else None
+                                filtered = [s for s in raw_season if s != year_int]
+                                raw_season = filtered[0] if filtered else (raw_season[0] if raw_season else None)
+                            season_guess = str(raw_season or "")
                             if season_guess == guess_year:
                                 if f"s{season_guess}" in video.lower():
                                     season_int = int(season_guess)
@@ -98,7 +107,7 @@ class SeasonEpisodeManager:
                                     season_int = 1
                                     season = "S01"
                             else:
-                                season_int = int(guess_data.get("season") or 1)
+                                season_int = int(raw_season or 1)
                                 season = "S" + str(season_int).zfill(2)
                         except Exception:
                             console.print(


### PR DESCRIPTION
… name

- getseasonep: guessit may return a list for `season` when a title word like "Seasons" and a year both parse as season candidates (e.g. The.Four.Seasons.2025.S02 → [2025, 2]). Normalise by stripping the year-valued entry and taking the first remainder, so S02 is preserved instead of silently falling back to S01 via the TypeError handler.

- audio: add path-based AD-only fallback for releases where MediaInfo track Title fields are empty (common on ATVP/streamer WEB-DL). When the release folder name matches the AD_TRACK_RE pattern and there is only one non-special audio track, set ad_only_audio=True so the upload is blocked/warned in upload.py.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of audio-description-only tracks by adding a fallback scan of release folder/filename when standard title-based checks don't find AD content.
  * Enhanced TV season identification to handle titles with multiple season candidates (e.g., "Seasons" plus a year) by normalizing candidates and selecting the most appropriate season.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->