### PR TITLE
fix(cli)/chore(ai): predb tag extension, UNIT3D retry loop, TOS unattended messages, ai stuff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ data/*.json
 venv/*
 .pyright
 web_ui/static/js/node_modules/
+graphify-out/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,13 @@
+## Agent skills
+
+### Issue tracker
+
+Issues are tracked locally using the `bd` CLI (Beads). External PRs are not a triage surface. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Default label vocabulary — `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context — one `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,35 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo:
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-*.md
+│   └── 0002-*.md
+└── src/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,31 @@
+# Issue Tracker
+
+Issues for this repo are managed with **Beads** (`bd` CLI) — a lightweight local issue tracker with first-class dependency support. Issues are stored in `.beads/` and prefixed `Upload-Assistant-*`.
+
+## Key commands
+
+```bash
+bd create "Title" -d "Description"   # create an issue
+bd list                               # list open issues
+bd show <id>                          # show issue details
+bd close <id>                         # close an issue
+bd label <id> <label>                 # apply a label
+bd tag <id> <label>                   # alias for bd label
+bd comment <id> "text"                # add a comment
+bd link <id> --deps <other-id>        # add a dependency
+bd set-state <id> <state>             # update operational state
+bd query '<expr>'                     # query issues with a filter expression
+```
+
+## Workflow for skills
+
+- **Creating issues** — use `bd create` with a clear title and `-d` for description. Add `--label needs-triage` on creation unless the triage state is already known.
+- **Triaging** — use `bd label <id> <triage-label>` to move an issue through the triage state machine (see `triage-labels.md`).
+- **Closing** — use `bd close <id>` when resolved.
+- **Linking related issues** — use `bd link` to express dependencies between issues.
+
+## Notes
+
+- External PRs are **not** a triage surface for this repo.
+- The `.beads/` directory is committed to the repo — issue data travels with the code.
+- Use `bd --help` or `bd <command> --help` for full flag reference.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,19 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table and apply it with:
+
+```bash
+bd label <id> <label-string>
+```
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/src/is_scene.py
+++ b/src/is_scene.py
@@ -251,13 +251,19 @@ class SceneManager:
                                 console.print(f"[yellow]Predb: Checking {release_name} against {video_base}")
                             if release_name == video_base:
                                 found = True
-                                meta["scene_name"] = release_attr
+                                # predb stores releases with file extensions; strip them from scene_name
+                                _root, _ext = os.path.splitext(release_attr)
+                                meta["scene_name"] = _root if _ext.lower() in {".mkv", ".mp4", ".ts", ".m2ts", ".avi", ".vob", ".nfo"} else release_attr
                                 console.print("[green]Predb: Match found")
                                 # The 4th <td> contains the group
                                 if len(tds) >= 4:
                                     group_a = tds[3].find("a")
                                     if group_a:
                                         group = self._attr_to_string(group_a.get_text()).strip()
+                                        # predb sometimes includes the file extension in the group column
+                                        _g_root, _g_ext = os.path.splitext(group)
+                                        if _g_ext.lower() in {".mkv", ".mp4", ".ts", ".m2ts", ".avi", ".vob", ".nfo"}:
+                                            group = _g_root
                                         meta["tag"] = f"-{group}" if group and not group.startswith("-") else group
                                 return True
                 if not found:

--- a/src/trackers/TOS.py
+++ b/src/trackers/TOS.py
@@ -531,8 +531,9 @@ class TOS(FrenchTrackerMixin, UNIT3D):
                         bitrate_error = True
                     elif bit_rate_kbps < min_kbps:
                         label = f"{codec_key} (anime)" if is_anime else codec_key
-                        console.print(f"[bold red]{self.tracker}: Video bitrate too low: {bit_rate_kbps:.0f} kbps for {label}.[/bold red]")
-                        console.print(f"[bold yellow]Must be >= {min_kbps} kbps for {resolution}.[/bold yellow]")
+                        if not meta.get("unattended", False):
+                            console.print(f"[bold red]{self.tracker}: Video bitrate too low: {bit_rate_kbps:.0f} kbps for {label}.[/bold red]")
+                            console.print(f"[bold yellow]Must be >= {min_kbps} kbps for {resolution}.[/bold yellow]")
                         bitrate_error = True
 
         if bitrate_error:

--- a/src/trackers/TOS.py
+++ b/src/trackers/TOS.py
@@ -517,7 +517,8 @@ class TOS(FrenchTrackerMixin, UNIT3D):
                 tracks = meta.get("mediainfo", {}).get("media", {}).get("track", [])
                 video_track = next((t for t in tracks if t.get("@type") == "Video"), None)
                 if video_track is None:
-                    console.print(f"[bold red]Could not determine video bitrate from mediainfo for {self.tracker} upload.[/bold red]")
+                    if not meta.get("unattended", False):
+                        console.print(f"[bold red]Could not determine video bitrate from mediainfo for {self.tracker} upload.[/bold red]")
                     bitrate_error = True
                 else:
                     raw_br = video_track.get("BitRate")
@@ -527,7 +528,8 @@ class TOS(FrenchTrackerMixin, UNIT3D):
                         bit_rate_kbps = None
 
                     if bit_rate_kbps is None:
-                        console.print(f"[bold red]Could not determine video bitrate from mediainfo for {self.tracker} upload.[/bold red]")
+                        if not meta.get("unattended", False):
+                            console.print(f"[bold red]Could not determine video bitrate from mediainfo for {self.tracker} upload.[/bold red]")
                         bitrate_error = True
                     elif bit_rate_kbps < min_kbps:
                         label = f"{codec_key} (anime)" if is_anime else codec_key

--- a/src/trackers/ULCX.py
+++ b/src/trackers/ULCX.py
@@ -140,7 +140,8 @@ class ULCX(UNIT3D):
                 else:
                     return False
             else:
-                console.print(f"[bold red]This release contains a compatibility audio track which is not allowed at {self.tracker}. Skipping.[/bold red]")
+                if not meta.get("unattended", False):
+                    console.print(f"[bold red]This release contains a compatibility audio track which is not allowed at {self.tracker}. Skipping.[/bold red]")
                 return False
 
         if meta.get("discs_missing_certificate", []):

--- a/src/trackers/UNIT3D.py
+++ b/src/trackers/UNIT3D.py
@@ -514,6 +514,7 @@ class UNIT3D:
                         return False  # Auth/permission error
                     elif e.response.status_code in [401, 404, 422]:
                         meta["tracker_status"][self.tracker]["status_message"] = f"data error: HTTP {e.response.status_code} - {e.response.text}"
+                        return False
                     else:
                         # Retry other HTTP errors
                         if attempt < max_retries - 1:


### PR DESCRIPTION
- is_scene.py: strip file extension from predb scene_name and group before
  storing in meta. predb stores releases including the container extension
  (e.g. BYNDR.mkv), which leaked into meta["tag"] and from there into the
  C411 release name, causing "Le nom de release ne doit pas contenir
  d'extension de fichier" validation errors. (closes Upload-Assistant-a3n)

- UNIT3D.py: add return False after HTTP 401/404/422 in the upload retry
  loop. These status codes indicate terminal data-validation errors that
  cannot succeed on retry; without the early return the loop continued to
  the next attempt, wasting a request and producing confusing output.
  (closes Upload-Assistant-8ix, Upload-Assistant-1gf, Upload-Assistant-p15)

- TOS.py: guard bitrate-error console.print calls with
  not meta.get("unattended"). The error messages were printed unconditionally
  before the unattended check, so they appeared even in fully automated runs.
  (closes Upload-Assistant-lez)

- AI stuff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added agent skills and domain knowledge structure documentation
  * Added comprehensive issue tracking workflow and triage label guides

* **Bug Fixes**
  * Improved media file extension normalization in scene metadata extraction
  * Refined validation messaging behavior for unattended uploads
  * Fixed control flow in tracker error handling responses

* **Chores**
  * Updated `.gitignore` with additional directory exclusion

<!-- end of auto-generated comment: release notes by coderabbit.ai -->