### PR TITLE
chore: sync upstream/master (6 commits)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+For further development, see https://github.com/autobrr/upbrr
+
 ### NOTE:
 - This project is in development freeze. Only critical bugs will be addressed moving forward.
 - More details on the future of Upload Assistant will be available at a later date.

--- a/src/cookie_auth.py
+++ b/src/cookie_auth.py
@@ -482,6 +482,7 @@ class CookieAuthUploader:
         success_status_code: str = "",
         error_text: str = "",
         success_text: str = "",
+        success_list: Optional[list[str]] = None,
         additional_files: Optional[dict[str, Any]] = None,
         hash_is_id: bool = False,
     ) -> bool:
@@ -501,14 +502,14 @@ class CookieAuthUploader:
         A failed upload will save the response HTML for analysis and also create a torrent entry with the announce URL,
         as the upload may have partially succeeded.
         """
-        values = [success_status_code, error_text, success_text]
+        values = [success_status_code, error_text, success_text, success_list]
         count = sum(bool(v) for v in values)
 
         if count == 0 or count > 1:
             if count == 0:
-                error = "You must provide at least one of: success_status_code, error_text, or success_text."
+                error = "You must provide at least one of: success_status_code, error_text, success_text, or success_list."
             else:
-                error = "Only one of success_status_code, error_text, or success_text should be provided."
+                error = "Only one of success_status_code, error_text, success_text, or success_list should be provided."
             meta["tracker_status"][tracker]["status_message"] = error
             return False
 
@@ -541,7 +542,7 @@ class CookieAuthUploader:
                 async with httpx.AsyncClient(headers=headers, timeout=30.0, cookies=upload_cookies, follow_redirects=True) as session:
                     response = await session.post(upload_url, data=data, files=files)
 
-                    if success_text and success_text in response.text:
+                    if success_text and success_text in response.text or success_list and any(item in response.text for item in success_list):
                         success = True
 
                     elif success_status_code:
@@ -577,6 +578,7 @@ class CookieAuthUploader:
                             success_text,
                             error_text,
                             response,
+                            success_list,
                         )
                         return False
 
@@ -698,10 +700,13 @@ class CookieAuthUploader:
         success_text: str,
         error_text: str,
         response: httpx.Response,
+        success_list: Optional[list[str]] = None,
     ) -> bool:
         message = ["data error: The upload appears to have failed. It may have uploaded, go check."]
         if success_text:
             message.append(f"Could not find the success text '{success_text}' in the response.")
+        elif success_list:
+            message.append(f"Could not find any of the success strings in {success_list} in the response.")
         elif error_text:
             message.append(f"Found the error text '{error_text}' in the response.")
         elif success_status_code:

--- a/src/edition.py
+++ b/src/edition.py
@@ -20,8 +20,13 @@ async def get_edition(video: str, bdinfo: Optional[dict[str, Any]], filelist: li
     edition = ""
     imdb_info = cast(dict[str, Any], meta.get('imdb_info', {}))
     edition_details = cast(dict[str, dict[str, Any]], imdb_info.get('edition_details', {}))
+    imdb_edition_count_value = imdb_info.get('edition_count', len(edition_details))
+    try:
+        imdb_edition_count = int(imdb_edition_count_value)
+    except (TypeError, ValueError):
+        imdb_edition_count = len(edition_details)
 
-    if meta.get('category') == "MOVIE" and not meta.get('anime') and edition_details and not manual_edition:
+    if meta.get('category') == "MOVIE" and not meta.get('anime') and edition_details and imdb_edition_count > 1 and not manual_edition:
         if meta.get('is_disc') != "BDMV" and meta.get('mediainfo', {}).get('media', {}).get('track'):
                 mediainfo = cast(dict[str, Any], meta.get('mediainfo', {}))
                 tracks = cast(list[dict[str, Any]], mediainfo.get('media', {}).get('track', []))

--- a/src/edition.py
+++ b/src/edition.py
@@ -346,6 +346,12 @@ async def get_edition(video: str, bdinfo: Optional[dict[str, Any]], filelist: li
 
     edition = edition.replace(",", " ")
 
+    # Expand bare "Special" to "Special Edition" — guessit and the generic
+    # "edition" word cleanup both strip the word, but "Special" alone is
+    # incomplete in release naming ("Extended" works alone, "Special" does not).
+    if edition and edition.lower().strip() == "special":
+        edition = "Special Edition"
+
     # Handle repack info
     repack = ""
     if "REPACK" in (video.upper() or edition.upper()) or "V2" in video:
@@ -371,11 +377,17 @@ async def get_edition(video: str, bdinfo: Optional[dict[str, Any]], filelist: li
         edition = re.sub(r"(\bREPACK\d?\b|\bRERIP\b|\bPROPER\b)", "", edition, flags=re.IGNORECASE).strip()
 
     if not meta.get("webdv", False):
-        hybrid = False
+        hybrid = ""
         if "HYBRID" in video.upper() or "HYBRID" in edition.upper():
-            hybrid = True
+            hybrid = "Hybrid"
+        elif "CUSTOM" in video.upper() or "CUSTOM" in edition.upper():
+            hybrid = "Custom"
     else:
-        hybrid = meta.get("webdv", False)
+        hybrid = "Hybrid"
+
+    # Strip Hybrid/Custom from edition — they are carried by the hybrid flag
+    if hybrid:
+        edition = re.sub(r"\b(?:Hybrid|Custom)\b", "", edition, flags=re.IGNORECASE).strip()
 
     # Handle distributor info
     if edition:
@@ -394,7 +406,11 @@ async def get_edition(video: str, bdinfo: Optional[dict[str, Any]], filelist: li
                 edition = edition.replace("  ", " ")
 
         if edition != "":
-            edition = edition.strip()
+            if not manual_edition:
+                edition = re.sub(r"\b(19|20)\d{2}\b", "", edition).strip()
+                while "  " in edition:
+                    edition = edition.replace("  ", " ")
+            edition = edition.strip().upper()
             if meta["debug"]:
                 console.print(f"Final Edition: {edition}")
 

--- a/src/edition.py
+++ b/src/edition.py
@@ -18,114 +18,120 @@ def guessit_fn(value: str, options: Optional[dict[str, Any]] = None) -> dict[str
 
 async def get_edition(video: str, bdinfo: Optional[dict[str, Any]], filelist: list[str], manual_edition: Union[str, list[str]], meta: dict[str, Any]) -> tuple[str, str, bool]:
     edition = ""
-    imdb_info = cast(dict[str, Any], meta.get('imdb_info', {}))
-    edition_details = cast(dict[str, dict[str, Any]], imdb_info.get('edition_details', {}))
-    imdb_edition_count_value = imdb_info.get('edition_count', len(edition_details))
+    imdb_info = cast(dict[str, Any], meta.get("imdb_info", {}))
+    edition_details = cast(dict[str, dict[str, Any]], imdb_info.get("edition_details", {}))
+    imdb_edition_count_value = imdb_info.get("edition_count", len(edition_details))
     try:
         imdb_edition_count = int(imdb_edition_count_value)
     except (TypeError, ValueError):
         imdb_edition_count = len(edition_details)
 
-    if meta.get('category') == "MOVIE" and not meta.get('anime') and edition_details and imdb_edition_count > 1 and not manual_edition:
-        if meta.get('is_disc') != "BDMV" and meta.get('mediainfo', {}).get('media', {}).get('track'):
-                mediainfo = cast(dict[str, Any], meta.get('mediainfo', {}))
-                tracks = cast(list[dict[str, Any]], mediainfo.get('media', {}).get('track', []))
-                general_track = next((track for track in tracks if track.get('@type') == 'General'), None)
+    if meta.get("category") == "MOVIE" and not meta.get("anime") and edition_details and imdb_edition_count > 1 and not manual_edition:
+        if meta.get("is_disc") != "BDMV" and meta.get("mediainfo", {}).get("media", {}).get("track"):
+            mediainfo = cast(dict[str, Any], meta.get("mediainfo", {}))
+            tracks = cast(list[dict[str, Any]], mediainfo.get("media", {}).get("track", []))
+            general_track = next((track for track in tracks if track.get("@type") == "General"), None)
 
-                if general_track and general_track.get('Duration'):
-                    try:
-                        media_duration_seconds = float(general_track['Duration'])
-                        formatted_duration = format_duration(media_duration_seconds)
-                        if meta['debug']:
-                            console.print(f"[cyan]Found media duration: {formatted_duration} ({media_duration_seconds} seconds)[/cyan]")
+            if general_track and general_track.get("Duration"):
+                try:
+                    media_duration_seconds = float(general_track["Duration"])
+                    formatted_duration = format_duration(media_duration_seconds)
+                    if meta["debug"]:
+                        console.print(f"[cyan]Found media duration: {formatted_duration} ({media_duration_seconds} seconds)[/cyan]")
 
-                        leeway_seconds = 50
-                        matching_editions: list[dict[str, Any]] = []
+                    leeway_seconds = 50
+                    matching_editions: list[dict[str, Any]] = []
 
-                        # Find all matching editions
-                        for edition_info in edition_details.values():
-                            edition_seconds = float(edition_info.get('seconds', 0) or 0)
-                            edition_formatted = format_duration(edition_seconds)
-                            difference = abs(media_duration_seconds - edition_seconds)
+                    # Find all matching editions
+                    for edition_info in edition_details.values():
+                        edition_seconds = float(edition_info.get("seconds", 0) or 0)
+                        edition_formatted = format_duration(edition_seconds)
+                        difference = abs(media_duration_seconds - edition_seconds)
 
-                            if difference <= leeway_seconds:
-                                attributes = edition_info.get('attributes')
-                                attributes_list = cast(list[Any], attributes) if isinstance(attributes, list) else []
-                                has_attributes = bool(attributes_list)
-                                if meta['debug']:
-                                    console.print(f"[green]Potential match: {edition_info.get('display_name', '')} - duration {edition_formatted}, difference: {format_duration(difference)}[/green]")
+                        if difference <= leeway_seconds:
+                            attributes = edition_info.get("attributes")
+                            attributes_list = cast(list[Any], attributes) if isinstance(attributes, list) else []
+                            has_attributes = bool(attributes_list)
+                            if meta["debug"]:
+                                console.print(
+                                    f"[green]Potential match: {edition_info.get('display_name', '')} - duration {edition_formatted}, difference: {format_duration(difference)}[/green]"
+                                )
 
-                                if has_attributes:
-                                    edition_name = " ".join(smart_title(str(attr)) for attr in attributes_list)
+                            if has_attributes:
+                                edition_name = " ".join(smart_title(str(attr)) for attr in attributes_list)
 
-                                    matching_editions.append({
-                                        'name': edition_name,
-                                        'display_name': str(edition_info.get('display_name', '')),
-                                        'has_attributes': bool(edition_info.get('attributes') and len(edition_info['attributes']) > 0),
-                                        'minutes': edition_info.get('minutes'),
-                                        'difference': difference,
-                                        'formatted_duration': edition_formatted
-                                    })
-                                else:
-                                    if meta['debug']:
-                                        console.print("[yellow]Edition without attributes are theatrical editions and skipped[/yellow]")
-
-                        if len(matching_editions) > 1:
-                            if not meta['unattended'] or (meta['unattended'] and meta.get('unattended_confirm', False)):
-                                console.print(f"[yellow]Media file duration {formatted_duration} matches multiple editions:[/yellow]")
-                                for i, ed in enumerate(matching_editions):
-                                    diff_formatted = format_duration(float(ed.get('difference', 0) or 0))
-                                    console.print(f"[yellow]{i+1}. [green]{ed.get('name', '')} ({ed.get('display_name', '')}, duration: {ed.get('formatted_duration', '')}, diff: {diff_formatted})[/yellow]")
-
-                                try:
-                                    choice = console.input(f"[yellow]Select edition number (1-{len(matching_editions)}) or press Enter to use the closest match: [/yellow]")
-
-                                    if choice.strip() and choice.isdigit() and 1 <= int(choice) <= len(matching_editions):
-                                        selected = matching_editions[int(choice)-1]
-                                    else:
-                                        selected = min(matching_editions, key=lambda x: float(x.get('difference', 0) or 0))
-                                        console.print(f"[yellow]Using closest match: {selected.get('name', '')}[/yellow]")
-                                except Exception as e:
-                                    console.print(f"[red]Error processing selection: {e}. Using closest match.[/red]")
-                                    selected = min(matching_editions, key=lambda x: float(x.get('difference', 0) or 0))
+                                matching_editions.append(
+                                    {
+                                        "name": edition_name,
+                                        "display_name": str(edition_info.get("display_name", "")),
+                                        "has_attributes": bool(edition_info.get("attributes") and len(edition_info["attributes"]) > 0),
+                                        "minutes": edition_info.get("minutes"),
+                                        "difference": difference,
+                                        "formatted_duration": edition_formatted,
+                                    }
+                                )
                             else:
-                                selected = min(matching_editions, key=lambda x: float(x.get('difference', 0) or 0))
-                                console.print(f"[yellow]Multiple matches found in unattended mode. Using closest match: {selected.get('name', '')}[/yellow]")
+                                if meta["debug"]:
+                                    console.print("[yellow]Edition without attributes are theatrical editions and skipped[/yellow]")
 
-                            edition = str(selected.get('name', '')) if selected.get('has_attributes') else ""
+                    if len(matching_editions) > 1:
+                        if not meta["unattended"] or (meta["unattended"] and meta.get("unattended_confirm", False)):
+                            console.print(f"[yellow]Media file duration {formatted_duration} matches multiple editions:[/yellow]")
+                            for i, ed in enumerate(matching_editions):
+                                diff_formatted = format_duration(float(ed.get("difference", 0) or 0))
+                                console.print(
+                                    f"[yellow]{i + 1}. [green]{ed.get('name', '')} ({ed.get('display_name', '')}, duration: {ed.get('formatted_duration', '')}, diff: {diff_formatted})[/yellow]"
+                                )
 
-                            console.print(f"[bold green]Setting edition from duration match: {edition}[/bold green]")
+                            try:
+                                choice = console.input(f"[yellow]Select edition number (1-{len(matching_editions)}) or press Enter to use the closest match: [/yellow]")
 
-                        elif len(matching_editions) == 1:
-                            selected = matching_editions[0]
-                            edition = str(selected.get('name', '')) if selected.get('has_attributes') else ""  # No special edition for single matches without attributes
-
-                            console.print(f"[bold green]Setting edition from duration match: {edition}[/bold green]")
-
+                                if choice.strip() and choice.isdigit() and 1 <= int(choice) <= len(matching_editions):
+                                    selected = matching_editions[int(choice) - 1]
+                                else:
+                                    selected = min(matching_editions, key=lambda x: float(x.get("difference", 0) or 0))
+                                    console.print(f"[yellow]Using closest match: {selected.get('name', '')}[/yellow]")
+                            except Exception as e:
+                                console.print(f"[red]Error processing selection: {e}. Using closest match.[/red]")
+                                selected = min(matching_editions, key=lambda x: float(x.get("difference", 0) or 0))
                         else:
-                            if meta['debug']:
-                                console.print(f"[yellow]No matching editions found within {leeway_seconds} seconds of media duration[/yellow]")
+                            selected = min(matching_editions, key=lambda x: float(x.get("difference", 0) or 0))
+                            console.print(f"[yellow]Multiple matches found in unattended mode. Using closest match: {selected.get('name', '')}[/yellow]")
 
-                    except (ValueError, TypeError) as e:
-                        console.print(f"[yellow]Error parsing duration: {e}[/yellow]")
+                        edition = str(selected.get("name", "")) if selected.get("has_attributes") else ""
 
-        elif meta.get('is_disc') == "BDMV" and meta.get('discs'):
-            if meta['debug']:
+                        console.print(f"[bold green]Setting edition from duration match: {edition}[/bold green]")
+
+                    elif len(matching_editions) == 1:
+                        selected = matching_editions[0]
+                        edition = str(selected.get("name", "")) if selected.get("has_attributes") else ""  # No special edition for single matches without attributes
+
+                        console.print(f"[bold green]Setting edition from duration match: {edition}[/bold green]")
+
+                    else:
+                        if meta["debug"]:
+                            console.print(f"[yellow]No matching editions found within {leeway_seconds} seconds of media duration[/yellow]")
+
+                except (ValueError, TypeError) as e:
+                    console.print(f"[yellow]Error parsing duration: {e}[/yellow]")
+
+        elif meta.get("is_disc") == "BDMV" and meta.get("discs"):
+            if meta["debug"]:
                 console.print("[cyan]Checking BDMV playlists for edition matches...[/cyan]")
             matched_editions: list[str] = []
 
             all_playlists: list[dict[str, Any]] = []
-            discs = cast(list[dict[str, Any]], meta.get('discs', []))
+            discs = cast(list[dict[str, Any]], meta.get("discs", []))
             for disc in discs:
-                if not meta['unattended'] or (meta['unattended'] and meta.get('unattended_confirm', False)):
-                    playlists = disc.get('playlists')
+                if not meta["unattended"] or (meta["unattended"] and meta.get("unattended_confirm", False)):
+                    playlists = disc.get("playlists")
                     if isinstance(playlists, list):
                         all_playlists.extend(cast(list[dict[str, Any]], playlists))
                 else:
-                    valid_playlists = disc.get('all_valid_playlists')
+                    valid_playlists = disc.get("all_valid_playlists")
                     if isinstance(valid_playlists, list):
                         all_playlists.extend(cast(list[dict[str, Any]], valid_playlists))
-            if meta['debug']:
+            if meta["debug"]:
                 console.print(f"[cyan]Found {len(all_playlists)} playlists to check against IMDb editions[/cyan]")
 
             leeway_seconds = 50
@@ -133,56 +139,62 @@ async def get_edition(video: str, bdinfo: Optional[dict[str, Any]], filelist: li
             matched_editions_without_attributes: list[str] = []
 
             for playlist in all_playlists:
-                playlist_file = str(playlist.get('file') or "")
-                playlist_edition = str(playlist.get('edition') or "")
-                if playlist.get('duration'):
-                    playlist_duration = float(playlist.get('duration') or 0)
+                playlist_file = str(playlist.get("file") or "")
+                playlist_edition = str(playlist.get("edition") or "")
+                if playlist.get("duration"):
+                    playlist_duration = float(playlist.get("duration") or 0)
                     formatted_duration = format_duration(playlist_duration)
-                    if meta['debug']:
+                    if meta["debug"]:
                         console.print(f"[cyan]Checking playlist duration: {formatted_duration} seconds[/cyan]")
 
                     playlist_matching_editions: list[dict[str, Any]] = []
 
                     for edition_info in edition_details.values():
-                        edition_seconds = float(edition_info.get('seconds', 0) or 0)
+                        edition_seconds = float(edition_info.get("seconds", 0) or 0)
                         difference = abs(playlist_duration - edition_seconds)
 
                         if difference <= leeway_seconds:
                             # Store the complete edition info
-                            attributes = edition_info.get('attributes')
+                            attributes = edition_info.get("attributes")
                             attributes_list = cast(list[Any], attributes) if isinstance(attributes, list) else []
                             if attributes_list:
                                 edition_name = " ".join(smart_title(str(attr)) for attr in attributes_list)
                             else:
                                 edition_name = f"{edition_info.get('minutes')} Minute Version (Theatrical)"
 
-                            playlist_matching_editions.append({
-                                'name': edition_name,
-                                'display_name': str(edition_info.get('display_name', '')),
-                                'has_attributes': bool(edition_info.get('attributes') and len(edition_info['attributes']) > 0),
-                                'minutes': edition_info.get('minutes'),
-                                'difference': difference
-                            })
+                            playlist_matching_editions.append(
+                                {
+                                    "name": edition_name,
+                                    "display_name": str(edition_info.get("display_name", "")),
+                                    "has_attributes": bool(edition_info.get("attributes") and len(edition_info["attributes"]) > 0),
+                                    "minutes": edition_info.get("minutes"),
+                                    "difference": difference,
+                                }
+                            )
 
                     # If multiple editions match this playlist, ask the user
                     if len(playlist_matching_editions) > 1:
-                        if not meta['unattended'] or (meta['unattended'] and meta.get('unattended_confirm', False)):
-                            console.print(f"[yellow]Playlist edition [green]{playlist_edition} [yellow]using file [green]{playlist_file} [yellow]with duration [green]{formatted_duration} [yellow]matches multiple editions:[/yellow]")
+                        if not meta["unattended"] or (meta["unattended"] and meta.get("unattended_confirm", False)):
+                            console.print(
+                                f"[yellow]Playlist edition [green]{playlist_edition} [yellow]using file [green]{playlist_file} [yellow]with duration [green]{formatted_duration} [yellow]matches multiple editions:[/yellow]"
+                            )
                             for i, ed in enumerate(playlist_matching_editions):
-                                console.print(f"[yellow]{i+1}. [green]{ed['name']} ({ed['display_name']}, diff: {ed['difference']:.2f} seconds)")
+                                console.print(f"[yellow]{i + 1}. [green]{ed['name']} ({ed['display_name']}, diff: {ed['difference']:.2f} seconds)")
 
                             try:
-                                choice = console.input(f"[yellow]Select edition number (1-{len(playlist_matching_editions)}), press e to use playlist edition or press Enter to use the closest match: [/yellow]")
+                                choice = console.input(
+                                    f"[yellow]Select edition number (1-{len(playlist_matching_editions)}), press e to use playlist edition or press Enter to use the closest match: [/yellow]"
+                                )
 
                                 playlist_selected: Union[str, dict[str, Any]]
 
                                 if choice.strip() and choice.isdigit() and 1 <= int(choice) <= len(playlist_matching_editions):
-                                    playlist_selected = playlist_matching_editions[int(choice)-1]
-                                elif choice.strip().lower() == 'e':
+                                    playlist_selected = playlist_matching_editions[int(choice) - 1]
+                                elif choice.strip().lower() == "e":
                                     playlist_selected = str(playlist_edition)
                                 else:
                                     # Default to the closest match (smallest difference)
-                                    playlist_selected = min(playlist_matching_editions, key=lambda x: x['difference'])
+                                    playlist_selected = min(playlist_matching_editions, key=lambda x: x["difference"])
                                     console.print(f"[yellow]Using closest match: {playlist_selected['name']}[/yellow]")
 
                                 # Add the selected edition to our matches
@@ -191,19 +203,19 @@ async def get_edition(video: str, bdinfo: Optional[dict[str, Any]], filelist: li
                                     if not normalized_playlist:
                                         # Empty playlist edition, fall back to closest match
                                         console.print("[yellow]Empty playlist edition, using closest match.[/yellow]")
-                                        playlist_selected = min(playlist_matching_editions, key=lambda x: x['difference'])
-                                        if playlist_selected['has_attributes']:
-                                            if playlist_selected['name'] not in matched_editions_with_attributes:
-                                                matched_editions_with_attributes.append(playlist_selected['name'])
+                                        playlist_selected = min(playlist_matching_editions, key=lambda x: x["difference"])
+                                        if playlist_selected["has_attributes"]:
+                                            if playlist_selected["name"] not in matched_editions_with_attributes:
+                                                matched_editions_with_attributes.append(playlist_selected["name"])
                                                 console.print(f"[green]Added edition with attributes: {playlist_selected['name']}[/green]")
                                         else:
-                                            matched_editions_without_attributes.append(str(playlist_selected['minutes']))
+                                            matched_editions_without_attributes.append(str(playlist_selected["minutes"]))
                                             console.print(f"[yellow]Added edition without attributes: {playlist_selected['name']}[/yellow]")
                                     elif normalized_playlist in ("theatrical", "theater", "theatre"):
                                         # Theatrical is a non-attribute edition; use closest match's minutes
                                         console.print(f"[yellow]Playlist edition '{playlist_selected}' is theatrical, treating as non-attribute edition.[/yellow]")
-                                        fallback = min(playlist_matching_editions, key=lambda x: x['difference'])
-                                        matched_editions_without_attributes.append(str(fallback['minutes']))
+                                        fallback = min(playlist_matching_editions, key=lambda x: x["difference"])
+                                        matched_editions_without_attributes.append(str(fallback["minutes"]))
                                     else:
                                         # Genuine attribute edition from playlist
                                         if playlist_selected.strip() not in matched_editions_with_attributes:
@@ -212,44 +224,46 @@ async def get_edition(video: str, bdinfo: Optional[dict[str, Any]], filelist: li
                                         else:
                                             console.print(f"[yellow]Playlist edition '{playlist_selected}' already added, skipping duplicate.[/yellow]")
                                 else:
-                                    if playlist_selected['has_attributes']:
-                                        if playlist_selected['name'] not in matched_editions_with_attributes:
-                                            matched_editions_with_attributes.append(playlist_selected['name'])
+                                    if playlist_selected["has_attributes"]:
+                                        if playlist_selected["name"] not in matched_editions_with_attributes:
+                                            matched_editions_with_attributes.append(playlist_selected["name"])
                                             console.print(f"[green]Added edition with attributes: {playlist_selected['name']}[/green]")
                                     else:
-                                        matched_editions_without_attributes.append(str(playlist_selected['minutes']))
+                                        matched_editions_without_attributes.append(str(playlist_selected["minutes"]))
                                         console.print(f"[yellow]Added edition without attributes: {playlist_selected['name']}[/yellow]")
 
                             except Exception as e:
                                 console.print(f"[red]Error processing selection: {e}. Using closest match.[/red]")
                                 # Default to closest match
-                                fallback_selected = min(playlist_matching_editions, key=lambda x: x['difference'])
-                                if fallback_selected['has_attributes']:
-                                    matched_editions_with_attributes.append(fallback_selected['name'])
+                                fallback_selected = min(playlist_matching_editions, key=lambda x: x["difference"])
+                                if fallback_selected["has_attributes"]:
+                                    matched_editions_with_attributes.append(fallback_selected["name"])
                                 else:
-                                    matched_editions_without_attributes.append(str(fallback_selected['minutes']))
+                                    matched_editions_without_attributes.append(str(fallback_selected["minutes"]))
                         else:
-                            console.print(f"[yellow]Playlist edition [green]{playlist_edition} [yellow]using file [green]{playlist_file} [yellow]with duration [green]{formatted_duration} [yellow]matches multiple editions, but unattended mode is enabled. Using closest match.[/yellow]")
-                            unattended_selected = min(playlist_matching_editions, key=lambda x: x['difference'])
-                            if unattended_selected['has_attributes']:
-                                matched_editions_with_attributes.append(unattended_selected['name'])
+                            console.print(
+                                f"[yellow]Playlist edition [green]{playlist_edition} [yellow]using file [green]{playlist_file} [yellow]with duration [green]{formatted_duration} [yellow]matches multiple editions, but unattended mode is enabled. Using closest match.[/yellow]"
+                            )
+                            unattended_selected = min(playlist_matching_editions, key=lambda x: x["difference"])
+                            if unattended_selected["has_attributes"]:
+                                matched_editions_with_attributes.append(unattended_selected["name"])
                             else:
-                                matched_editions_without_attributes.append(str(unattended_selected['minutes']))
+                                matched_editions_without_attributes.append(str(unattended_selected["minutes"]))
 
                     # If just one edition matches, add it directly
                     elif len(playlist_matching_editions) == 1:
                         edition_info = playlist_matching_editions[0]
-                        if meta['debug']:
+                        if meta["debug"]:
                             console.print(f"[green]Playlist {playlist_edition} matches edition: {edition_info['display_name']} {edition_info['name']}[/green]")
 
-                        if edition_info['has_attributes']:
-                            if edition_info['name'] not in matched_editions_with_attributes:
-                                matched_editions_with_attributes.append(edition_info['name'])
-                                if meta['debug']:
+                        if edition_info["has_attributes"]:
+                            if edition_info["name"] not in matched_editions_with_attributes:
+                                matched_editions_with_attributes.append(edition_info["name"])
+                                if meta["debug"]:
                                     console.print(f"[green]Added edition with attributes: {edition_info['name']}[/green]")
                         else:
-                            matched_editions_without_attributes.append(str(edition_info['minutes']))
-                            if meta['debug']:
+                            matched_editions_without_attributes.append(str(edition_info["minutes"]))
+                            if meta["debug"]:
                                 console.print(f"[yellow]Added edition without attributes: {edition_info['name']}[/yellow]")
 
                 # Process the matched editions
@@ -257,14 +271,14 @@ async def get_edition(video: str, bdinfo: Optional[dict[str, Any]], filelist: li
                     # Only use "Theatrical" if we have at least one edition with attributes
                     if matched_editions_with_attributes and matched_editions_without_attributes:
                         matched_editions = matched_editions_with_attributes + ["Theatrical"]
-                        if meta['debug']:
+                        if meta["debug"]:
                             console.print("[cyan]Adding 'Theatrical' label because we have both attribute and non-attribute editions[/cyan]")
                     elif matched_editions_with_attributes:
                         matched_editions = matched_editions_with_attributes
-                        if meta['debug']:
+                        if meta["debug"]:
                             console.print("[cyan]Using only editions with attributes[/cyan]")
                     else:
-                        if meta['debug']:
+                        if meta["debug"]:
                             console.print("[cyan]No useful editions found[/cyan]")
 
                     # Handle final edition formatting
@@ -279,38 +293,38 @@ async def get_edition(video: str, bdinfo: Optional[dict[str, Any]], filelist: li
                         else:
                             edition = matched_editions[0]
 
-                        if meta['debug']:
+                        if meta["debug"]:
                             console.print(f"[bold green]Setting edition from BDMV playlist matches: {edition}[/bold green]")
 
     if edition and (edition.lower() in ["cut", "approximate"] or len(edition) < 6):
         edition = ""
     if edition and "edition" in edition.lower():
-        edition = re.sub(r'\bedition\b', '', edition, flags=re.IGNORECASE).strip()
+        edition = re.sub(r"\bedition\b", "", edition, flags=re.IGNORECASE).strip()
     if edition and "extended" in edition.lower():
         edition = "Extended"
 
     if not edition:
-        if video.lower().startswith('dc'):
-            video = video.lower().replace('dc', '', 1)
+        if video.lower().startswith("dc"):
+            video = video.lower().replace("dc", "", 1)
 
         guess: Any = guessit_fn(video)
 
-        tag_value: Any = guess.get('release_group', 'NOGROUP')
+        tag_value: Any = guess.get("release_group", "NOGROUP")
         tag = " ".join(str(t) for t in cast(list[Any], tag_value)) if isinstance(tag_value, list) else str(tag_value)
         repack = ""
 
         if bdinfo is not None:
             try:
-                edition_value: Any = guessit_fn(bdinfo['label']).get('edition', '')
+                edition_value: Any = guessit_fn(bdinfo["label"]).get("edition", "")
             except Exception as e:
-                if meta['debug']:
+                if meta["debug"]:
                     console.print(f"BDInfo Edition Guess Error: {e}", markup=False)
                 edition_value = ""
         else:
             try:
-                edition_value = guess.get('edition', "")
+                edition_value = guess.get("edition", "")
             except Exception as e:
-                if meta['debug']:
+                if meta["debug"]:
                     console.print(f"Video Edition Guess Error: {e}", markup=False)
                 edition_value = ""
 
@@ -319,7 +333,7 @@ async def get_edition(video: str, bdinfo: Optional[dict[str, Any]], filelist: li
         if len(filelist) == 1:
             video = os.path.basename(video)
 
-        video = video.upper().replace('.', ' ').replace(tag.upper(), '').replace('-', '')
+        video = video.upper().replace(".", " ").replace(tag.upper(), "").replace("-", "")
 
         if "OPEN MATTE" in video.upper():
             edition = edition + " Open Matte"
@@ -350,35 +364,38 @@ async def get_edition(video: str, bdinfo: Optional[dict[str, Any]], filelist: li
         repack = "RERIP"
 
     # Only remove REPACK, RERIP, or PROPER from edition if not in manual edition
-    if not manual_edition or (isinstance(manual_edition, str) and all(tag.lower() not in ['repack', 'repack2', 'repack3', 'proper', 'proper2', 'proper3', 'rerip'] for tag in manual_edition.strip().lower().split())):
+    if not manual_edition or (
+        isinstance(manual_edition, str)
+        and all(tag.lower() not in ["repack", "repack2", "repack3", "proper", "proper2", "proper3", "rerip"] for tag in manual_edition.strip().lower().split())
+    ):
         edition = re.sub(r"(\bREPACK\d?\b|\bRERIP\b|\bPROPER\b)", "", edition, flags=re.IGNORECASE).strip()
 
-    if not meta.get('webdv', False):
+    if not meta.get("webdv", False):
         hybrid = False
         if "HYBRID" in video.upper() or "HYBRID" in edition.upper():
             hybrid = True
     else:
-        hybrid = meta.get('webdv', False)
+        hybrid = meta.get("webdv", False)
 
     # Handle distributor info
     if edition:
         distributors = await get_distributor(edition)
 
-        bad = ['internal', 'limited', 'retail', 'version', 'remastered']
+        bad = ["internal", "limited", "retail", "version", "remastered"]
 
-        if distributors and meta['is_disc']:
+        if distributors and meta["is_disc"]:
             bad.append(distributors.lower())
-            meta['distributor'] = distributors
+            meta["distributor"] = distributors
 
         if any(term.lower() in edition.lower() for term in bad):
-            edition = re.sub(r'\b(?:' + '|'.join(bad) + r')\b', '', edition, flags=re.IGNORECASE).strip()
+            edition = re.sub(r"\b(?:" + "|".join(bad) + r")\b", "", edition, flags=re.IGNORECASE).strip()
             # Clean up extra spaces
-            while '  ' in edition:
-                edition = edition.replace('  ', ' ')
+            while "  " in edition:
+                edition = edition.replace("  ", " ")
 
         if edition != "":
             edition = edition.strip()
-            if meta['debug']:
+            if meta["debug"]:
                 console.print(f"Final Edition: {edition}")
 
     return edition, repack, hybrid

--- a/src/edition.py
+++ b/src/edition.py
@@ -16,7 +16,7 @@ def guessit_fn(value: str, options: Optional[dict[str, Any]] = None) -> dict[str
     return cast(dict[str, Any], guessit_module.guessit(value, options))
 
 
-async def get_edition(video: str, bdinfo: Optional[dict[str, Any]], filelist: list[str], manual_edition: Union[str, list[str]], meta: dict[str, Any]) -> tuple[str, str, bool]:
+async def get_edition(video: str, bdinfo: Optional[dict[str, Any]], filelist: list[str], manual_edition: Union[str, list[str]], meta: dict[str, Any]) -> tuple[str, str, str]:
     edition = ""
     imdb_info = cast(dict[str, Any], meta.get("imdb_info", {}))
     edition_details = cast(dict[str, dict[str, Any]], imdb_info.get("edition_details", {}))

--- a/src/imdb.py
+++ b/src/imdb.py
@@ -378,6 +378,7 @@ class ImdbManager:
                         'attributes': attribute_texts
                     }
 
+            imdb_info['edition_count'] = len(edition_list)
             imdb_info['editions'] = ', '.join(edition_list)
 
         akas_edges = cast(list[Mapping[str, Any]], self.safe_get(title_data, ['akas', 'edges'], default=[]))

--- a/src/imdb.py
+++ b/src/imdb.py
@@ -43,7 +43,7 @@ class ImdbManager:
         imdb_info: dict[str, Any] = {}
 
         if not imdbID or imdbID == 0:
-            imdb_info['type'] = None
+            imdb_info["type"] = None
             return imdb_info
 
         try:
@@ -289,50 +289,48 @@ class ImdbManager:
         if not title_data:
             return imdb_info  # Return empty if no data found
 
-        imdb_info['imdbID'] = imdbID
-        imdb_info['imdb_url'] = f"https://www.imdb.com/title/{imdbID}"
-        imdb_info['title'] = self.safe_get(title_data, ['titleText', 'text'])
-        countries_list = cast(list[Mapping[str, Any]], self.safe_get(title_data, ['countriesOfOrigin', 'countries'], []))
+        imdb_info["imdbID"] = imdbID
+        imdb_info["imdb_url"] = f"https://www.imdb.com/title/{imdbID}"
+        imdb_info["title"] = self.safe_get(title_data, ["titleText", "text"])
+        countries_list = cast(list[Mapping[str, Any]], self.safe_get(title_data, ["countriesOfOrigin", "countries"], []))
         if countries_list:
             # First country for 'country'
-            imdb_info['country'] = countries_list[0].get('text', '')
+            imdb_info["country"] = countries_list[0].get("text", "")
             # All countries joined for 'country_list'
-            imdb_info['country_list'] = ', '.join(
-                [c.get('text', '') for c in countries_list if isinstance(c, dict) and 'text' in c]
-            )
+            imdb_info["country_list"] = ", ".join([c.get("text", "") for c in countries_list if isinstance(c, dict) and "text" in c])
         else:
-            imdb_info['country'] = ''
-            imdb_info['country_list'] = ''
-        imdb_info['year'] = self.safe_get(title_data, ['releaseYear', 'year'])
-        imdb_info['end_year'] = self.safe_get(title_data, ['releaseYear', 'endYear'])
-        original_title = self.safe_get(title_data, ['originalTitleText', 'text'], '')
-        imdb_info['aka'] = original_title if original_title and original_title != imdb_info['title'] else imdb_info['title']
-        imdb_info['type'] = self.safe_get(title_data, ['titleType', 'id'], None)
-        runtime_seconds = self.safe_get(title_data, ['runtime', 'seconds'], 0)
-        imdb_info['runtime'] = str(runtime_seconds // 60 if runtime_seconds else 60)
-        imdb_info['cover'] = self.safe_get(title_data, ['primaryImage', 'url'])
-        imdb_info['plot'] = self.safe_get(title_data, ['plot', 'plotText', 'plainText'], 'No plot available')
+            imdb_info["country"] = ""
+            imdb_info["country_list"] = ""
+        imdb_info["year"] = self.safe_get(title_data, ["releaseYear", "year"])
+        imdb_info["end_year"] = self.safe_get(title_data, ["releaseYear", "endYear"])
+        original_title = self.safe_get(title_data, ["originalTitleText", "text"], "")
+        imdb_info["aka"] = original_title if original_title and original_title != imdb_info["title"] else imdb_info["title"]
+        imdb_info["type"] = self.safe_get(title_data, ["titleType", "id"], None)
+        runtime_seconds = self.safe_get(title_data, ["runtime", "seconds"], 0)
+        imdb_info["runtime"] = str(runtime_seconds // 60 if runtime_seconds else 60)
+        imdb_info["cover"] = self.safe_get(title_data, ["primaryImage", "url"])
+        imdb_info["plot"] = self.safe_get(title_data, ["plot", "plotText", "plainText"], "No plot available")
 
-        genres = cast(list[Mapping[str, Any]], self.safe_get(title_data, ['titleGenres', 'genres'], []))
-        genre_list = [self.safe_get(g, ['genre', 'text'], '') for g in genres]
-        imdb_info['genres'] = ', '.join(filter(None, genre_list))
+        genres = cast(list[Mapping[str, Any]], self.safe_get(title_data, ["titleGenres", "genres"], []))
+        genre_list = [self.safe_get(g, ["genre", "text"], "") for g in genres]
+        imdb_info["genres"] = ", ".join(filter(None, genre_list))
 
-        imdb_info['rating'] = self.safe_get(title_data, ['ratingsSummary', 'aggregateRating'], 'N/A')
+        imdb_info["rating"] = self.safe_get(title_data, ["ratingsSummary", "aggregateRating"], "N/A")
 
         def get_credits(title_data: dict[str, Any], category_keyword: str) -> tuple[list[str], list[str]]:
             people_list: list[str] = []
             people_id_list: list[str] = []
-            principal_credits = cast(list[Mapping[str, Any]], self.safe_get(title_data, ['principalCredits'], []))
+            principal_credits = cast(list[Mapping[str, Any]], self.safe_get(title_data, ["principalCredits"], []))
 
             for pc in principal_credits:
-                category_text = self.safe_get(pc, ['category', 'text'], '')
+                category_text = self.safe_get(pc, ["category", "text"], "")
 
                 if category_keyword in category_text:
-                    credits = cast(list[Mapping[str, Any]], self.safe_get(pc, ['credits'], []))
+                    credits = cast(list[Mapping[str, Any]], self.safe_get(pc, ["credits"], []))
                     for c in credits:
-                        name_obj = self.safe_get(c, ['name'], {})
-                        person_id = self.safe_get(name_obj, ['id'], '')
-                        person_name = self.safe_get(name_obj, ['nameText', 'text'], '')
+                        name_obj = self.safe_get(c, ["name"], {})
+                        person_id = self.safe_get(name_obj, ["id"], "")
+                        person_name = self.safe_get(name_obj, ["nameText", "text"], "")
 
                         if person_id and person_name:
                             people_list.append(person_name)
@@ -341,25 +339,25 @@ class ImdbManager:
 
             return people_list, people_id_list
 
-        imdb_info['directors'], imdb_info['directors_id'] = get_credits(title_data, 'Direct')
-        imdb_info['creators'], imdb_info['creators_id'] = get_credits(title_data, 'Creat')
-        imdb_info['writers'], imdb_info['writers_id'] = get_credits(title_data, 'Writ')
-        imdb_info['stars'], imdb_info['stars_id'] = get_credits(title_data, 'Star')
+        imdb_info["directors"], imdb_info["directors_id"] = get_credits(title_data, "Direct")
+        imdb_info["creators"], imdb_info["creators_id"] = get_credits(title_data, "Creat")
+        imdb_info["writers"], imdb_info["writers_id"] = get_credits(title_data, "Writ")
+        imdb_info["stars"], imdb_info["stars_id"] = get_credits(title_data, "Star")
 
-        editions = cast(list[Mapping[str, Any]], self.safe_get(title_data, ['runtimes', 'edges'], []))
+        editions = cast(list[Mapping[str, Any]], self.safe_get(title_data, ["runtimes", "edges"], []))
         if editions:
             edition_list: list[str] = []
-            imdb_info['edition_details'] = {}
+            imdb_info["edition_details"] = {}
 
             for edge in editions:
-                node = self.safe_get(edge, ['node'], {})
-                seconds = self.safe_get(node, ['seconds'], 0)
+                node = self.safe_get(edge, ["node"], {})
+                seconds = self.safe_get(node, ["seconds"], 0)
                 minutes = seconds // 60 if seconds else 0
-                displayable_property = self.safe_get(node, ['displayableProperty', 'value', 'plainText'], '')
-                attributes = cast(list[Mapping[str, Any]], self.safe_get(node, ['attributes'], []))
+                displayable_property = self.safe_get(node, ["displayableProperty", "value", "plainText"], "")
+                attributes = cast(list[Mapping[str, Any]], self.safe_get(node, ["attributes"], []))
                 attribute_texts: list[str] = []
                 for attr in attributes:
-                    text = attr.get('text')
+                    text = attr.get("text")
                     if isinstance(text, str) and text:
                         attribute_texts.append(text)
 
@@ -371,66 +369,61 @@ class ImdbManager:
                     edition_list.append(edition_display)
 
                     runtime_key = str(minutes)
-                    imdb_info['edition_details'][runtime_key] = {
-                        'display_name': displayable_property,
-                        'seconds': seconds,
-                        'minutes': minutes,
-                        'attributes': attribute_texts
-                    }
+                    imdb_info["edition_details"][runtime_key] = {"display_name": displayable_property, "seconds": seconds, "minutes": minutes, "attributes": attribute_texts}
 
-            imdb_info['edition_count'] = len(edition_list)
-            imdb_info['editions'] = ', '.join(edition_list)
+            imdb_info["edition_count"] = len(edition_list)
+            imdb_info["editions"] = ", ".join(edition_list)
 
-        akas_edges = cast(list[Mapping[str, Any]], self.safe_get(title_data, ['akas', 'edges'], default=[]))
-        imdb_info['akas'] = [
+        akas_edges = cast(list[Mapping[str, Any]], self.safe_get(title_data, ["akas", "edges"], default=[]))
+        imdb_info["akas"] = [
             {
-                "title": self.safe_get(edge, ['node', 'text']),
-                "country": self.safe_get(edge, ['node', 'country', 'text']),
-                "language": self.safe_get(edge, ['node', 'language', 'text']),
-                "attributes": self.safe_get(edge, ['node', 'attributes'], []),
+                "title": self.safe_get(edge, ["node", "text"]),
+                "country": self.safe_get(edge, ["node", "country", "text"]),
+                "language": self.safe_get(edge, ["node", "language", "text"]),
+                "attributes": self.safe_get(edge, ["node", "attributes"], []),
             }
             for edge in akas_edges
         ]
 
         if manual_language:
-            imdb_info['original_language'] = manual_language
+            imdb_info["original_language"] = manual_language
 
         episodes_list: list[dict[str, Any]] = []
-        imdb_info['episodes'] = episodes_list
-        episodes_data = self.safe_get(title_data, ['episodes', 'episodes'], None)
+        imdb_info["episodes"] = episodes_list
+        episodes_data = self.safe_get(title_data, ["episodes", "episodes"], None)
         if episodes_data:
-            edges = cast(list[Mapping[str, Any]], self.safe_get(episodes_data, ['edges'], []))
+            edges = cast(list[Mapping[str, Any]], self.safe_get(episodes_data, ["edges"], []))
             for edge in edges:
-                node = self.safe_get(edge, ['node'], {})
+                node = self.safe_get(edge, ["node"], {})
 
-                series_info = self.safe_get(node, ['series', 'displayableEpisodeNumber'], {})
-                season_info = self.safe_get(series_info, ['displayableSeason'], {})
-                episode_number_info = self.safe_get(series_info, ['episodeNumber'], {})
+                series_info = self.safe_get(node, ["series", "displayableEpisodeNumber"], {})
+                season_info = self.safe_get(series_info, ["displayableSeason"], {})
+                episode_number_info = self.safe_get(series_info, ["episodeNumber"], {})
 
                 episode_info = {
-                    'id': self.safe_get(node, ['id'], ''),
-                    'title': self.safe_get(node, ['titleText', 'text'], 'Unknown Title'),
-                    'release_year': self.safe_get(node, ['releaseYear', 'year'], 'Unknown Year'),
-                    'release_date': {
-                        'year': self.safe_get(node, ['releaseDate', 'year'], None),
-                        'month': self.safe_get(node, ['releaseDate', 'month'], None),
-                        'day': self.safe_get(node, ['releaseDate', 'day'], None),
+                    "id": self.safe_get(node, ["id"], ""),
+                    "title": self.safe_get(node, ["titleText", "text"], "Unknown Title"),
+                    "release_year": self.safe_get(node, ["releaseYear", "year"], "Unknown Year"),
+                    "release_date": {
+                        "year": self.safe_get(node, ["releaseDate", "year"], None),
+                        "month": self.safe_get(node, ["releaseDate", "month"], None),
+                        "day": self.safe_get(node, ["releaseDate", "day"], None),
                     },
-                    'season': self.safe_get(season_info, ['season'], 'unknown'),
-                    'episode_number': self.safe_get(episode_number_info, ['text'], '')
+                    "season": self.safe_get(season_info, ["season"], "unknown"),
+                    "episode_number": self.safe_get(episode_number_info, ["text"], ""),
                 }
                 episodes_list.append(episode_info)
 
-        if imdb_info['episodes']:
+        if imdb_info["episodes"]:
             seasons_data: dict[int, set[int]] = {}
 
-            episodes = cast(list[dict[str, Any]], imdb_info.get('episodes', []))
+            episodes = cast(list[dict[str, Any]], imdb_info.get("episodes", []))
             for episode in episodes:
-                season_str = episode.get('season', 'unknown')
-                release_year = episode.get('release_year')
+                season_str = episode.get("season", "unknown")
+                release_year = episode.get("release_year")
 
                 try:
-                    season_int = int(season_str) if season_str != 'unknown' and season_str else None
+                    season_int = int(season_str) if season_str != "unknown" and season_str else None
                 except (ValueError, TypeError):
                     season_int = None
 
@@ -442,34 +435,26 @@ class ImdbManager:
             seasons_summary: list[dict[str, Any]] = []
             for season_num in sorted(seasons_data.keys()):
                 years = sorted(seasons_data[season_num])
-                season_entry = {
-                    'season': season_num,
-                    'year': years[0],
-                    'year_range': f"{years[0]}" if len(years) == 1 else f"{years[0]}-{years[-1]}"
-                }
+                season_entry = {"season": season_num, "year": years[0], "year_range": f"{years[0]}" if len(years) == 1 else f"{years[0]}-{years[-1]}"}
                 seasons_summary.append(season_entry)
 
-            imdb_info['seasons_summary'] = seasons_summary
+            imdb_info["seasons_summary"] = seasons_summary
         else:
-            imdb_info['seasons_summary'] = []
+            imdb_info["seasons_summary"] = []
 
-        sound_mixes = cast(list[Mapping[str, Any]], self.safe_get(title_data, ['technicalSpecifications', 'soundMixes', 'items'], []))
-        imdb_info['sound_mixes'] = [sm.get('text', '') for sm in sound_mixes if 'text' in sm]
+        sound_mixes = cast(list[Mapping[str, Any]], self.safe_get(title_data, ["technicalSpecifications", "soundMixes", "items"], []))
+        imdb_info["sound_mixes"] = [sm.get("text", "") for sm in sound_mixes if "text" in sm]
 
-        episodes = cast(list[dict[str, Any]], imdb_info.get('episodes', []))
+        episodes = cast(list[dict[str, Any]], imdb_info.get("episodes", []))
         current_year = datetime.now(timezone.utc).year
-        release_years = [
-            episode['release_year']
-            for episode in episodes
-            if 'release_year' in episode and isinstance(episode['release_year'], int)
-        ]
-        if imdb_info['end_year']:
-            imdb_info['tv_year'] = imdb_info['end_year']
+        release_years = [episode["release_year"] for episode in episodes if "release_year" in episode and isinstance(episode["release_year"], int)]
+        if imdb_info["end_year"]:
+            imdb_info["tv_year"] = imdb_info["end_year"]
         elif release_years:
             closest_year = min(release_years, key=lambda year: abs(year - current_year))
-            imdb_info['tv_year'] = closest_year
+            imdb_info["tv_year"] = closest_year
         else:
-            imdb_info['tv_year'] = None
+            imdb_info["tv_year"] = None
 
         if debug:
             console.print(f"[yellow]IMDb Response: {json.dumps(imdb_info, indent=2)[:1000]}...[/yellow]")
@@ -517,7 +502,7 @@ class ImdbManager:
                 await asyncio.sleep(1)  # Whoa baby, slow down
             url = "https://api.graphql.imdb.com/"
             if category == "MOVIE":
-                filename = filename.replace('and', '&').replace('And', '&').replace('AND', '&').strip()
+                filename = filename.replace("and", "&").replace("And", "&").replace("AND", "&").strip()
 
             constraints_parts = [f'titleTextConstraint: {{searchTerm: "{filename}"}}']
 
@@ -526,19 +511,15 @@ class ImdbManager:
                 search_year_int = int(search_year)
                 start_year = search_year_int - 1
                 end_year = search_year_int + 1
-                constraints_parts.append(
-                    f'releaseDateConstraint: {{releaseDateRange: {{start: "{start_year}-01-01", end: "{end_year}-12-31"}}}}'
-                )
+                constraints_parts.append(f'releaseDateConstraint: {{releaseDateRange: {{start: "{start_year}-01-01", end: "{end_year}-12-31"}}}}')
 
             if not wide_search and duration and isinstance(duration, int):
                 duration = str(duration)
                 start_duration = int(duration) - 10
                 end_duration = int(duration) + 10
-                constraints_parts.append(
-                    f'runtimeConstraint: {{runtimeRangeMinutes: {{min: {start_duration}, max: {end_duration}}}}}'
-                )
+                constraints_parts.append(f"runtimeConstraint: {{runtimeRangeMinutes: {{min: {start_duration}, max: {end_duration}}}}}")
 
-            constraints_string = ', '.join(constraints_parts)
+            constraints_string = ", ".join(constraints_parts)
 
             query = {
                 "query": f"""
@@ -607,13 +588,13 @@ class ImdbManager:
         if not search_results:
             try:
                 words = filename.split()
-                bad_words = ['the']
+                bad_words = ["the"]
                 words_lower = [word.lower() for word in words]
 
                 if words_lower and words_lower[0] in bad_words:
                     words.pop(0)
                     words_lower.pop(0)
-                    title = ' '.join(words)
+                    title = " ".join(words)
                     if debug:
                         console.print(f"[bold yellow]Trying IMDb with the prefix removed: {title}[/bold yellow]")
                     result = await run_imdb_search(title, search_year, category, debug, attempted + 1, wide_search=False)
@@ -638,8 +619,8 @@ class ImdbManager:
         if not search_results:
             try:
                 parsed = guessit_fn(untouched_filename or "", {"excludes": ["country", "language"]})
-                parsed_title_data = cast(dict[str, Any], anitopy_parse_fn(parsed.get('title', '')) or {})
-                parsed_title = str(parsed_title_data.get('anime_title', ''))
+                parsed_title_data = cast(dict[str, Any], anitopy_parse_fn(parsed.get("title", "")) or {})
+                parsed_title = str(parsed_title_data.get("anime_title", ""))
                 if debug:
                     console.print(f"[bold yellow]Trying IMDB with parsed title: {parsed_title}[/bold yellow]")
                 result = await run_imdb_search(parsed_title, search_year, category, debug, attempted + 1, wide_search=True)
@@ -652,7 +633,7 @@ class ImdbManager:
         if not search_results:
             try:
                 words = filename.split()
-                extensions = ['mp4', 'mkv', 'avi', 'webm', 'mov', 'wmv']
+                extensions = ["mp4", "mkv", "avi", "webm", "mov", "wmv"]
                 words_lower = [word.lower() for word in words]
 
                 for ext in extensions:
@@ -663,7 +644,7 @@ class ImdbManager:
                         break
 
                 if len(words) > 1:
-                    reduced_title = ' '.join(words[:-1])
+                    reduced_title = " ".join(words[:-1])
                     if debug:
                         console.print(f"[bold yellow]Trying IMDB with reduced name: {reduced_title}[/bold yellow]")
                     result = await run_imdb_search(reduced_title, search_year, category, debug, attempted + 1, wide_search=True)
@@ -676,7 +657,7 @@ class ImdbManager:
         if not search_results:
             try:
                 words = filename.split()
-                extensions = ['mp4', 'mkv', 'avi', 'webm', 'mov', 'wmv']
+                extensions = ["mp4", "mkv", "avi", "webm", "mov", "wmv"]
                 words_lower = [word.lower() for word in words]
 
                 for ext in extensions:
@@ -687,7 +668,7 @@ class ImdbManager:
                         break
 
                 if len(words) > 2:
-                    further_reduced_title = ' '.join(words[:-2])
+                    further_reduced_title = " ".join(words[:-2])
                     if debug:
                         console.print(f"[bold yellow]Trying IMDB with further reduced name: {further_reduced_title}[/bold yellow]")
                     result = await run_imdb_search(further_reduced_title, search_year, category, debug, attempted + 1, wide_search=True)
@@ -719,14 +700,14 @@ class ImdbManager:
                 if imdb_id and type_matches:
                     if year_int and search_year_int:
                         if year_int == search_year_int:
-                            imdbID = int(imdb_id.replace('tt', '').strip())
+                            imdbID = int(imdb_id.replace("tt", "").strip())
                             return imdbID
                         else:
                             if debug:
                                 console.print(f"[yellow]Year mismatch: found {year_int}, expected {search_year_int}[/yellow]")
                             return 0
                     else:
-                        imdbID = int(imdb_id.replace('tt', '').strip())
+                        imdbID = int(imdb_id.replace("tt", "").strip())
                         return imdbID
                 else:
                     if not imdb_id and debug:
@@ -741,7 +722,7 @@ class ImdbManager:
             if len(search_results) == 1:
                 imdb_id = self.safe_get(search_results[0], ["node", "title", "id"], "")
                 if imdb_id:
-                    imdbID = int(imdb_id.replace('tt', '').strip())
+                    imdbID = int(imdb_id.replace("tt", "").strip())
                     return imdbID
             elif len(search_results) > 1:
                 # Calculate similarity for all results
@@ -772,15 +753,11 @@ class ImdbManager:
                 # Filter results: if we have high similarity matches (>= 0.90), hide low similarity ones (< 0.75)
                 best_similarity = results_with_similarity[0][1]
                 if best_similarity >= 0.90:
-                    filtered_results_with_similarity: list[tuple[dict[str, Any], float]] = [
-                        (result, sim) for result, sim in results_with_similarity if sim >= 0.75
-                    ]
+                    filtered_results_with_similarity: list[tuple[dict[str, Any], float]] = [(result, sim) for result, sim in results_with_similarity if sim >= 0.75]
                     results_with_similarity = filtered_results_with_similarity
 
                     if debug:
-                        console.print(
-                            f"[yellow]Filtered out low similarity results (< 0.70) since best match has {best_similarity:.2f} similarity[/yellow]"
-                        )
+                        console.print(f"[yellow]Filtered out low similarity results (< 0.70) since best match has {best_similarity:.2f} similarity[/yellow]")
 
                 sorted_results: list[dict[str, Any]] = [r[0] for r in results_with_similarity]
 
@@ -798,13 +775,13 @@ class ImdbManager:
                             )
                         imdb_id = self.safe_get(sorted_results[0], ["node", "title", "id"], "")
                         if imdb_id:
-                            imdbID = int(imdb_id.replace('tt', '').strip())
+                            imdbID = int(imdb_id.replace("tt", "").strip())
                             return imdbID
 
                 if unattended:
                     imdb_id = self.safe_get(sorted_results[0], ["node", "title", "id"], "")
                     if imdb_id:
-                        imdbID = int(imdb_id.replace('tt', '').strip())
+                        imdbID = int(imdb_id.replace("tt", "").strip())
                         if debug:
                             console.print(f"[green]Unattended mode: auto-selected IMDb ID {imdbID}[/green]")
                         return imdbID
@@ -823,7 +800,7 @@ class ImdbManager:
                     similarity_score = results_with_similarity[idx][1]
 
                     console.print(
-                        f"[cyan]{idx+1}.[/cyan] [bold]{title_text}[/bold] ({year}) [yellow]ID:[/yellow] {imdb_id} [yellow]Type:[/yellow] {title_type} [dim](similarity: {similarity_score:.2f})[/dim]"
+                        f"[cyan]{idx + 1}.[/cyan] [bold]{title_text}[/bold] ({year}) [yellow]ID:[/yellow] {imdb_id} [yellow]Type:[/yellow] {title_type} [dim](similarity: {similarity_score:.2f})[/dim]"
                     )
                     if plot:
                         console.print(f"[green]Plot:[/green] {plot[:200]}{'...' if len(plot) > 200 else ''}")
@@ -833,9 +810,7 @@ class ImdbManager:
                     selection = None
                     while True:
                         try:
-                            selection = cli_ui.ask_string(
-                                "Enter the number of the correct entry, 0 for none, or manual IMDb ID (tt1234567): "
-                            ) or ""
+                            selection = cli_ui.ask_string("Enter the number of the correct entry, 0 for none, or manual IMDb ID (tt1234567): ") or ""
                         except (EOFError, KeyboardInterrupt):
                             console.print("\n[red]Exiting on user request (Ctrl+C)[/red]")
                             await cleanup_manager.cleanup()
@@ -843,9 +818,9 @@ class ImdbManager:
                             sys.exit(1)
                         try:
                             # Check if it's a manual IMDb ID entry
-                            if selection.lower().startswith('tt') and len(selection) >= 3:
+                            if selection.lower().startswith("tt") and len(selection) >= 3:
                                 try:
-                                    manual_imdb_id = selection.lower().replace('tt', '').strip()
+                                    manual_imdb_id = selection.lower().replace("tt", "").strip()
                                     if manual_imdb_id.isdigit():
                                         console.print(f"[green]Using manual IMDb ID: {selection}[/green]")
                                         return int(manual_imdb_id)
@@ -862,7 +837,7 @@ class ImdbManager:
                                 selected = sorted_results[selection_int - 1]
                                 imdb_id = self.safe_get(selected, ["node", "title", "id"], "")
                                 if imdb_id:
-                                    imdbID = int(imdb_id.replace('tt', '').strip())
+                                    imdbID = int(imdb_id.replace("tt", "").strip())
                                     return imdbID
                             elif selection_int == 0:
                                 console.print("[bold red]Skipping IMDb[/bold red]")
@@ -875,17 +850,15 @@ class ImdbManager:
             else:
                 if not unattended:
                     try:
-                        selection = cli_ui.ask_string(
-                            "No results found. Please enter a manual IMDb ID (tt1234567) or 0 to skip: "
-                        ) or ""
+                        selection = cli_ui.ask_string("No results found. Please enter a manual IMDb ID (tt1234567) or 0 to skip: ") or ""
                     except (EOFError, KeyboardInterrupt):
                         console.print("\n[red]Exiting on user request (Ctrl+C)[/red]")
                         await cleanup_manager.cleanup()
                         cleanup_manager.reset_terminal()
                         sys.exit(1)
-                    if selection.lower().startswith('tt') and len(selection) >= 3:
+                    if selection.lower().startswith("tt") and len(selection) >= 3:
                         try:
-                            manual_imdb_id = selection.lower().replace('tt', '').strip()
+                            manual_imdb_id = selection.lower().replace("tt", "").strip()
                             if manual_imdb_id.isdigit():
                                 console.print(f"[green]Using manual IMDb ID: {selection}[/green]")
                                 return int(manual_imdb_id)
@@ -947,12 +920,7 @@ class ImdbManager:
 
         async with httpx.AsyncClient() as client:
             try:
-                response = await client.post(
-                    "https://api.graphql.imdb.com/",
-                    json=query,
-                    headers={"Content-Type": "application/json"},
-                    timeout=10
-                )
+                response = await client.post("https://api.graphql.imdb.com/", json=query, headers={"Content-Type": "application/json"}, timeout=10)
                 response.raise_for_status()
                 data = response.json()
             except Exception as e:

--- a/src/imdb.py
+++ b/src/imdb.py
@@ -349,7 +349,7 @@ class ImdbManager:
             edition_list: list[str] = []
             imdb_info["edition_details"] = {}
 
-            for edge in editions:
+            for _edition_idx, edge in enumerate(editions):
                 node = self.safe_get(edge, ["node"], {})
                 seconds = self.safe_get(node, ["seconds"], 0)
                 minutes = seconds // 60 if seconds else 0
@@ -368,7 +368,7 @@ class ImdbManager:
                 if seconds and displayable_property:
                     edition_list.append(edition_display)
 
-                    runtime_key = str(minutes)
+                    runtime_key = f"{minutes}_{_edition_idx}"
                     imdb_info["edition_details"][runtime_key] = {"display_name": displayable_property, "seconds": seconds, "minutes": minutes, "attributes": attribute_texts}
 
             imdb_info["edition_count"] = len(edition_list)

--- a/src/metadata_searching.py
+++ b/src/metadata_searching.py
@@ -18,6 +18,22 @@ def _coerce_int(value: Any) -> Optional[int]:
         return None
 
 
+def _apply_tvdb_series_metadata(meta: dict[str, Any], episodes_data: Any, series_name: Any = None) -> None:
+    if meta.get('original_language') == 'en':
+        return
+
+    if series_name:
+        meta['tvdb_series_name'] = series_name
+    if isinstance(episodes_data, dict):
+        series_title = episodes_data.get('series_title')
+        if series_title and not meta.get('tvdb_series_name'):
+            meta['tvdb_series_name'] = series_title
+        series_year = episodes_data.get('series_year')
+        if isinstance(series_year, (str, int)) and re.fullmatch(r'19\d\d|20[0-3]\d', str(series_year)):
+            meta['tvdb_series_year'] = str(series_year)
+            meta['search_year'] = str(series_year)
+
+
 class MetadataSearchingManager:
     def __init__(self, config: dict[str, Any]) -> None:
         self.tvdb_handler = tvdb_data(config)
@@ -206,8 +222,7 @@ async def all_ids(meta: dict[str, Any], tvdb_handler: Any, tmdb_manager: TmdbMan
                 episodes_data, series_name = None, None
             if episodes_data is not None:
                 meta['tvdb_episode_data'] = episodes_data
-                if series_name:
-                    meta['tvdb_series_name'] = series_name
+                _apply_tvdb_series_metadata(meta, episodes_data, series_name)
                 meta['we_checked_tvdb'] = True
             else:
                 console.print(f"[yellow]Unexpected TVDb data format: {tvdb_episode_data!r}[/yellow]")
@@ -377,8 +392,7 @@ async def imdb_tmdb_tvdb(meta: dict[str, Any], filename: str, tvdb_handler: Any,
                         episodes_data, series_name = tvdb_episode_tuple
                 if episodes_data is not None:
                     meta['tvdb_episode_data'] = episodes_data
-                    if series_name:
-                        meta['tvdb_series_name'] = series_name
+                    _apply_tvdb_series_metadata(meta, episodes_data, series_name)
                     meta['we_checked_tvdb'] = True
                 else:
                     console.print(f"[yellow]Unexpected TVDb data format: {tvdb_episode_data!r}[/yellow]")
@@ -488,8 +502,7 @@ async def imdb_tvdb(meta: dict[str, Any], filename: str, tvdb_handler: Any, tmdb
                     episodes_data, series_name = tvdb_episode_tuple
             if episodes_data is not None:
                 meta['tvdb_episode_data'] = episodes_data
-                if series_name:
-                    meta['tvdb_series_name'] = series_name
+                _apply_tvdb_series_metadata(meta, episodes_data, series_name)
                 meta['we_checked_tvdb'] = True
             else:
                 console.print(f"[yellow]Unexpected TVDb data format: {tvdb_episode_data!r}[/yellow]")
@@ -778,16 +791,7 @@ async def get_tv_data(meta: dict[str, Any], tvdb_handler: Any, tmdb_manager: Tmd
             )
             if tvdb_episode_data:
                 meta['tvdb_episode_data'] = tvdb_episode_data
-            if tvdb_name:
-                meta['tvdb_series_name'] = tvdb_name
-
-        tvdb_series_name = meta.get('tvdb_series_name')
-        if isinstance(tvdb_series_name, str):
-            year_match = re.search(r'\b(19\d\d|20[0-3]\d)\b', tvdb_series_name)
-            if year_match:
-                meta['search_year'] = year_match.group(0)
-            else:
-                meta['search_year'] = ""
+            _apply_tvdb_series_metadata(meta, tvdb_episode_data, tvdb_name)
 
         if meta.get('tvdb_episode_data', None) and meta.get('tvdb_id', 0):
             try:
@@ -899,15 +903,7 @@ async def get_tv_data(meta: dict[str, Any], tvdb_handler: Any, tmdb_manager: Tmd
             )
             if tvdb_episode_data:
                 meta['tvdb_episode_data'] = tvdb_episode_data
-            if tvdb_name:
-                meta['tvdb_series_name'] = tvdb_name
-        tvdb_series_name = meta.get('tvdb_series_name')
-        if isinstance(tvdb_series_name, str):
-            year_match = re.search(r'\b(19\d\d|20[0-3]\d)\b', tvdb_series_name)
-            if year_match:
-                meta['search_year'] = year_match.group(0)
-            else:
-                meta['search_year'] = ""
+            _apply_tvdb_series_metadata(meta, tvdb_episode_data, tvdb_name)
 
         if meta.get('tvdb_episode_data', None) and meta.get('tvdb_id', 0):
             try:
@@ -1015,16 +1011,15 @@ async def get_tvdb_tvmaze_tmdb_episode_data(meta: dict[str, Any], tvdb_handler: 
                     tvdb_episode_data, tvdb_name = tvdb_tuple
             if tvdb_episode_data is not None:
                 meta['tvdb_episode_data'] = tvdb_episode_data
+                _apply_tvdb_series_metadata(meta, tvdb_episode_data, tvdb_name)
                 meta['we_checked_tvdb'] = True
                 if meta['debug'] and isinstance(tvdb_episode_data, list):
                     tvdb_episode_list = cast(list[Any], tvdb_episode_data)
                     console.print(f"[green]TVDb episodes list retrieved with {len(tvdb_episode_list)} episodes[/green]")
             else:
                 console.print(f"[yellow]Unexpected TVDb episodes result format: {tvdb_episodes_result}[/yellow]")
-            if tvdb_name:
-                meta['tvdb_series_name'] = tvdb_name
-                if meta['debug']:
-                    console.print(f"[green]TVDb series name: {tvdb_name}[/green]")
+            if tvdb_name and meta['debug']:
+                console.print(f"[green]TVDb series name: {tvdb_name}[/green]")
         elif isinstance(tvdb_episodes_result, Exception):
             console.print(f"[yellow]TVDb episode data retrieval failed: {tvdb_episodes_result}[/yellow]")
 
@@ -1040,5 +1035,3 @@ async def get_tvdb_tvmaze_tmdb_episode_data(meta: dict[str, Any], tvdb_handler: 
             console.print(f"[yellow]TMDb episode data retrieval failed: {tmdb_episode_data}[/yellow]")
 
     return meta
-
-

--- a/src/metadata_searching.py
+++ b/src/metadata_searching.py
@@ -19,19 +19,19 @@ def _coerce_int(value: Any) -> Optional[int]:
 
 
 def _apply_tvdb_series_metadata(meta: dict[str, Any], episodes_data: Any, series_name: Any = None) -> None:
-    if meta.get('original_language') == 'en':
+    if meta.get("original_language") == "en":
         return
 
     if series_name:
-        meta['tvdb_series_name'] = series_name
+        meta["tvdb_series_name"] = series_name
     if isinstance(episodes_data, dict):
-        series_title = episodes_data.get('series_title')
-        if series_title and not meta.get('tvdb_series_name'):
-            meta['tvdb_series_name'] = series_title
-        series_year = episodes_data.get('series_year')
-        if isinstance(series_year, (str, int)) and re.fullmatch(r'19\d\d|20[0-3]\d', str(series_year)):
-            meta['tvdb_series_year'] = str(series_year)
-            meta['search_year'] = str(series_year)
+        series_title = episodes_data.get("series_title")
+        if series_title and not meta.get("tvdb_series_name"):
+            meta["tvdb_series_name"] = series_title
+        series_year = episodes_data.get("series_year")
+        if isinstance(series_year, (str, int)) and re.fullmatch(r"19\d\d|20[0-3]\d", str(series_year)):
+            meta["tvdb_series_year"] = str(series_year)
+            meta["search_year"] = str(series_year)
 
 
 class MetadataSearchingManager:
@@ -59,7 +59,7 @@ class MetadataSearchingManager:
         tmdb: Optional[Union[int, str]],
         manual_date: Optional[str] = None,
         tvmaze_manual: Optional[str] = None,
-        year: str = '',
+        year: str = "",
         debug: bool = False,
         tv_movie: bool = False,
     ) -> tuple[int, int, Optional[Any], str]:
@@ -84,94 +84,69 @@ class MetadataSearchingManager:
 
 
 async def all_ids(meta: dict[str, Any], tvdb_handler: Any, tmdb_manager: TmdbManager) -> dict[str, Any]:
-    if meta['debug']:
+    if meta["debug"]:
         console.print("[yellow]Starting metadata retrieval with all IDs present[/yellow]")
     # Create a list of all tasks to run in parallel
     all_tasks: list[Awaitable[Any]] = [
         # Core metadata tasks
         tmdb_manager.tmdb_other_meta(
-            tmdb_id=meta['tmdb_id'],
-            path=meta.get('path'),
-            search_year=meta.get('search_year'),
-            category=meta.get('category'),
-            imdb_id=meta.get('imdb_id', 0),
-            manual_language=meta.get('manual_language'),
-            anime=meta.get('anime', False),
-            mal_manual=meta.get('mal_manual'),
-            aka=meta.get('aka', ''),
-            original_language=meta.get('original_language'),
-            poster=meta.get('poster'),
-            debug=meta.get('debug', False),
-            mode=meta.get('mode', 'cli'),
-            tvdb_id=meta.get('tvdb_id', 0),
-            filename=meta.get('filename', '')
+            tmdb_id=meta["tmdb_id"],
+            path=meta.get("path"),
+            search_year=meta.get("search_year"),
+            category=meta.get("category"),
+            imdb_id=meta.get("imdb_id", 0),
+            manual_language=meta.get("manual_language"),
+            anime=meta.get("anime", False),
+            mal_manual=meta.get("mal_manual"),
+            aka=meta.get("aka", ""),
+            original_language=meta.get("original_language"),
+            poster=meta.get("poster"),
+            debug=meta.get("debug", False),
+            mode=meta.get("mode", "cli"),
+            tvdb_id=meta.get("tvdb_id", 0),
+            filename=meta.get("filename", ""),
         ),
-        imdb_manager.get_imdb_info_api(
-            meta['imdb_id'],
-            manual_language=meta.get('manual_language'),
-            debug=meta.get('debug', False)
-        )
+        imdb_manager.get_imdb_info_api(meta["imdb_id"], manual_language=meta.get("manual_language"), debug=meta.get("debug", False)),
     ]
 
     # Always add get_tvdb_episodes for TV category
-    if meta.get('category') == 'TV':
+    if meta.get("category") == "TV":
         tvdb_episodes_task = tvdb_handler.get_tvdb_episodes(
-            meta['tvdb_id'],
-            meta.get('base_dir'),
-            meta.get('debug', False),
-            season=meta.get('season_int'),
-            episode=meta.get('episode_int'),
-            aired_date=meta.get('daily_episode_title'),
-            original_language=meta.get('original_language')
+            meta["tvdb_id"],
+            meta.get("base_dir"),
+            meta.get("debug", False),
+            season=meta.get("season_int"),
+            episode=meta.get("episode_int"),
+            aired_date=meta.get("daily_episode_title"),
+            original_language=meta.get("original_language"),
         )
         all_tasks.append(tvdb_episodes_task)
 
     # Add episode-specific tasks if this is a TV show with episodes
     tvmaze_task_idx: Optional[int] = None
     tmdb_task_idx: Optional[int] = None
-    if (meta['category'] == 'TV' and not meta.get('tv_pack', False) and
-            'season_int' in meta and 'episode_int' in meta and meta.get('episode_int') != 0):
-
+    if meta["category"] == "TV" and not meta.get("tv_pack", False) and "season_int" in meta and "episode_int" in meta and meta.get("episode_int") != 0:
         # Add TVMaze episode details task
-        tvmaze_id = _coerce_int(meta.get('tvmaze_id'))
-        season_int = _coerce_int(meta.get('season_int'))
-        episode_int = _coerce_int(meta.get('episode_int'))
+        tvmaze_id = _coerce_int(meta.get("tvmaze_id"))
+        season_int = _coerce_int(meta.get("season_int"))
+        episode_int = _coerce_int(meta.get("episode_int"))
         if tvmaze_id is not None and season_int is not None and episode_int is not None:
             tvmaze_task_idx = len(all_tasks)
-            all_tasks.append(
-                tvmaze_manager.get_tvmaze_episode_data(
-                    tvmaze_id,
-                    season_int,
-                    episode_int
-                )
-            )
+            all_tasks.append(tvmaze_manager.get_tvmaze_episode_data(tvmaze_id, season_int, episode_int))
         # TMDb last
-        tmdb_id = _coerce_int(meta.get('tmdb_id'))
-        season_int = _coerce_int(meta.get('season_int'))
-        episode_int = _coerce_int(meta.get('episode_int'))
+        tmdb_id = _coerce_int(meta.get("tmdb_id"))
+        season_int = _coerce_int(meta.get("season_int"))
+        episode_int = _coerce_int(meta.get("episode_int"))
         if tmdb_id is not None and season_int is not None and episode_int is not None:
             tmdb_task_idx = len(all_tasks)
-            all_tasks.append(
-                tmdb_manager.get_episode_details(
-                    tmdb_id,
-                    season_int,
-                    episode_int,
-                    debug=meta.get('debug', False)
-                )
-            )
-    elif meta['category'] == 'TV' and meta.get('tv_pack', False) and 'season_int' in meta:
+            all_tasks.append(tmdb_manager.get_episode_details(tmdb_id, season_int, episode_int, debug=meta.get("debug", False)))
+    elif meta["category"] == "TV" and meta.get("tv_pack", False) and "season_int" in meta:
         # For TV packs, we might want to get season details instead
-        tmdb_id = _coerce_int(meta.get('tmdb_id'))
-        season_int = _coerce_int(meta.get('season_int'))
+        tmdb_id = _coerce_int(meta.get("tmdb_id"))
+        season_int = _coerce_int(meta.get("season_int"))
         if tmdb_id is not None and season_int is not None:
             tmdb_task_idx = len(all_tasks)
-            all_tasks.append(
-                tmdb_manager.get_season_details(
-                    tmdb_id,
-                    season_int,
-                    debug=meta.get('debug', False)
-                )
-            )
+            all_tasks.append(tmdb_manager.get_season_details(tmdb_id, season_int, debug=meta.get("debug", False)))
 
     # Execute all tasks in parallel
     try:
@@ -197,17 +172,17 @@ async def all_ids(meta: dict[str, Any], tvdb_handler: Any, tmdb_manager: TmdbMan
 
     # Process IMDB info
     if isinstance(imdb_info, dict):
-        meta['imdb_info'] = imdb_info
+        meta["imdb_info"] = imdb_info
 
     elif isinstance(imdb_info, Exception):
         console.print(f"[red]IMDb API call failed: {imdb_info}[/red]")
-        meta['imdb_info'] = meta.get('imdb_info', {})  # Keep previous IMDb info if it exists
+        meta["imdb_info"] = meta.get("imdb_info", {})  # Keep previous IMDb info if it exists
     else:
         console.print("[red]Unexpected IMDb response, setting imdb_info to empty.[/red]")
-        meta['imdb_info'] = {}
+        meta["imdb_info"] = {}
 
     # Process TVDB episodes data if it was requested for TV category
-    if meta.get('category') == 'TV':
+    if meta.get("category") == "TV":
         tvdb_episode_data = results[result_index]
         result_index += 1
         if tvdb_episode_data and not isinstance(tvdb_episode_data, Exception):
@@ -221,22 +196,22 @@ async def all_ids(meta: dict[str, Any], tvdb_handler: Any, tmdb_manager: TmdbMan
             else:
                 episodes_data, series_name = None, None
             if episodes_data is not None:
-                meta['tvdb_episode_data'] = episodes_data
+                meta["tvdb_episode_data"] = episodes_data
                 _apply_tvdb_series_metadata(meta, episodes_data, series_name)
-                meta['we_checked_tvdb'] = True
+                meta["we_checked_tvdb"] = True
             else:
                 console.print(f"[yellow]Unexpected TVDb data format: {tvdb_episode_data!r}[/yellow]")
         elif isinstance(tvdb_episode_data, Exception):
             console.print(f"[yellow]TVDb episode data retrieval failed: {tvdb_episode_data}[/yellow]")
 
     # Process episode data if this is a TV show
-    if meta['category'] == 'TV' and not meta.get('tv_pack', False) and meta.get('episode_int', 0) != 0:
+    if meta["category"] == "TV" and not meta.get("tv_pack", False) and meta.get("episode_int", 0) != 0:
         # Process TVMaze episode data
         if tvmaze_task_idx is not None:
             tvmaze_episode_data = results[tvmaze_task_idx]
             if not isinstance(tvmaze_episode_data, Exception) and tvmaze_episode_data:
-                meta['tvmaze_episode_data'] = tvmaze_episode_data
-                meta['we_asked_tvmaze'] = True
+                meta["tvmaze_episode_data"] = tvmaze_episode_data
+                meta["we_asked_tvmaze"] = True
             elif isinstance(tvmaze_episode_data, Exception):
                 console.print(f"[yellow]TVMaze episode data retrieval failed: {tvmaze_episode_data}")
 
@@ -244,18 +219,18 @@ async def all_ids(meta: dict[str, Any], tvdb_handler: Any, tmdb_manager: TmdbMan
         if tmdb_task_idx is not None:
             tmdb_episode_data = results[tmdb_task_idx]
             if not isinstance(tmdb_episode_data, Exception) and tmdb_episode_data:
-                meta['tmdb_episode_data'] = tmdb_episode_data
-                meta['we_checked_tmdb'] = True
+                meta["tmdb_episode_data"] = tmdb_episode_data
+                meta["we_checked_tmdb"] = True
             elif isinstance(tmdb_episode_data, Exception):
                 console.print(f"[yellow]TMDb episode data retrieval failed: {tmdb_episode_data}")
 
-    elif meta['category'] == 'TV' and meta.get('tv_pack', False) and 'season_int' in meta:
+    elif meta["category"] == "TV" and meta.get("tv_pack", False) and "season_int" in meta:
         # Process TMDb season data for TV packs
         if tmdb_task_idx is not None:
             tmdb_season_data = results[tmdb_task_idx]
             if not isinstance(tmdb_season_data, Exception) and tmdb_season_data:
-                meta['tmdb_season_data'] = tmdb_season_data
-                meta['we_checked_tmdb'] = True
+                meta["tmdb_season_data"] = tmdb_season_data
+                meta["we_checked_tmdb"] = True
             elif isinstance(tmdb_season_data, Exception):
                 console.print(f"[yellow]TMDb season data retrieval failed: {tmdb_season_data}[/yellow]")
 
@@ -263,82 +238,71 @@ async def all_ids(meta: dict[str, Any], tvdb_handler: Any, tmdb_manager: TmdbMan
 
 
 async def imdb_tmdb_tvdb(meta: dict[str, Any], filename: str, tvdb_handler: Any, tmdb_manager: TmdbManager) -> dict[str, Any]:
-    if meta['debug']:
+    if meta["debug"]:
         console.print("[yellow]IMDb, TMDb, and TVDb IDs are all present[/yellow]")
     # Core metadata tasks that run in parallel
     tasks: list[Awaitable[Any]] = [
         tmdb_manager.tmdb_other_meta(
-            tmdb_id=meta['tmdb_id'],
-            path=meta.get('path'),
-            search_year=meta.get('search_year'),
-            category=meta.get('category'),
-            imdb_id=meta.get('imdb_id', 0),
-            manual_language=meta.get('manual_language'),
-            anime=meta.get('anime', False),
-            mal_manual=meta.get('mal_manual'),
-            aka=meta.get('aka', ''),
-            original_language=meta.get('original_language'),
-            poster=meta.get('poster'),
-            debug=meta.get('debug', False),
-            mode=meta.get('mode', 'cli'),
-            tvdb_id=meta.get('tvdb_id', 0),
-            filename=filename
+            tmdb_id=meta["tmdb_id"],
+            path=meta.get("path"),
+            search_year=meta.get("search_year"),
+            category=meta.get("category"),
+            imdb_id=meta.get("imdb_id", 0),
+            manual_language=meta.get("manual_language"),
+            anime=meta.get("anime", False),
+            mal_manual=meta.get("mal_manual"),
+            aka=meta.get("aka", ""),
+            original_language=meta.get("original_language"),
+            poster=meta.get("poster"),
+            debug=meta.get("debug", False),
+            mode=meta.get("mode", "cli"),
+            tvdb_id=meta.get("tvdb_id", 0),
+            filename=filename,
         ),
-
-        imdb_manager.get_imdb_info_api(
-            meta['imdb_id'],
-            manual_language=meta.get('manual_language'),
-            debug=meta.get('debug', False)
-        ),
+        imdb_manager.get_imdb_info_api(meta["imdb_id"], manual_language=meta.get("manual_language"), debug=meta.get("debug", False)),
     ]
 
-    if meta.get('category') == 'TV':
+    if meta.get("category") == "TV":
         tasks.append(
             tvmaze_manager.search_tvmaze(
-                filename, meta['search_year'], meta.get('imdb_id', 0), meta.get('tvdb_id', 0),
-                manual_date=meta.get('manual_date'),
-                tvmaze_manual=meta.get('tvmaze_manual'),
-                debug=meta.get('debug', False),
-                return_full_tuple=False
+                filename,
+                meta["search_year"],
+                meta.get("imdb_id", 0),
+                meta.get("tvdb_id", 0),
+                manual_date=meta.get("manual_date"),
+                tvmaze_manual=meta.get("tvmaze_manual"),
+                debug=meta.get("debug", False),
+                return_full_tuple=False,
             )
         )
 
-    if meta.get('category') == 'TV':
+    if meta.get("category") == "TV":
         tvdb_task = tvdb_handler.get_tvdb_episodes(
-            meta['tvdb_id'],
-            meta.get('base_dir'),
-            meta.get('debug', False),
-            season=meta.get('season_int'),
-            episode=meta.get('episode_int'),
-            aired_date=meta.get('daily_episode_title'),
-            original_language=meta.get('original_language')
+            meta["tvdb_id"],
+            meta.get("base_dir"),
+            meta.get("debug", False),
+            season=meta.get("season_int"),
+            episode=meta.get("episode_int"),
+            aired_date=meta.get("daily_episode_title"),
+            original_language=meta.get("original_language"),
         )
         tasks.append(tvdb_task)
 
-        if not meta.get('tv_pack', False) and 'season_int' in meta and 'episode_int' in meta and meta.get('episode_int') != 0:
+        if not meta.get("tv_pack", False) and "season_int" in meta and "episode_int" in meta and meta.get("episode_int") != 0:
             # Add TMDb episode details task
-            tmdb_id = _coerce_int(meta.get('tmdb_id'))
-            season_int = _coerce_int(meta.get('season_int'))
-            episode_int = _coerce_int(meta.get('episode_int'))
+            tmdb_id = _coerce_int(meta.get("tmdb_id"))
+            season_int = _coerce_int(meta.get("season_int"))
+            episode_int = _coerce_int(meta.get("episode_int"))
             if tmdb_id is not None and season_int is not None and episode_int is not None:
-                tmdb_episode_task = tmdb_manager.get_episode_details(
-                    tmdb_id,
-                    season_int,
-                    episode_int,
-                    debug=meta.get('debug', False)
-                )
+                tmdb_episode_task = tmdb_manager.get_episode_details(tmdb_id, season_int, episode_int, debug=meta.get("debug", False))
                 tasks.append(tmdb_episode_task)
 
-        if meta.get('tv_pack') and 'season_int' in meta:
+        if meta.get("tv_pack") and "season_int" in meta:
             # For TV packs, we might want to get season details instead
-            tmdb_id = _coerce_int(meta.get('tmdb_id'))
-            season_int = _coerce_int(meta.get('season_int'))
+            tmdb_id = _coerce_int(meta.get("tmdb_id"))
+            season_int = _coerce_int(meta.get("season_int"))
             if tmdb_id is not None and season_int is not None:
-                tmdb_season_task = tmdb_manager.get_season_details(
-                    tmdb_id,
-                    season_int,
-                    debug=meta.get('debug', False)
-                )
+                tmdb_season_task = tmdb_manager.get_season_details(tmdb_id, season_int, debug=meta.get("debug", False))
                 tasks.append(tmdb_season_task)
 
     # Execute all tasks in parallel
@@ -358,26 +322,26 @@ async def imdb_tmdb_tvdb(meta: dict[str, Any], filename: str, tvdb_handler: Any,
         imdb_info = results[result_index]
         result_index += 1
         if isinstance(imdb_info, dict):
-            meta['imdb_info'] = imdb_info
+            meta["imdb_info"] = imdb_info
 
         elif isinstance(imdb_info, Exception):
             console.print(f"[red]IMDb API call failed: {imdb_info}[/red]")
-            meta['imdb_info'] = meta.get('imdb_info', {})
+            meta["imdb_info"] = meta.get("imdb_info", {})
         else:
             console.print("[red]Unexpected IMDb response, setting imdb_info to empty.[/red]")
-            meta['imdb_info'] = {}
+            meta["imdb_info"] = {}
 
-    if meta.get('category') == 'TV' and len(results) > result_index:
+    if meta.get("category") == "TV" and len(results) > result_index:
         tvmaze_id = results[result_index]
         result_index += 1
 
         if isinstance(tvmaze_id, int):
-            meta['tvmaze_id'] = tvmaze_id
+            meta["tvmaze_id"] = tvmaze_id
         elif isinstance(tvmaze_id, Exception):
             console.print(f"[yellow]TVMaze ID retrieval failed: {tvmaze_id}[/yellow]")
-            meta['tvmaze_id'] = 0
+            meta["tvmaze_id"] = 0
 
-    if meta.get('category') == 'TV':
+    if meta.get("category") == "TV":
         if len(results) > result_index:
             tvdb_episode_data = results[result_index]
             result_index += 1
@@ -391,35 +355,34 @@ async def imdb_tmdb_tvdb(meta: dict[str, Any], filename: str, tvdb_handler: Any,
                     if len(tvdb_episode_tuple) == 2:
                         episodes_data, series_name = tvdb_episode_tuple
                 if episodes_data is not None:
-                    meta['tvdb_episode_data'] = episodes_data
+                    meta["tvdb_episode_data"] = episodes_data
                     _apply_tvdb_series_metadata(meta, episodes_data, series_name)
-                    meta['we_checked_tvdb'] = True
+                    meta["we_checked_tvdb"] = True
                 else:
                     console.print(f"[yellow]Unexpected TVDb data format: {tvdb_episode_data!r}[/yellow]")
             elif isinstance(tvdb_episode_data, Exception):
                 console.print(f"[yellow]TVDb episode data retrieval failed: {tvdb_episode_data}[/yellow]")
 
         # Process TMDb episode data only if we added that task
-        if (not meta.get('tv_pack', False) and 'season_int' in meta and
-                'episode_int' in meta and meta.get('episode_int') != 0 and len(results) > result_index):
+        if not meta.get("tv_pack", False) and "season_int" in meta and "episode_int" in meta and meta.get("episode_int") != 0 and len(results) > result_index:
             tmdb_episode_data = results[result_index]
             result_index += 1
 
             if not isinstance(tmdb_episode_data, Exception) and tmdb_episode_data:
-                meta['tmdb_episode_data'] = tmdb_episode_data
-                meta['we_checked_tmdb'] = True
+                meta["tmdb_episode_data"] = tmdb_episode_data
+                meta["we_checked_tmdb"] = True
 
             elif isinstance(tmdb_episode_data, Exception):
                 console.print(f"[yellow]TMDb episode data retrieval failed: {tmdb_episode_data}[/yellow]")
 
         # Process TMDb season data for TV packs
-        elif (meta.get('tv_pack', False) and 'season_int' in meta and len(results) > result_index):
+        elif meta.get("tv_pack", False) and "season_int" in meta and len(results) > result_index:
             tmdb_season_data = results[result_index]
             result_index += 1
 
             if not isinstance(tmdb_season_data, Exception) and tmdb_season_data:
-                meta['tmdb_season_data'] = tmdb_season_data
-                meta['we_checked_tmdb'] = True
+                meta["tmdb_season_data"] = tmdb_season_data
+                meta["we_checked_tmdb"] = True
 
             elif isinstance(tmdb_season_data, Exception):
                 console.print(f"[yellow]TMDb season data retrieval failed: {tmdb_season_data}[/yellow]")
@@ -428,41 +391,40 @@ async def imdb_tmdb_tvdb(meta: dict[str, Any], filename: str, tvdb_handler: Any,
 
 
 async def imdb_tvdb(meta: dict[str, Any], filename: str, tvdb_handler: Any, tmdb_manager: TmdbManager) -> dict[str, Any]:
-    if meta['debug']:
+    if meta["debug"]:
         console.print("[yellow]Both IMDb and TVDB IDs are present[/yellow]")
     tasks: list[Awaitable[Any]] = [
         tmdb_manager.get_tmdb_from_imdb(
-            meta['imdb_id'],
-            meta.get('tvdb_id'),
-            meta.get('search_year'),
+            meta["imdb_id"],
+            meta.get("tvdb_id"),
+            meta.get("search_year"),
             filename,
-            debug=meta.get('debug', False),
-            mode=meta.get('mode', 'discord'),
-            category_preference=meta.get('category')
+            debug=meta.get("debug", False),
+            mode=meta.get("mode", "discord"),
+            category_preference=meta.get("category"),
         ),
         tvmaze_manager.search_tvmaze(
-            filename, meta['search_year'], meta.get('imdb_id', 0), meta.get('tvdb_id', 0),
-            manual_date=meta.get('manual_date'),
-            tvmaze_manual=meta.get('tvmaze_manual'),
-            debug=meta.get('debug', False),
-            return_full_tuple=False
+            filename,
+            meta["search_year"],
+            meta.get("imdb_id", 0),
+            meta.get("tvdb_id", 0),
+            manual_date=meta.get("manual_date"),
+            tvmaze_manual=meta.get("tvmaze_manual"),
+            debug=meta.get("debug", False),
+            return_full_tuple=False,
         ),
-        imdb_manager.get_imdb_info_api(
-            meta['imdb_id'],
-            manual_language=meta.get('manual_language'),
-            debug=meta.get('debug', False)
-        )
+        imdb_manager.get_imdb_info_api(meta["imdb_id"], manual_language=meta.get("manual_language"), debug=meta.get("debug", False)),
     ]
 
-    if meta.get('category') == 'TV':
+    if meta.get("category") == "TV":
         tvdb_episodes_task = tvdb_handler.get_tvdb_episodes(
-            meta['tvdb_id'],
-            meta.get('base_dir'),
-            meta.get('debug', False),
-            season=meta.get('season_int'),
-            episode=meta.get('episode_int'),
-            aired_date=meta.get('daily_episode_title'),
-            original_language=meta.get('original_language')
+            meta["tvdb_id"],
+            meta.get("base_dir"),
+            meta.get("debug", False),
+            season=meta.get("season_int"),
+            episode=meta.get("episode_int"),
+            aired_date=meta.get("daily_episode_title"),
+            original_language=meta.get("original_language"),
         )
         tasks.append(tvdb_episodes_task)
 
@@ -472,25 +434,25 @@ async def imdb_tvdb(meta: dict[str, Any], filename: str, tvdb_handler: Any, tmdb
         tmdb_tuple = cast(tuple[Any, Any, Any, Any], tmdb_result)
         if len(tmdb_tuple) == 4:
             category, tmdb_id, original_language, filename_search = tmdb_tuple
-            meta['category'] = category
-            meta['tmdb_id'] = tmdb_id
-            meta['original_language'] = original_language
-            meta['no_ids'] = filename_search
+            meta["category"] = category
+            meta["tmdb_id"] = tmdb_id
+            meta["original_language"] = original_language
+            meta["no_ids"] = filename_search
 
-    meta['tvmaze_id'] = tvmaze_id if isinstance(tvmaze_id, int) else 0
+    meta["tvmaze_id"] = tvmaze_id if isinstance(tvmaze_id, int) else 0
 
     if isinstance(imdb_info_result, dict):
-        meta['imdb_info'] = imdb_info_result
+        meta["imdb_info"] = imdb_info_result
 
     elif isinstance(imdb_info_result, Exception):
         console.print(f"[red]IMDb API call failed: {imdb_info_result}[/red]")
-        meta['imdb_info'] = meta.get('imdb_info', {})  # Keep previous IMDb info if it exists
+        meta["imdb_info"] = meta.get("imdb_info", {})  # Keep previous IMDb info if it exists
     else:
         console.print("[red]Unexpected IMDb response, setting imdb_info to empty.[/red]")
-        meta['imdb_info'] = {}
+        meta["imdb_info"] = {}
 
     # Process TVDB episodes data if it was requested
-    if meta.get('category') == 'TV' and len(results) > 3:
+    if meta.get("category") == "TV" and len(results) > 3:
         tvdb_episode_data = results[3]
         if tvdb_episode_data and not isinstance(tvdb_episode_data, Exception):
             # tvdb_episode_data is a tuple: (episodes_list, series_name)
@@ -501,9 +463,9 @@ async def imdb_tvdb(meta: dict[str, Any], filename: str, tvdb_handler: Any, tmdb
                 if len(tvdb_episode_tuple) == 2:
                     episodes_data, series_name = tvdb_episode_tuple
             if episodes_data is not None:
-                meta['tvdb_episode_data'] = episodes_data
+                meta["tvdb_episode_data"] = episodes_data
                 _apply_tvdb_series_metadata(meta, episodes_data, series_name)
-                meta['we_checked_tvdb'] = True
+                meta["we_checked_tvdb"] = True
             else:
                 console.print(f"[yellow]Unexpected TVDb data format: {tvdb_episode_data!r}[/yellow]")
         elif isinstance(tvdb_episode_data, Exception):
@@ -516,69 +478,53 @@ async def imdb_tmdb(meta: dict[str, Any], filename: str, _tvdb_handler: Any, tmd
     # Create a list of coroutines to run concurrently
     coroutines: list[Awaitable[Any]] = [
         tmdb_manager.tmdb_other_meta(
-            tmdb_id=meta['tmdb_id'],
-            path=meta.get('path'),
-            search_year=meta.get('search_year'),
-            category=meta.get('category'),
-            imdb_id=meta.get('imdb_id', 0),
-            manual_language=meta.get('manual_language'),
-            anime=meta.get('anime', False),
-            mal_manual=meta.get('mal_manual'),
-            aka=meta.get('aka', ''),
-            original_language=meta.get('original_language'),
-            poster=meta.get('poster'),
-            debug=meta.get('debug', False),
-            mode=meta.get('mode', 'cli'),
-            tvdb_id=meta.get('tvdb_id', 0),
-            quickie_search=meta.get('quickie_search', False),
-            filename=filename
+            tmdb_id=meta["tmdb_id"],
+            path=meta.get("path"),
+            search_year=meta.get("search_year"),
+            category=meta.get("category"),
+            imdb_id=meta.get("imdb_id", 0),
+            manual_language=meta.get("manual_language"),
+            anime=meta.get("anime", False),
+            mal_manual=meta.get("mal_manual"),
+            aka=meta.get("aka", ""),
+            original_language=meta.get("original_language"),
+            poster=meta.get("poster"),
+            debug=meta.get("debug", False),
+            mode=meta.get("mode", "cli"),
+            tvdb_id=meta.get("tvdb_id", 0),
+            quickie_search=meta.get("quickie_search", False),
+            filename=filename,
         ),
-        imdb_manager.get_imdb_info_api(
-            meta['imdb_id'],
-            manual_language=meta.get('manual_language'),
-            debug=meta.get('debug', False)
-        )
+        imdb_manager.get_imdb_info_api(meta["imdb_id"], manual_language=meta.get("manual_language"), debug=meta.get("debug", False)),
     ]
 
     # Add TVMaze search if it's a TV category
-    if meta['category'] == 'TV':
+    if meta["category"] == "TV":
         coroutines.append(
             tvmaze_manager.search_tvmaze(
-                filename, meta['search_year'], meta.get('imdb_id', 0), meta.get('tvdb_id', 0),
-                manual_date=meta.get('manual_date'),
-                tvmaze_manual=meta.get('tvmaze_manual'),
-                debug=meta.get('debug', False),
-                return_full_tuple=False
+                filename,
+                meta["search_year"],
+                meta.get("imdb_id", 0),
+                meta.get("tvdb_id", 0),
+                manual_date=meta.get("manual_date"),
+                tvmaze_manual=meta.get("tvmaze_manual"),
+                debug=meta.get("debug", False),
+                return_full_tuple=False,
             )
         )
 
         # Add TMDb episode details if it's a TV show with episodes
-        if ('season_int' in meta and 'episode_int' in meta and
-                not meta.get('tv_pack', False) and
-                meta.get('episode_int') != 0):
-            tmdb_id = _coerce_int(meta.get('tmdb_id'))
-            season_int = _coerce_int(meta.get('season_int'))
-            episode_int = _coerce_int(meta.get('episode_int'))
+        if "season_int" in meta and "episode_int" in meta and not meta.get("tv_pack", False) and meta.get("episode_int") != 0:
+            tmdb_id = _coerce_int(meta.get("tmdb_id"))
+            season_int = _coerce_int(meta.get("season_int"))
+            episode_int = _coerce_int(meta.get("episode_int"))
             if tmdb_id is not None and season_int is not None and episode_int is not None:
-                coroutines.append(
-                    tmdb_manager.get_episode_details(
-                        tmdb_id,
-                        season_int,
-                        episode_int,
-                        debug=meta.get('debug', False)
-                    )
-                )
-        elif meta.get('tv_pack', False) and 'season_int' in meta:
-            tmdb_id = _coerce_int(meta.get('tmdb_id'))
-            season_int = _coerce_int(meta.get('season_int'))
+                coroutines.append(tmdb_manager.get_episode_details(tmdb_id, season_int, episode_int, debug=meta.get("debug", False)))
+        elif meta.get("tv_pack", False) and "season_int" in meta:
+            tmdb_id = _coerce_int(meta.get("tmdb_id"))
+            season_int = _coerce_int(meta.get("season_int"))
             if tmdb_id is not None and season_int is not None:
-                coroutines.append(
-                    tmdb_manager.get_season_details(
-                        tmdb_id,
-                        season_int,
-                        debug=meta.get('debug', False)
-                    )
-                )
+                coroutines.append(tmdb_manager.get_season_details(tmdb_id, season_int, debug=meta.get("debug", False)))
 
     # Gather results
     results: list[Any] = await asyncio.gather(*coroutines, return_exceptions=True)
@@ -604,17 +550,17 @@ async def imdb_tmdb(meta: dict[str, Any], filename: str, _tvdb_handler: Any, tmd
 
     # Process IMDb info
     if isinstance(imdb_info_result, dict):
-        meta['imdb_info'] = imdb_info_result
+        meta["imdb_info"] = imdb_info_result
 
     elif isinstance(imdb_info_result, Exception):
         console.print(f"[red]IMDb API call failed: {imdb_info_result}[/red]")
-        meta['imdb_info'] = meta.get('imdb_info', {})  # Keep previous IMDb info if it exists
+        meta["imdb_info"] = meta.get("imdb_info", {})  # Keep previous IMDb info if it exists
     else:
         console.print("[red]Unexpected IMDb response, setting imdb_info to empty.[/red]")
-        meta['imdb_info'] = {}
+        meta["imdb_info"] = {}
 
     # Process TVMaze results if it was included
-    if meta['category'] == 'TV':
+    if meta["category"] == "TV":
         if len(results) > 2:
             tvmaze_result = results[2]
             if isinstance(tvmaze_result, tuple):
@@ -627,38 +573,38 @@ async def imdb_tmdb(meta: dict[str, Any], filename: str, _tvdb_handler: Any, tmd
             else:
                 tvmaze_id, tvdb_id = None, None
             if tvmaze_id is not None:
-                meta['tvmaze_id'] = tvmaze_id if isinstance(tvmaze_id, int) else 0
+                meta["tvmaze_id"] = tvmaze_id if isinstance(tvmaze_id, int) else 0
 
                 # Set tvdb_id if not already set and we got a valid one
-                if not meta.get('tvdb_id', 0) and isinstance(tvdb_id, int) and tvdb_id > 0:
-                    meta['tvdb_id'] = tvdb_id
-                    if meta.get('debug'):
+                if not meta.get("tvdb_id", 0) and isinstance(tvdb_id, int) and tvdb_id > 0:
+                    meta["tvdb_id"] = tvdb_id
+                    if meta.get("debug"):
                         console.print(f"[green]Set TVDb ID from TVMaze: {tvdb_id}[/green]")
             elif isinstance(tvmaze_result, int):
-                meta['tvmaze_id'] = tvmaze_result
+                meta["tvmaze_id"] = tvmaze_result
             elif isinstance(tvmaze_result, Exception):
                 console.print(f"[red]TVMaze API call failed: {tvmaze_result}[/red]")
-                meta['tvmaze_id'] = 0  # Set default value if an exception occurred
+                meta["tvmaze_id"] = 0  # Set default value if an exception occurred
             else:
                 console.print(f"[yellow]Unexpected TVMaze result type: {tvmaze_result!r}[/yellow]")
-                meta['tvmaze_id'] = 0
+                meta["tvmaze_id"] = 0
 
         # Process TMDb episode details if they were included
-        if not meta.get('tv_pack', False):
+        if not meta.get("tv_pack", False):
             if len(results) > 3:
                 episode_details_result = results[3]
                 if isinstance(episode_details_result, dict):
-                    meta['tmdb_episode_data'] = episode_details_result
-                    meta['we_checked_tmdb'] = True
+                    meta["tmdb_episode_data"] = episode_details_result
+                    meta["we_checked_tmdb"] = True
 
                 elif isinstance(episode_details_result, Exception):
                     console.print(f"[red]TMDb episode details API call failed: {episode_details_result}[/red]")
         else:
-            if 'season_int' in meta and len(results) > 3:
+            if "season_int" in meta and len(results) > 3:
                 season_details_result = results[3]
                 if isinstance(season_details_result, dict):
-                    meta['tmdb_season_data'] = season_details_result
-                    meta['we_checked_tmdb'] = True
+                    meta["tmdb_season_data"] = season_details_result
+                    meta["we_checked_tmdb"] = True
 
                 elif isinstance(season_details_result, Exception):
                     console.print(f"[red]TMDb season details API call failed: {season_details_result}[/red]")
@@ -674,7 +620,7 @@ async def get_tvmaze_tvdb(
     tvdb_handler: Any,
     manual_date: Optional[str] = None,
     tvmaze_manual: Optional[str] = None,
-    year: str = '',
+    year: str = "",
     debug: bool = False,
     tv_movie: bool = False,
 ) -> tuple[int, int, Optional[Any], str]:
@@ -686,22 +632,12 @@ async def get_tvmaze_tvdb(
         console.print("[yellow]Finding both TVMaze and TVDb IDs[/yellow]")
     # Core metadata tasks that run in parallel
     tasks: list[Awaitable[Any]] = [
-        tvmaze_manager.search_tvmaze(
-            filename, search_year, imdb, 0,
-            manual_date=manual_date,
-            tvmaze_manual=tvmaze_manual,
-            debug=debug,
-            return_full_tuple=True
-        )
+        tvmaze_manager.search_tvmaze(filename, search_year, imdb, 0, manual_date=manual_date, tvmaze_manual=tvmaze_manual, debug=debug, return_full_tuple=True)
     ]
     if (imdb and imdb != 0) or (tmdb and tmdb != 0):
-        tasks.append(
-            tvdb_handler.get_tvdb_by_external_id(imdb=imdb, tmdb=tmdb, debug=debug, tv_movie=tv_movie)
-        )
+        tasks.append(tvdb_handler.get_tvdb_by_external_id(imdb=imdb, tmdb=tmdb, debug=debug, tv_movie=tv_movie))
     else:
-        tasks.append(
-            tvdb_handler.search_tvdb_series(filename=filename, year=year, debug=debug)
-        )
+        tasks.append(tvdb_handler.search_tvdb_series(filename=filename, year=year, debug=debug))
 
     results: list[Any] = await asyncio.gather(*tasks, return_exceptions=True)
 
@@ -775,212 +711,217 @@ async def get_tvmaze_tvdb(
 
 async def get_tv_data(meta: dict[str, Any], tvdb_handler: Any, tmdb_manager: TmdbManager) -> dict[str, Any]:
     if "tvdb_series_name" not in meta:
-        meta['tvdb_series_name'] = None
-    if not meta.get('tv_pack', False) and meta.get('episode_int') != 0:
-        if (not meta.get('we_checked_tvdb', False) and not meta.get('we_asked_tvmaze', False)) and meta.get('tvmaze_id') != 0 and meta['tvdb_id'] != 0 and meta.get('tmdb_id') != 0 and not meta.get('anime', False):
+        meta["tvdb_series_name"] = None
+    if not meta.get("tv_pack", False) and meta.get("episode_int") != 0:
+        if (
+            (not meta.get("we_checked_tvdb", False) and not meta.get("we_asked_tvmaze", False))
+            and meta.get("tvmaze_id") != 0
+            and meta["tvdb_id"] != 0
+            and meta.get("tmdb_id") != 0
+            and not meta.get("anime", False)
+        ):
             meta = await get_tvdb_tvmaze_tmdb_episode_data(meta, tvdb_handler, tmdb_manager)
-        elif meta.get('tvdb_id', 0) and not meta.get('we_checked_tvdb', False):
+        elif meta.get("tvdb_id", 0) and not meta.get("we_checked_tvdb", False):
             tvdb_episode_data, tvdb_name = await tvdb_handler.get_tvdb_episodes(
-                meta['tvdb_id'],
-                meta.get('base_dir'),
-                meta.get('debug', False),
-                season=meta.get('season_int'),
-                episode=meta.get('episode_int'),
-                aired_date=meta.get('daily_episode_title'),
-                original_language=meta.get('original_language')
+                meta["tvdb_id"],
+                meta.get("base_dir"),
+                meta.get("debug", False),
+                season=meta.get("season_int"),
+                episode=meta.get("episode_int"),
+                aired_date=meta.get("daily_episode_title"),
+                original_language=meta.get("original_language"),
             )
             if tvdb_episode_data:
-                meta['tvdb_episode_data'] = tvdb_episode_data
+                meta["tvdb_episode_data"] = tvdb_episode_data
             _apply_tvdb_series_metadata(meta, tvdb_episode_data, tvdb_name)
 
-        if meta.get('tvdb_episode_data', None) and meta.get('tvdb_id', 0):
+        if meta.get("tvdb_episode_data", None) and meta.get("tvdb_id", 0):
             try:
-                meta['tvdb_season_name'], meta['tvdb_episode_name'], meta['tvdb_overview'], meta['tvdb_season'], meta['tvdb_episode'], meta['tvdb_episode_year'], meta['tvdb_episode_id'] = await tvdb_handler.get_specific_episode_data(
-                    meta['tvdb_episode_data'],
-                    meta.get('season_int', None),
-                    meta.get('episode_int', None),
-                    debug=meta.get('debug', False),
-                    aired_date=meta.get('daily_episode_title')
+                (
+                    meta["tvdb_season_name"],
+                    meta["tvdb_episode_name"],
+                    meta["tvdb_overview"],
+                    meta["tvdb_season"],
+                    meta["tvdb_episode"],
+                    meta["tvdb_episode_year"],
+                    meta["tvdb_episode_id"],
+                ) = await tvdb_handler.get_specific_episode_data(
+                    meta["tvdb_episode_data"],
+                    meta.get("season_int", None),
+                    meta.get("episode_int", None),
+                    debug=meta.get("debug", False),
+                    aired_date=meta.get("daily_episode_title"),
                 )
             except Exception as e:
                 console.print(f"[red]Error fetching TVDb episode data: {e}[/red]")
 
-        tvdb_episode_name = meta.get('tvdb_episode_name')
+        tvdb_episode_name = meta.get("tvdb_episode_name")
         if isinstance(tvdb_episode_name, str):
             tvdb_name_lc = tvdb_episode_name.lower()
-            if tvdb_name_lc.startswith('episode') or 'tba' in tvdb_name_lc:
-                meta['auto_episode_title'] = None
+            if tvdb_name_lc.startswith("episode") or "tba" in tvdb_name_lc:
+                meta["auto_episode_title"] = None
             else:
-                meta['auto_episode_title'] = tvdb_episode_name
-        if meta.get('tvdb_overview', None):
-            meta['overview_meta'] = meta['tvdb_overview']
-        tvdb_season_int = _coerce_int(meta.get('tvdb_season'))
-        meta['tvdb_season_int'] = tvdb_season_int
-        if tvdb_season_int is not None and tvdb_season_int != meta.get('season_int', None) and not meta.get('season', None) and not meta.get('no_season', False) and not meta.get('manual_date', None):
-            meta['season_int'] = tvdb_season_int
-            meta['season'] = f"S{tvdb_season_int:02d}"
-        tvdb_episode_int = _coerce_int(meta.get('tvdb_episode'))
-        if tvdb_episode_int is not None and tvdb_episode_int != meta.get('episode_int', None) and not meta.get('episode', None) and not meta.get('manual_date', None):
-            meta['episode_int'] = tvdb_episode_int
-            meta['episode'] = f"E{tvdb_episode_int:02d}"
+                meta["auto_episode_title"] = tvdb_episode_name
+        if meta.get("tvdb_overview", None):
+            meta["overview_meta"] = meta["tvdb_overview"]
+        tvdb_season_int = _coerce_int(meta.get("tvdb_season"))
+        meta["tvdb_season_int"] = tvdb_season_int
+        if (
+            tvdb_season_int is not None
+            and tvdb_season_int != meta.get("season_int", None)
+            and not meta.get("season", None)
+            and not meta.get("no_season", False)
+            and not meta.get("manual_date", None)
+        ):
+            meta["season_int"] = tvdb_season_int
+            meta["season"] = f"S{tvdb_season_int:02d}"
+        tvdb_episode_int = _coerce_int(meta.get("tvdb_episode"))
+        if tvdb_episode_int is not None and tvdb_episode_int != meta.get("episode_int", None) and not meta.get("episode", None) and not meta.get("manual_date", None):
+            meta["episode_int"] = tvdb_episode_int
+            meta["episode"] = f"E{tvdb_episode_int:02d}"
 
         # fallback to tvmaze data if tvdb data is available
-        if 'tvmaze_episode_data' not in meta or meta['tvmaze_episode_data'] is None:
-            meta['tvmaze_episode_data'] = {}
-            tvmaze_id = _coerce_int(meta.get('tvmaze_id'))
-            season_int = _coerce_int(meta.get('season_int'))
-            episode_int = _coerce_int(meta.get('episode_int'))
+        if "tvmaze_episode_data" not in meta or meta["tvmaze_episode_data"] is None:
+            meta["tvmaze_episode_data"] = {}
+            tvmaze_id = _coerce_int(meta.get("tvmaze_id"))
+            season_int = _coerce_int(meta.get("season_int"))
+            episode_int = _coerce_int(meta.get("episode_int"))
             if tvmaze_id is not None and season_int is not None and episode_int is not None:
-                tvmaze_episode_data = await tvmaze_manager.get_tvmaze_episode_data(
-                    tvmaze_id,
-                    season_int,
-                    episode_int,
-                    meta
-                )
+                tvmaze_episode_data = await tvmaze_manager.get_tvmaze_episode_data(tvmaze_id, season_int, episode_int, meta)
                 if tvmaze_episode_data:
-                    meta['tvmaze_episode_data'] = tvmaze_episode_data
-        if meta.get('auto_episode_title') is None or meta.get('overview_meta') is None:
-            tvmaze_name = meta['tvmaze_episode_data'].get('name')
-            if meta.get('auto_episode_title') is None and isinstance(tvmaze_name, str):
+                    meta["tvmaze_episode_data"] = tvmaze_episode_data
+        if meta.get("auto_episode_title") is None or meta.get("overview_meta") is None:
+            tvmaze_name = meta["tvmaze_episode_data"].get("name")
+            if meta.get("auto_episode_title") is None and isinstance(tvmaze_name, str):
                 tvmaze_name_lc = tvmaze_name.lower()
-                if tvmaze_name_lc.startswith('episode') or 'tba' in tvmaze_name_lc:
-                    meta['auto_episode_title'] = None
+                if tvmaze_name_lc.startswith("episode") or "tba" in tvmaze_name_lc:
+                    meta["auto_episode_title"] = None
                 else:
-                    meta['auto_episode_title'] = tvmaze_name
-            tvmaze_overview = meta['tvmaze_episode_data'].get('overview')
-            if meta.get('overview_meta') is None and tvmaze_overview is not None:
-                meta['overview_meta'] = tvmaze_overview
+                    meta["auto_episode_title"] = tvmaze_name
+            tvmaze_overview = meta["tvmaze_episode_data"].get("overview")
+            if meta.get("overview_meta") is None and tvmaze_overview is not None:
+                meta["overview_meta"] = tvmaze_overview
 
         # fallback to tmdb data if no other data is not available
-        if (meta.get('auto_episode_title') is None or meta.get('overview_meta') is None) and meta.get('episode_overview', None):
-            if 'tvdb_episode_int' in meta and meta.get('tvdb_episode_int') != 0 and meta.get('tvdb_episode_int') != meta.get('episode_int'):
-                episode = _coerce_int(meta.get('episode_int'))
-                season = _coerce_int(meta.get('tvdb_season_int'))
-                if meta['debug']:
+        if (meta.get("auto_episode_title") is None or meta.get("overview_meta") is None) and meta.get("episode_overview", None):
+            if "tvdb_episode_int" in meta and meta.get("tvdb_episode_int") != 0 and meta.get("tvdb_episode_int") != meta.get("episode_int"):
+                episode = _coerce_int(meta.get("episode_int"))
+                season = _coerce_int(meta.get("tvdb_season_int"))
+                if meta["debug"]:
                     console.print(f"[yellow]Using absolute episode number from TVDb: {episode}[/yellow]")
                     console.print(f"[yellow]Using matching season number from TVDb: {season}[/yellow]")
             else:
-                episode = _coerce_int(meta.get('episode_int'))
-                season = _coerce_int(meta.get('season_int'))
-            if meta['debug']:
+                episode = _coerce_int(meta.get("episode_int"))
+                season = _coerce_int(meta.get("season_int"))
+            if meta["debug"]:
                 console.print("[yellow]Fetching TMDb episode metadata...")
             episode_details: dict[str, Any] = {}
-            if not meta.get('tmdb_episode_data'):
-                tmdb_id = _coerce_int(meta.get('tmdb_id'))
+            if not meta.get("tmdb_episode_data"):
+                tmdb_id = _coerce_int(meta.get("tmdb_id"))
                 if tmdb_id is not None and season is not None and episode is not None:
-                    episode_details_result = await tmdb_manager.get_episode_details(
-                        tmdb_id,
-                        season,
-                        episode,
-                        debug=meta.get('debug', False)
-                    )
+                    episode_details_result = await tmdb_manager.get_episode_details(tmdb_id, season, episode, debug=meta.get("debug", False))
                     if episode_details_result:
                         episode_details = episode_details_result
             else:
-                existing_episode_data = meta.get('tmdb_episode_data')
+                existing_episode_data = meta.get("tmdb_episode_data")
                 if existing_episode_data:
                     episode_details = existing_episode_data
             episode_name = episode_details.get("name")
-            if meta.get('auto_episode_title') is None and isinstance(episode_name, str):
+            if meta.get("auto_episode_title") is None and isinstance(episode_name, str):
                 episode_name_lc = episode_name.lower()
-                if episode_name_lc.startswith('episode') or 'tba' in episode_name_lc:
-                    meta['auto_episode_title'] = None
+                if episode_name_lc.startswith("episode") or "tba" in episode_name_lc:
+                    meta["auto_episode_title"] = None
                 else:
-                    meta['auto_episode_title'] = episode_name
-            if meta.get('overview_meta') is None and episode_details.get('overview') is not None:
-                meta['overview_meta'] = episode_details.get('overview', None)
+                    meta["auto_episode_title"] = episode_name
+            if meta.get("overview_meta") is None and episode_details.get("overview") is not None:
+                meta["overview_meta"] = episode_details.get("overview", None)
 
-    elif meta.get('tv_pack', False):
-        if not meta.get('we_checked_tvdb', False) and meta.get('tvdb_id', 0):
+    elif meta.get("tv_pack", False):
+        if not meta.get("we_checked_tvdb", False) and meta.get("tvdb_id", 0):
             tvdb_episode_data, tvdb_name = await tvdb_handler.get_tvdb_episodes(
-                meta['tvdb_id'],
-                meta.get('base_dir'),
-                meta.get('debug', False),
-                season=meta.get('season_int'),
-                episode=meta.get('episode_int'),
-                aired_date=meta.get('daily_episode_title'),
-                original_language=meta.get('original_language')
+                meta["tvdb_id"],
+                meta.get("base_dir"),
+                meta.get("debug", False),
+                season=meta.get("season_int"),
+                episode=meta.get("episode_int"),
+                aired_date=meta.get("daily_episode_title"),
+                original_language=meta.get("original_language"),
             )
             if tvdb_episode_data:
-                meta['tvdb_episode_data'] = tvdb_episode_data
+                meta["tvdb_episode_data"] = tvdb_episode_data
             _apply_tvdb_series_metadata(meta, tvdb_episode_data, tvdb_name)
 
-        if meta.get('tvdb_episode_data', None) and meta.get('tvdb_id', 0):
+        if meta.get("tvdb_episode_data", None) and meta.get("tvdb_id", 0):
             try:
-                meta['tvdb_season_name'], meta['tvdb_episode_name'], meta['tvdb_overview'], meta['tvdb_season'], meta['tvdb_episode'], meta['tvdb_episode_year'], meta['tvdb_episode_id'] = await tvdb_handler.get_specific_episode_data(
-                    meta['tvdb_episode_data'],
-                    meta.get('season_int', None),
-                    meta.get('episode_int', None),
-                    debug=meta.get('debug', False),
-                    aired_date=meta.get('daily_episode_title')
+                (
+                    meta["tvdb_season_name"],
+                    meta["tvdb_episode_name"],
+                    meta["tvdb_overview"],
+                    meta["tvdb_season"],
+                    meta["tvdb_episode"],
+                    meta["tvdb_episode_year"],
+                    meta["tvdb_episode_id"],
+                ) = await tvdb_handler.get_specific_episode_data(
+                    meta["tvdb_episode_data"],
+                    meta.get("season_int", None),
+                    meta.get("episode_int", None),
+                    debug=meta.get("debug", False),
+                    aired_date=meta.get("daily_episode_title"),
                 )
             except Exception as e:
                 console.print(f"[red]Error fetching TVDb episode data: {e}[/red]")
 
-        tvdb_episode_id = meta.get('tvdb_episode_id')
+        tvdb_episode_id = meta.get("tvdb_episode_id")
         if tvdb_episode_id is not None:
-            meta['tvdb_imdb_id'] = await tvdb_handler.get_imdb_id_from_tvdb_episode_id(tvdb_episode_id, debug=meta.get('debug', False))
+            meta["tvdb_imdb_id"] = await tvdb_handler.get_imdb_id_from_tvdb_episode_id(tvdb_episode_id, debug=meta.get("debug", False))
 
     return meta
 
 
 async def get_tvdb_tvmaze_tmdb_episode_data(meta: dict[str, Any], tvdb_handler: Any, tmdb_manager: TmdbManager) -> dict[str, Any]:
-    if meta['debug']:
+    if meta["debug"]:
         console.print("[yellow]Gathering TVDb and TVMaze episode data[/yellow]")
 
     tasks: list[Awaitable[Any]] = []
     task_map = {}  # Track which tasks we added
 
     # Add TVMaze episode data task
-    if meta.get('tvmaze_id'):
-        if meta['debug']:
+    if meta.get("tvmaze_id"):
+        if meta["debug"]:
             console.print("[yellow]Fetching TVMaze episode data...[/yellow]")
-        tvmaze_id = _coerce_int(meta.get('tvmaze_id'))
-        season_int = _coerce_int(meta.get('season_int'))
-        episode_int = _coerce_int(meta.get('episode_int'))
+        tvmaze_id = _coerce_int(meta.get("tvmaze_id"))
+        season_int = _coerce_int(meta.get("season_int"))
+        episode_int = _coerce_int(meta.get("episode_int"))
         if tvmaze_id is not None and season_int is not None and episode_int is not None:
-            tasks.append(
-                tvmaze_manager.get_tvmaze_episode_data(
-                    tvmaze_id,
-                    season_int,
-                    episode_int
-                )
-            )
-            task_map['tvmaze'] = len(tasks) - 1
+            tasks.append(tvmaze_manager.get_tvmaze_episode_data(tvmaze_id, season_int, episode_int))
+            task_map["tvmaze"] = len(tasks) - 1
 
     # Add TVDb episode data task
-    if meta.get('tvdb_id'):
-        if meta['debug']:
+    if meta.get("tvdb_id"):
+        if meta["debug"]:
             console.print("[yellow]Fetching TVDb episode data...[/yellow]")
         tasks.append(
             tvdb_handler.get_tvdb_episodes(
-                meta['tvdb_id'],
-                meta.get('base_dir'),
-                meta.get('debug', False),
-                season=meta.get('season_int'),
-                episode=meta.get('episode_int'),
-                aired_date=meta.get('daily_episode_title'),
-                original_language=meta.get('original_language')
+                meta["tvdb_id"],
+                meta.get("base_dir"),
+                meta.get("debug", False),
+                season=meta.get("season_int"),
+                episode=meta.get("episode_int"),
+                aired_date=meta.get("daily_episode_title"),
+                original_language=meta.get("original_language"),
             )
         )
-        task_map['tvdb'] = len(tasks) - 1
+        task_map["tvdb"] = len(tasks) - 1
 
-    if meta.get('tmdb_id'):
-        if meta['debug']:
+    if meta.get("tmdb_id"):
+        if meta["debug"]:
             console.print("[yellow]Fetching TMDb episode data...[/yellow]")
-        tmdb_id = _coerce_int(meta.get('tmdb_id'))
-        season_int = _coerce_int(meta.get('season_int'))
-        episode_int = _coerce_int(meta.get('episode_int'))
+        tmdb_id = _coerce_int(meta.get("tmdb_id"))
+        season_int = _coerce_int(meta.get("season_int"))
+        episode_int = _coerce_int(meta.get("episode_int"))
         if tmdb_id is not None and season_int is not None and episode_int is not None:
-            tasks.append(
-                tmdb_manager.get_episode_details(
-                    tmdb_id,
-                    season_int,
-                    episode_int,
-                    debug=meta.get('debug', False)
-                )
-            )
-            task_map['tmdb'] = len(tasks) - 1
+            tasks.append(tmdb_manager.get_episode_details(tmdb_id, season_int, episode_int, debug=meta.get("debug", False)))
+            task_map["tmdb"] = len(tasks) - 1
 
     if not tasks:
         return meta
@@ -988,20 +929,20 @@ async def get_tvdb_tvmaze_tmdb_episode_data(meta: dict[str, Any], tvdb_handler: 
     results: list[Any] = await asyncio.gather(*tasks, return_exceptions=True)
 
     # Process TVMaze results
-    if 'tvmaze' in task_map:
-        tvmaze_episode_data = results[task_map['tvmaze']]
+    if "tvmaze" in task_map:
+        tvmaze_episode_data = results[task_map["tvmaze"]]
         if tvmaze_episode_data and not isinstance(tvmaze_episode_data, Exception):
-            meta['tvmaze_episode_data'] = tvmaze_episode_data
-            meta['we_asked_tvmaze'] = True
+            meta["tvmaze_episode_data"] = tvmaze_episode_data
+            meta["we_asked_tvmaze"] = True
 
-            if meta['debug']:
+            if meta["debug"]:
                 console.print("[green]TVMaze episode data retrieved successfully.[/green]")
         elif isinstance(tvmaze_episode_data, Exception):
             console.print(f"[yellow]TVMaze episode data retrieval failed: {tvmaze_episode_data}[/yellow]")
 
     # Process TVDB results
-    if 'tvdb' in task_map:
-        tvdb_episodes_result = results[task_map['tvdb']]
+    if "tvdb" in task_map:
+        tvdb_episodes_result = results[task_map["tvdb"]]
         if tvdb_episodes_result and not isinstance(tvdb_episodes_result, Exception):
             tvdb_episode_data: Any = None
             tvdb_name: Any = None
@@ -1010,26 +951,26 @@ async def get_tvdb_tvmaze_tmdb_episode_data(meta: dict[str, Any], tvdb_handler: 
                 if len(tvdb_tuple) == 2:
                     tvdb_episode_data, tvdb_name = tvdb_tuple
             if tvdb_episode_data is not None:
-                meta['tvdb_episode_data'] = tvdb_episode_data
+                meta["tvdb_episode_data"] = tvdb_episode_data
                 _apply_tvdb_series_metadata(meta, tvdb_episode_data, tvdb_name)
-                meta['we_checked_tvdb'] = True
-                if meta['debug'] and isinstance(tvdb_episode_data, list):
+                meta["we_checked_tvdb"] = True
+                if meta["debug"] and isinstance(tvdb_episode_data, list):
                     tvdb_episode_list = cast(list[Any], tvdb_episode_data)
                     console.print(f"[green]TVDb episodes list retrieved with {len(tvdb_episode_list)} episodes[/green]")
             else:
                 console.print(f"[yellow]Unexpected TVDb episodes result format: {tvdb_episodes_result}[/yellow]")
-            if tvdb_name and meta['debug']:
+            if tvdb_name and meta["debug"]:
                 console.print(f"[green]TVDb series name: {tvdb_name}[/green]")
         elif isinstance(tvdb_episodes_result, Exception):
             console.print(f"[yellow]TVDb episode data retrieval failed: {tvdb_episodes_result}[/yellow]")
 
     # Process TMDb episode details results
-    if 'tmdb' in task_map:
-        tmdb_episode_data = results[task_map['tmdb']]
+    if "tmdb" in task_map:
+        tmdb_episode_data = results[task_map["tmdb"]]
         if not isinstance(tmdb_episode_data, Exception) and tmdb_episode_data:
-            meta['tmdb_episode_data'] = tmdb_episode_data
-            meta['we_checked_tmdb'] = True
-            if meta['debug']:
+            meta["tmdb_episode_data"] = tmdb_episode_data
+            meta["we_checked_tmdb"] = True
+            if meta["debug"]:
                 console.print("[green]TMDb episode data retrieved successfully.[/green]")
         elif isinstance(tmdb_episode_data, Exception):
             console.print(f"[yellow]TMDb episode data retrieval failed: {tmdb_episode_data}[/yellow]")

--- a/src/metadata_searching.py
+++ b/src/metadata_searching.py
@@ -26,12 +26,13 @@ def _apply_tvdb_series_metadata(meta: dict[str, Any], episodes_data: Any, series
         meta["tvdb_series_name"] = series_name
     if isinstance(episodes_data, dict):
         series_title = episodes_data.get("series_title")
-        if series_title and not meta.get("tvdb_series_name"):
-            meta["tvdb_series_name"] = series_title
         series_year = episodes_data.get("series_year")
-        if isinstance(series_year, (str, int)) and re.fullmatch(r"19\d\d|20[0-3]\d", str(series_year)):
-            meta["tvdb_series_year"] = str(series_year)
-            meta["search_year"] = str(series_year)
+        valid_year = str(series_year) if isinstance(series_year, (str, int)) and re.fullmatch(r"19\d\d|20[0-3]\d", str(series_year)) else None
+        if series_title and not meta.get("tvdb_series_name"):
+            meta["tvdb_series_name"] = f"{series_title} ({valid_year})" if valid_year else series_title
+        if valid_year:
+            meta["tvdb_series_year"] = valid_year
+            meta["search_year"] = valid_year
 
 
 class MetadataSearchingManager:

--- a/src/prep.py
+++ b/src/prep.py
@@ -75,6 +75,20 @@ def _to_int(value: Any, default: int = 0) -> int:
         return default
 
 
+def _title_without_leading_article(title: str) -> str:
+    return re.sub(r'^(the|a|an)\s+', '', title.strip().lower(), flags=re.IGNORECASE)
+
+
+def _tvdb_title_drops_existing_leading_article(current_title: Any, tvdb_title: str) -> bool:
+    if not isinstance(current_title, str) or not current_title.strip() or not tvdb_title.strip():
+        return False
+
+    current = current_title.strip().lower()
+    tvdb = tvdb_title.strip().lower()
+    current_has_article = re.match(r'^(the|a|an)\s+', current, flags=re.IGNORECASE) is not None
+    return current_has_article and current != tvdb and _title_without_leading_article(current) == tvdb
+
+
 class Prep:
     """
     Prepare for upload:
@@ -1084,10 +1098,13 @@ class Prep:
                     year_match = re.search(r'\b(19|20)\d{2}\b', series_name)
                     if year_match:
                         extracted_year = year_match.group(0)
-                        meta['search_year'] = extracted_year
                         series_name = re.sub(r'\s*\b(19|20)\d{2}\b\s*', '', series_name).strip()
                     series_name = series_name.replace('(', '').replace(')', '').strip()
-                    if series_name and year_match:  # Only set if not empty and year was found
+                    should_use_tvdb_series_name = (
+                        series_name
+                        and not _tvdb_title_drops_existing_leading_article(meta.get('title'), series_name)
+                    )
+                    if should_use_tvdb_series_name:
                         meta['title'] = series_name
 
         # bluray.com data if config

--- a/src/prep.py
+++ b/src/prep.py
@@ -1169,7 +1169,7 @@ class Prep:
         if not meta.get("emby", False):
             meta["container"] = await video_manager.get_container(meta)
 
-            meta["audio"], meta["channels"], meta["has_commentary"] = await self.audio_manager.get_audio_v2(mi_data, meta, bdinfo)
+            meta["audio"], meta["channels"], meta["has_commentary"], meta["has_audiodesc"] = await self.audio_manager.get_audio_v2(mi_data, meta, bdinfo)
 
             meta["3D"] = await video_manager.is_3d(bdinfo)
 

--- a/src/prep.py
+++ b/src/prep.py
@@ -52,9 +52,9 @@ try:
 
 except ModuleNotFoundError:
     if console is not None:
-        console.print('Missing Module Found. Please reinstall required dependencies from requirements.txt.', markup=False)
+        console.print("Missing Module Found. Please reinstall required dependencies from requirements.txt.", markup=False)
     else:
-        print('Missing Module Found. Please reinstall required dependencies from requirements.txt.')
+        print("Missing Module Found. Please reinstall required dependencies from requirements.txt.")
     raise SystemExit(1) from None
 except KeyboardInterrupt:
     exit()
@@ -76,7 +76,7 @@ def _to_int(value: Any, default: int = 0) -> int:
 
 
 def _title_without_leading_article(title: str) -> str:
-    return re.sub(r'^(the|a|an)\s+', '', title.strip().lower(), flags=re.IGNORECASE)
+    return re.sub(r"^(the|a|an)\s+", "", title.strip().lower(), flags=re.IGNORECASE)
 
 
 def _tvdb_title_drops_existing_leading_article(current_title: Any, tvdb_title: str) -> bool:
@@ -85,7 +85,7 @@ def _tvdb_title_drops_existing_leading_article(current_title: Any, tvdb_title: s
 
     current = current_title.strip().lower()
     tvdb = tvdb_title.strip().lower()
-    current_has_article = re.match(r'^(the|a|an)\s+', current, flags=re.IGNORECASE) is not None
+    current_has_article = re.match(r"^(the|a|an)\s+", current, flags=re.IGNORECASE) is not None
     return current_has_article and current != tvdb and _title_without_leading_article(current) == tvdb
 
 
@@ -128,227 +128,234 @@ class Prep:
         bdinfo: dict[str, Any] = {}
         mi: Optional[dict[str, Any]] = None
         # set some details we'll need
-        meta['cutoff'] = int(self.config['DEFAULT'].get('cutoff_screens', 1))
+        meta["cutoff"] = int(self.config["DEFAULT"].get("cutoff_screens", 1))
 
-        meta['mode'] = mode
-        meta['isdir'] = os.path.isdir(meta['path'])
-        base_dir = meta['base_dir']
-        meta['saved_description'] = False
+        meta["mode"] = mode
+        meta["isdir"] = os.path.isdir(meta["path"])
+        base_dir = meta["base_dir"]
+        meta["saved_description"] = False
         client = Clients(config=self.config)
-        meta['skip_auto_torrent'] = meta.get('skip_auto_torrent', False) or self.config['DEFAULT'].get('skip_auto_torrent', False)
-        hash_ids = ['infohash', 'torrent_hash', 'skip_auto_torrent']
-        tracker_ids = ['aither', 'ulcx', 'lst', 'blu', 'oe', 'btn', 'bhd', 'huno', 'hdb', 'rf', 'otw', 'yus', 'dp', 'sp', 'ptp']
-        use_sonarr = self.config['DEFAULT'].get('use_sonarr', False)
-        use_radarr = self.config['DEFAULT'].get('use_radarr', False)
-        meta['print_tracker_messages'] = self.config['DEFAULT'].get('print_tracker_messages', False)
-        meta['print_tracker_links'] = self.config['DEFAULT'].get('print_tracker_links', True)
-        only_id_val = meta.get('onlyID')
-        only_id = bool(self.config['DEFAULT'].get('only_id', False) if only_id_val is None else only_id_val)
-        meta['only_id'] = only_id
-        meta['keep_images'] = bool(self.config['DEFAULT'].get('keep_images', True) if not meta.get('keep_images') else True)
-        mkbrr_threads = self.config['DEFAULT'].get('mkbrr_threads', "0")
-        meta['mkbrr_threads'] = mkbrr_threads
+        meta["skip_auto_torrent"] = meta.get("skip_auto_torrent", False) or self.config["DEFAULT"].get("skip_auto_torrent", False)
+        hash_ids = ["infohash", "torrent_hash", "skip_auto_torrent"]
+        tracker_ids = ["aither", "ulcx", "lst", "blu", "oe", "btn", "bhd", "huno", "hdb", "rf", "otw", "yus", "dp", "sp", "ptp"]
+        use_sonarr = self.config["DEFAULT"].get("use_sonarr", False)
+        use_radarr = self.config["DEFAULT"].get("use_radarr", False)
+        meta["print_tracker_messages"] = self.config["DEFAULT"].get("print_tracker_messages", False)
+        meta["print_tracker_links"] = self.config["DEFAULT"].get("print_tracker_links", True)
+        only_id_val = meta.get("onlyID")
+        only_id = bool(self.config["DEFAULT"].get("only_id", False) if only_id_val is None else only_id_val)
+        meta["only_id"] = only_id
+        meta["keep_images"] = bool(self.config["DEFAULT"].get("keep_images", True) if not meta.get("keep_images") else True)
+        mkbrr_threads = self.config["DEFAULT"].get("mkbrr_threads", "0")
+        meta["mkbrr_threads"] = mkbrr_threads
 
         # make sure these are set in meta
-        meta['we_checked_tvdb'] = False
-        meta['we_checked_tmdb'] = False
-        meta['we_asked_tvmaze'] = False
-        meta['audio_languages'] = None
-        meta['subtitle_languages'] = None
-        meta['aither_trumpable'] = None
+        meta["we_checked_tvdb"] = False
+        meta["we_checked_tmdb"] = False
+        meta["we_asked_tvmaze"] = False
+        meta["audio_languages"] = None
+        meta["subtitle_languages"] = None
+        meta["aither_trumpable"] = None
 
-        folder_id = os.path.basename(meta['path'])
-        if meta.get('uuid') is None:
-            meta['uuid'] = folder_id
+        folder_id = os.path.basename(meta["path"])
+        if meta.get("uuid") is None:
+            meta["uuid"] = folder_id
         if not os.path.exists(f"{base_dir}/tmp/{meta['uuid']}"):
             os.makedirs(f"{base_dir}/tmp/{meta['uuid']}", mode=0o700, exist_ok=True)
 
-        if meta['debug']:
+        if meta["debug"]:
             console.print(f"[cyan]ID: {meta['uuid']}")
 
         try:
-            meta['is_disc'], videoloc, bdinfo, meta['discs'] = await self.disc_info_manager.get_disc(meta)
+            meta["is_disc"], videoloc, bdinfo, meta["discs"] = await self.disc_info_manager.get_disc(meta)
         except Exception:
             raise
-        if meta.get('debug', False):
+        if meta.get("debug", False):
             console.print(f"[blue]is_disc: [yellow]{meta['is_disc']}[/yellow][/blue]")
         # Debugging information
         # console.print(f"Debug: meta['filelist'] before population: {meta.get('filelist', 'Not Set')}")
 
-        if meta['is_disc'] == "BDMV":
-            video, meta['scene'], meta['imdb_id'] = await self.scene_manager.is_scene(meta['path'], meta, meta.get('imdb_id', 0))
-            meta['filelist'] = []  # No filelist for discs, use path
-            search_term = os.path.basename(meta['path'])
-            search_file_folder = 'folder'
+        if meta["is_disc"] == "BDMV":
+            video, meta["scene"], meta["imdb_id"] = await self.scene_manager.is_scene(meta["path"], meta, meta.get("imdb_id", 0))
+            meta["filelist"] = []  # No filelist for discs, use path
+            search_term = os.path.basename(meta["path"])
+            search_file_folder = "folder"
             try:
-                if meta.get('emby', False):
+                if meta.get("emby", False):
                     title, secondary_title, extracted_year = await self.name_manager.extract_title_and_year(meta, video)
-                    if meta['debug']:
+                    if meta["debug"]:
                         console.print(f"Title: {title}, Secondary Title: {secondary_title}, Year: {extracted_year}")
                     if secondary_title:
-                        meta['secondary_title'] = secondary_title
-                    if extracted_year and not meta.get('year'):
-                        meta['year'] = extracted_year
+                        meta["secondary_title"] = secondary_title
+                    if extracted_year and not meta.get("year"):
+                        meta["year"] = extracted_year
                     if title:
                         filename = title
                         untouched_filename = search_term
-                        meta['regex_title'] = title
-                        meta['regex_secondary_title'] = secondary_title
-                        meta['regex_year'] = extracted_year
+                        meta["regex_title"] = title
+                        meta["regex_secondary_title"] = secondary_title
+                        meta["regex_year"] = extracted_year
                     else:
-                        guess_name = search_term.replace('-', ' ')
+                        guess_name = search_term.replace("-", " ")
                         untouched_filename = search_term
-                        filename = str(guessit_fn(guess_name, {"excludes": ["country", "language"]}).get('title', ''))
+                        filename = str(guessit_fn(guess_name, {"excludes": ["country", "language"]}).get("title", ""))
                 else:
                     title, secondary_title, extracted_year = await self.name_manager.extract_title_and_year(meta, video)
-                    if meta['debug']:
+                    if meta["debug"]:
                         console.print(f"Title: {title}, Secondary Title: {secondary_title}, Year: {extracted_year}")
                     if secondary_title:
-                        meta['secondary_title'] = secondary_title
-                    if extracted_year and not meta.get('year'):
-                        meta['year'] = extracted_year
+                        meta["secondary_title"] = secondary_title
+                    if extracted_year and not meta.get("year"):
+                        meta["year"] = extracted_year
                     if title:
                         filename = title
                         untouched_filename = search_term
                     else:
-                        guess_name = bdinfo['title'].replace('-', ' ')
-                        untouched_filename = bdinfo['title']
-                        filename = str(guessit_fn(re.sub(r"[^0-9a-zA-Z\[\\]]+", " ", guess_name), {"excludes": ["country", "language"]}).get('title', ''))
+                        guess_name = bdinfo["title"].replace("-", " ")
+                        untouched_filename = bdinfo["title"]
+                        filename = str(guessit_fn(re.sub(r"[^0-9a-zA-Z\[\\]]+", " ", guess_name), {"excludes": ["country", "language"]}).get("title", ""))
 
                     try:
-                        is_hfr = bdinfo['video'][0]['fps'].split()[0] if bdinfo['video'] else "25"
+                        is_hfr = bdinfo["video"][0]["fps"].split()[0] if bdinfo["video"] else "25"
                         if int(float(is_hfr)) > 30:
-                            meta['hfr'] = True
+                            meta["hfr"] = True
                         else:
-                            meta['hfr'] = False
+                            meta["hfr"] = False
                     except Exception:
-                        meta['hfr'] = False
+                        meta["hfr"] = False
 
                 try:
-                    meta['search_year'] = guessit_fn(bdinfo['title'])['year']
+                    meta["search_year"] = guessit_fn(bdinfo["title"])["year"]
                 except Exception:
-                    meta['search_year'] = ""
+                    meta["search_year"] = ""
             except Exception:
-                guess_name = bdinfo['label'].replace('-', ' ')
-                filename = str(guessit_fn(re.sub(r"[^0-9a-zA-Z\[\\]]+", " ", guess_name), {"excludes": ["country", "language"]}).get('title', ''))
-                untouched_filename = bdinfo['label']
+                guess_name = bdinfo["label"].replace("-", " ")
+                filename = str(guessit_fn(re.sub(r"[^0-9a-zA-Z\[\\]]+", " ", guess_name), {"excludes": ["country", "language"]}).get("title", ""))
+                untouched_filename = bdinfo["label"]
                 try:
-                    meta['search_year'] = guessit_fn(bdinfo['label'])['year']
+                    meta["search_year"] = guessit_fn(bdinfo["label"])["year"]
                 except Exception:
-                    meta['search_year'] = ""
+                    meta["search_year"] = ""
 
-            if meta.get('resolution') is None and not meta.get('emby', False):
-                meta['resolution'] = await mi_resolution(
-                    bdinfo['video'][0]['res'],
+            if meta.get("resolution") is None and not meta.get("emby", False):
+                meta["resolution"] = await mi_resolution(
+                    bdinfo["video"][0]["res"],
                     guessit_fn(video),
                     width="OTHER",
                     scan="p",
                 )
 
-            elif meta.get('emby', False):
-                meta['resolution'] = "1080p"
+            elif meta.get("emby", False):
+                meta["resolution"] = "1080p"
 
-            meta['sd'] = await video_manager.is_sd(str(meta.get('resolution', '')))
+            meta["sd"] = await video_manager.is_sd(str(meta.get("resolution", "")))
 
             mi = None
 
-        elif meta['is_disc'] == "DVD":
-            video, meta['scene'], meta['imdb_id'] = await self.scene_manager.is_scene(meta['path'], meta, meta.get('imdb_id', 0))
-            meta['filelist'] = []
-            search_term = os.path.basename(meta['path'])
-            search_file_folder = 'folder'
-            if meta.get('emby', False):
+        elif meta["is_disc"] == "DVD":
+            video, meta["scene"], meta["imdb_id"] = await self.scene_manager.is_scene(meta["path"], meta, meta.get("imdb_id", 0))
+            meta["filelist"] = []
+            search_term = os.path.basename(meta["path"])
+            search_file_folder = "folder"
+            if meta.get("emby", False):
                 title, secondary_title, extracted_year = await self.name_manager.extract_title_and_year(meta, video)
-                if meta['debug']:
+                if meta["debug"]:
                     console.print(f"Title: {title}, Secondary Title: {secondary_title}, Year: {extracted_year}")
                 if secondary_title:
-                    meta['secondary_title'] = secondary_title
-                if extracted_year and not meta.get('year'):
-                    meta['year'] = extracted_year
+                    meta["secondary_title"] = secondary_title
+                if extracted_year and not meta.get("year"):
+                    meta["year"] = extracted_year
                 if title:
                     filename = title
                     untouched_filename = search_term
-                    meta['regex_title'] = title
-                    meta['regex_secondary_title'] = secondary_title
-                    meta['regex_year'] = extracted_year
+                    meta["regex_title"] = title
+                    meta["regex_secondary_title"] = secondary_title
+                    meta["regex_year"] = extracted_year
                 else:
-                    guess_name = search_term.replace('-', ' ')
+                    guess_name = search_term.replace("-", " ")
                     filename = guess_name
                     untouched_filename = search_term
-                meta['resolution'] = "480p"
-                meta['search_year'] = ""
+                meta["resolution"] = "480p"
+                meta["search_year"] = ""
             else:
                 title, secondary_title, extracted_year = await self.name_manager.extract_title_and_year(meta, video)
-                if meta['debug']:
+                if meta["debug"]:
                     console.print(f"Title: {title}, Secondary Title: {secondary_title}, Year: {extracted_year}")
                 if secondary_title:
-                    meta['secondary_title'] = secondary_title
-                if extracted_year and not meta.get('year'):
-                    meta['year'] = extracted_year
+                    meta["secondary_title"] = secondary_title
+                if extracted_year and not meta.get("year"):
+                    meta["year"] = extracted_year
                 if title:
                     filename = title
                     untouched_filename = search_term
                 else:
-                    guess_name = meta['discs'][0]['path'].replace('-', ' ')
-                    filename = str(guessit_fn(guess_name, {"excludes": ["country", "language"]}).get('title', ''))
-                    untouched_filename = os.path.basename(os.path.dirname(meta['discs'][0]['path']))
+                    guess_name = meta["discs"][0]["path"].replace("-", " ")
+                    filename = str(guessit_fn(guess_name, {"excludes": ["country", "language"]}).get("title", ""))
+                    untouched_filename = os.path.basename(os.path.dirname(meta["discs"][0]["path"]))
                 try:
-                    meta['search_year'] = guessit_fn(meta['discs'][0]['path'])['year']
+                    meta["search_year"] = guessit_fn(meta["discs"][0]["path"])["year"]
                 except Exception:
-                    meta['search_year'] = ""
-                if not meta.get('edit', False):
-                    mi = await exportInfo(f"{meta['discs'][0]['path']}/VTS_{meta['discs'][0]['main_set'][0][:2]}_0.IFO", False, meta['uuid'], meta['base_dir'], is_dvd=True, debug=meta.get('debug', False))
-                    meta['mediainfo'] = mi
+                    meta["search_year"] = ""
+                if not meta.get("edit", False):
+                    mi = await exportInfo(
+                        f"{meta['discs'][0]['path']}/VTS_{meta['discs'][0]['main_set'][0][:2]}_0.IFO",
+                        False,
+                        meta["uuid"],
+                        meta["base_dir"],
+                        is_dvd=True,
+                        debug=meta.get("debug", False),
+                    )
+                    meta["mediainfo"] = mi
                 else:
-                    mi = meta['mediainfo']
+                    mi = meta["mediainfo"]
 
-                meta['dvd_size'] = await self.disc_info_manager.get_dvd_size(meta['discs'], meta.get('manual_dvds'))
-                meta['resolution'], meta['hfr'] = await video_manager.get_resolution(guessit_fn(video), meta['uuid'], base_dir, meta)
-                meta['sd'] = await video_manager.is_sd(meta['resolution'])
+                meta["dvd_size"] = await self.disc_info_manager.get_dvd_size(meta["discs"], meta.get("manual_dvds"))
+                meta["resolution"], meta["hfr"] = await video_manager.get_resolution(guessit_fn(video), meta["uuid"], base_dir, meta)
+                meta["sd"] = await video_manager.is_sd(meta["resolution"])
 
-        elif meta['is_disc'] == "HDDVD":
-            video, meta['scene'], meta['imdb_id'] = await self.scene_manager.is_scene(meta['path'], meta, meta.get('imdb_id', 0))
-            meta['filelist'] = []
-            search_term = os.path.basename(meta['path'])
-            search_file_folder = 'folder'
-            guess_name = meta['discs'][0]['path'].replace('-', '')
-            filename = str(guessit_fn(guess_name, {"excludes": ["country", "language"]}).get('title', ''))
-            untouched_filename = os.path.basename(meta['discs'][0]['path'])
-            videopath = meta['discs'][0]['largest_evo']
+        elif meta["is_disc"] == "HDDVD":
+            video, meta["scene"], meta["imdb_id"] = await self.scene_manager.is_scene(meta["path"], meta, meta.get("imdb_id", 0))
+            meta["filelist"] = []
+            search_term = os.path.basename(meta["path"])
+            search_file_folder = "folder"
+            guess_name = meta["discs"][0]["path"].replace("-", "")
+            filename = str(guessit_fn(guess_name, {"excludes": ["country", "language"]}).get("title", ""))
+            untouched_filename = os.path.basename(meta["discs"][0]["path"])
+            videopath = meta["discs"][0]["largest_evo"]
             try:
-                meta['search_year'] = guessit_fn(meta['discs'][0]['path'])['year']
+                meta["search_year"] = guessit_fn(meta["discs"][0]["path"])["year"]
             except Exception:
-                meta['search_year'] = ""
-            if not meta.get('edit', False):
-                mi = await exportInfo(meta['discs'][0]['largest_evo'], False, meta['uuid'], meta['base_dir'], debug=meta['debug'])
-                meta['mediainfo'] = mi
+                meta["search_year"] = ""
+            if not meta.get("edit", False):
+                mi = await exportInfo(meta["discs"][0]["largest_evo"], False, meta["uuid"], meta["base_dir"], debug=meta["debug"])
+                meta["mediainfo"] = mi
             else:
-                mi = meta['mediainfo']
-            meta['resolution'], meta['hfr'] = await video_manager.get_resolution(guessit_fn(video), meta['uuid'], base_dir, meta)
-            meta['sd'] = await video_manager.is_sd(meta['resolution'])
+                mi = meta["mediainfo"]
+            meta["resolution"], meta["hfr"] = await video_manager.get_resolution(guessit_fn(video), meta["uuid"], base_dir, meta)
+            meta["sd"] = await video_manager.is_sd(meta["resolution"])
 
         else:
-            videopath, meta['filelist'] = await video_manager.get_video(videoloc, meta.get('mode', 'discord'), meta.get('sorted_filelist', False), meta.get('debug', False))
-            filelist = cast(list[str], meta.get('filelist') or [])
-            meta['filelist'] = filelist
+            videopath, meta["filelist"] = await video_manager.get_video(videoloc, meta.get("mode", "discord"), meta.get("sorted_filelist", False), meta.get("debug", False))
+            filelist = cast(list[str], meta.get("filelist") or [])
+            meta["filelist"] = filelist
             search_term = os.path.basename(filelist[0]) if filelist else ""
-            search_file_folder = 'file'
+            search_file_folder = "file"
 
-            video, meta['scene'], meta['imdb_id'] = await self.scene_manager.is_scene(videopath, meta, meta.get('imdb_id', 0))
+            video, meta["scene"], meta["imdb_id"] = await self.scene_manager.is_scene(videopath, meta, meta.get("imdb_id", 0))
 
             try:
                 title, secondary_title, extracted_year = await self.name_manager.extract_title_and_year(meta, video)
-                if meta['debug']:
+                if meta["debug"]:
                     console.print(f"Title: {title}, Secondary Title: {secondary_title}, Year: {extracted_year}")
                 if secondary_title:
-                    meta['secondary_title'] = secondary_title
-                if extracted_year and not meta.get('year'):
-                    meta['year'] = extracted_year
+                    meta["secondary_title"] = secondary_title
+                if extracted_year and not meta.get("year"):
+                    meta["year"] = extracted_year
 
-                if meta.get('isdir', False):
-                    guess_name = os.path.basename(meta['path']).replace("_", "").replace("-", "") if meta['path'] else ""
+                if meta.get("isdir", False):
+                    guess_name = os.path.basename(meta["path"]).replace("_", "").replace("-", "") if meta["path"] else ""
                 else:
-                    guess_name = ntpath.basename(video).replace('-', ' ')
+                    guess_name = ntpath.basename(video).replace("-", " ")
             except Exception as e:
                 console.print(f"[red]Error extracting title and year: {e}[/red]")
                 raise Exception(f"Error extracting title and year: {e}") from e
@@ -356,22 +363,24 @@ class Prep:
             try:
                 if title:
                     filename = title
-                    meta['regex_title'] = title
-                    meta['regex_secondary_title'] = secondary_title
-                    meta['regex_year'] = extracted_year
+                    meta["regex_title"] = title
+                    meta["regex_secondary_title"] = secondary_title
+                    meta["regex_year"] = extracted_year
                 else:
                     try:
-                        filename = str(guessit_fn(re.sub(r"[^0-9a-zA-Z\[\\]]+", " ", guess_name), {"excludes": ["country", "language"]}).get(
-                            "title",
-                            str(guessit_fn(re.sub("[^0-9a-zA-Z]+", " ", guess_name), {"excludes": ["country", "language"]}).get("title", ""))
-                        ))
+                        filename = str(
+                            guessit_fn(re.sub(r"[^0-9a-zA-Z\[\\]]+", " ", guess_name), {"excludes": ["country", "language"]}).get(
+                                "title", str(guessit_fn(re.sub("[^0-9a-zA-Z]+", " ", guess_name), {"excludes": ["country", "language"]}).get("title", ""))
+                            )
+                        )
                     except Exception:
                         try:
-                            guess_name = ntpath.basename(video).replace('-', ' ')
-                            filename = str(guessit_fn(re.sub(r"[^0-9a-zA-Z\[\\]]+", " ", guess_name), {"excludes": ["country", "language"]}).get(
-                                "title",
-                                str(guessit_fn(re.sub("[^0-9a-zA-Z]+", " ", guess_name), {"excludes": ["country", "language"]}).get("title", ""))
-                            ))
+                            guess_name = ntpath.basename(video).replace("-", " ")
+                            filename = str(
+                                guessit_fn(re.sub(r"[^0-9a-zA-Z\[\\]]+", " ", guess_name), {"excludes": ["country", "language"]}).get(
+                                    "title", str(guessit_fn(re.sub("[^0-9a-zA-Z]+", " ", guess_name), {"excludes": ["country", "language"]}).get("title", ""))
+                                )
+                            )
                         except Exception as e:
                             console.print(f"[red]Error extracting title from video name: {e}[/red]")
                             raise Exception(f"Error extracting title from video name: {e}") from e
@@ -382,49 +391,49 @@ class Prep:
                 raise Exception(f"Error processing filename: {e}") from e
 
             try:
-                if not meta.get('emby', False):
+                if not meta.get("emby", False):
                     # rely only on guessit for search_year for tv matching
                     try:
-                        meta['search_year'] = guessit_fn(video)['year']
+                        meta["search_year"] = guessit_fn(video)["year"]
                     except Exception:
-                        meta['search_year'] = ""
+                        meta["search_year"] = ""
 
-                    if not meta.get('edit', False):
-                        mi = await exportInfo(videopath, meta['isdir'], meta['uuid'], base_dir, is_dvd=meta.get('is_disc', False), debug=meta.get('debug', False))
-                        meta['mediainfo'] = mi
+                    if not meta.get("edit", False):
+                        mi = await exportInfo(videopath, meta["isdir"], meta["uuid"], base_dir, is_dvd=meta.get("is_disc", False), debug=meta.get("debug", False))
+                        meta["mediainfo"] = mi
                     else:
-                        mi = meta['mediainfo']
+                        mi = meta["mediainfo"]
 
-                    if meta.get('resolution') is None:
-                        meta['resolution'], meta['hfr'] = await video_manager.get_resolution(guessit_fn(video), meta['uuid'], base_dir, meta)
+                    if meta.get("resolution") is None:
+                        meta["resolution"], meta["hfr"] = await video_manager.get_resolution(guessit_fn(video), meta["uuid"], base_dir, meta)
 
-                    meta['sd'] = await video_manager.is_sd(meta['resolution'])
+                    meta["sd"] = await video_manager.is_sd(meta["resolution"])
                 else:
-                    meta['resolution'] = "1080p"
-                    meta['search_year'] = ""
+                    meta["resolution"] = "1080p"
+                    meta["search_year"] = ""
             except Exception as e:
                 console.print(f"[red]Error processing Mediainfo: {e}[/red]")
                 raise Exception(f"Error processing Mediainfo: {e}") from e
 
         source_size = 0
-        if not meta['is_disc']:
+        if not meta["is_disc"]:
             # Sum every non-disc file so downstream steps know the total payload size
-            filelist = cast(list[str], meta.get('filelist') or [])
+            filelist = cast(list[str], meta.get("filelist") or [])
             files_to_measure = filelist if filelist else ([videopath] if videopath else [])
             for file_path in files_to_measure:
                 if not os.path.isfile(file_path):
-                    if meta.get('debug'):
+                    if meta.get("debug"):
                         console.print(f"[yellow]Skipping size check for missing file: {file_path}")
                     continue
                 try:
                     source_size += os.path.getsize(file_path)
                 except OSError as exc:
-                    if meta.get('debug'):
+                    if meta.get("debug"):
                         console.print(f"[yellow]Unable to stat {file_path}: {exc}")
 
         else:
             # Disc structures can span many files; walk the tree rooted at meta['path']
-            disc_root = meta.get('path')
+            disc_root = meta.get("path")
             disc_root_str = disc_root if isinstance(disc_root, str) else ""
             if disc_root_str and os.path.exists(disc_root_str):
                 for root, _, files in os.walk(disc_root_str):
@@ -433,30 +442,33 @@ class Prep:
                         try:
                             source_size += os.path.getsize(file_path)
                         except OSError as exc:
-                            if meta.get('debug'):
+                            if meta.get("debug"):
                                 console.print(f"[yellow]Unable to stat {file_path}: {exc}")
                             continue
             else:
-                if meta.get('debug'):
+                if meta.get("debug"):
                     console.print(f"[yellow]Disc path missing, source size set to 0: {disc_root_str}")
 
-        meta['source_size'] = source_size
-        if meta['debug']:
+        meta["source_size"] = source_size
+        if meta["debug"]:
             console.print(f"[cyan]Calculated source size: {meta['source_size']} bytes")
 
         filename = str(filename)
         untouched_filename = str(untouched_filename)
-        if " AKA " in filename.replace('.', ' '):
-            filename = filename.split('AKA')[0]
-        meta['filename'] = filename
-        meta['bdinfo'] = bdinfo
+        if " AKA " in filename.replace(".", " "):
+            filename = filename.split("AKA")[0]
+        meta["filename"] = filename
+        meta["bdinfo"] = bdinfo
 
         conform_issues = await get_conformance_error(meta)
         if conform_issues:
             upload = False
-            if not meta['unattended'] or (meta['unattended'] and meta.get('unattended_confirm', False)):
+            if not meta["unattended"] or (meta["unattended"] and meta.get("unattended_confirm", False)):
                 try:
-                    upload = cli_ui.ask_yes_no("Found Conformance errors in mediainfo (possible cause: corrupted file, incomplete download, new codec, etc...), proceed to upload anyway?", default=False)
+                    upload = cli_ui.ask_yes_no(
+                        "Found Conformance errors in mediainfo (possible cause: corrupted file, incomplete download, new codec, etc...), proceed to upload anyway?",
+                        default=False,
+                    )
                 except EOFError:
                     console.print("\n[red]Exiting on user request (Ctrl+C)[/red]")
                     await cleanup_manager.cleanup()
@@ -472,17 +484,17 @@ class Prep:
                             file_path = os.path.join(tmp_dir, file)
                             if os.path.isfile(file_path) and file.endswith((".txt", ".json")):
                                 os.remove(file_path)
-                                if meta['debug']:
+                                if meta["debug"]:
                                     console.print(f"[yellow]Removed temporary metadata file: {file_path}[/yellow]")
                     except Exception as e:
                         console.print(f"[red]Error cleaning up temporary metadata files: {e}[/red]", highlight=False)
                 console.print("[red]Not uploading due to conformance errors.[/red]")
                 raise Exception("Conformance errors found in mediainfo")
 
-        meta['valid_mi'] = True
-        if not meta['is_disc'] and not meta.get('emby', False):
+        meta["valid_mi"] = True
+        if not meta["is_disc"] and not meta.get("emby", False):
             try:
-                valid_mi = validate_mediainfo(meta, debug=meta['debug'])
+                valid_mi = validate_mediainfo(meta, debug=meta["debug"])
             except NoAudioMediaError as e:
                 console.print(f"[red]MediaInfo validation failed: {str(e)}[/red]")
                 raise NoAudioMediaError(f"Upload Assistant does not support no audio media. Details: {str(e)}") from e
@@ -491,22 +503,18 @@ class Prep:
                 raise
             if not valid_mi:
                 console.print("[red]MediaInfo validation failed. This file does not contain (Unique ID).")
-                meta['valid_mi'] = False
+                meta["valid_mi"] = False
                 await asyncio.sleep(2)
 
         mediainfo_tracks = meta.get("mediainfo", {}).get("media", {}).get("track") or []
         meta["has_multiple_default_subtitle_tracks"] = len([track for track in mediainfo_tracks if track["@type"] == "Text" and track["Default"] == "Yes"]) > 1
 
         # Check if there's a language restriction
-        if meta['has_languages'] is not None and not meta.get('emby', False):
+        if meta["has_languages"] is not None and not meta.get("emby", False):
             try:
                 parsed_info = await languages_manager.parsed_mediainfo(meta)
-                audio_languages = [
-                    audio_track['language'].lower()
-                    for audio_track in parsed_info.get('audio', [])
-                    if 'language' in audio_track and audio_track['language']
-                ]
-                any_of_languages = meta['has_languages'].lower().split(",")
+                audio_languages = [audio_track["language"].lower() for audio_track in parsed_info.get("audio", []) if "language" in audio_track and audio_track["language"]]
+                any_of_languages = meta["has_languages"].lower().split(",")
                 if all(len(lang.strip()) == 2 for lang in any_of_languages):
                     raise Exception(f"Warning: Languages should be full names, not ISO codes. Found: {any_of_languages}")
                 # We need to have user input languages and file must have audio tracks.
@@ -517,11 +525,11 @@ class Prep:
                 console.print(f"[red]{e}[/red]")
                 raise Exception("Language check failed") from e
 
-        if not meta.get('emby', False):
-            if 'description' not in meta or meta.get('description') is None:
-                meta['description'] = ""
+        if not meta.get("emby", False):
+            if "description" not in meta or meta.get("description") is None:
+                meta["description"] = ""
 
-            description_text = meta.get('description', '')
+            description_text = meta.get("description", "")
             if description_text is None:
                 description_text = ""
             async with aiofiles.open(
@@ -533,95 +541,95 @@ class Prep:
                 if len(description_text):
                     await description.write(description_text)
 
-        meta['skip_trackers'] = False
-        if meta.get('emby', False):
+        meta["skip_trackers"] = False
+        if meta.get("emby", False):
             only_id = True
-            meta['only_id'] = True
-            meta['keep_images'] = False
-            if meta.get('imdb_id', 0) != 0:
-                meta['skip_trackers'] = True
-        if meta.get('emby_debug', False):
-            meta['skip_trackers'] = True
+            meta["only_id"] = True
+            meta["keep_images"] = False
+            if meta.get("imdb_id", 0) != 0:
+                meta["skip_trackers"] = True
+        if meta.get("emby_debug", False):
+            meta["skip_trackers"] = True
 
-        if meta['debug']:
+        if meta["debug"]:
             pathed_time_start = time.time()
 
-        if not meta.get('emby') and meta.get('trackers'):
-            trackers = meta['trackers']
+        if not meta.get("emby") and meta.get("trackers"):
+            trackers = meta["trackers"]
         else:
-            default_trackers = self.config['TRACKERS'].get('default_trackers', '')
-            trackers = [tracker.strip() for tracker in default_trackers.split(',')]
+            default_trackers = self.config["TRACKERS"].get("default_trackers", "")
+            trackers = [tracker.strip() for tracker in default_trackers.split(",")]
 
         if isinstance(trackers, str):
-            trackers = [t.strip().upper() for t in trackers.split(',')] if "," in trackers else [trackers.strip().upper()]
+            trackers = [t.strip().upper() for t in trackers.split(",")] if "," in trackers else [trackers.strip().upper()]
         else:
             trackers = [t.strip().upper() for t in trackers]
-        meta['trackers'] = trackers
-        meta['requested_trackers'] = trackers
+        meta["trackers"] = trackers
+        meta["requested_trackers"] = trackers
 
         # auto torrent searching with qbittorrent that grabs torrent ids for metadata searching
-        if not any(meta.get(id_type) for id_type in hash_ids + tracker_ids) and not meta.get('skip_trackers', False) and not meta.get('edit', False):
-            await client.get_pathed_torrents(meta['path'], meta)
+        if not any(meta.get(id_type) for id_type in hash_ids + tracker_ids) and not meta.get("skip_trackers", False) and not meta.get("edit", False):
+            await client.get_pathed_torrents(meta["path"], meta)
 
-        if meta['debug']:
+        if meta["debug"]:
             pathed_time_end = time.time()
             console.print(f"Pathed torrent data processed in {pathed_time_end - pathed_time_start:.2f} seconds")
 
         # Ensure all manual IDs have proper default values
-        meta['tmdb_manual'] = meta.get('tmdb_manual') or 0
-        meta['imdb_manual'] = meta.get('imdb_manual') or 0
-        meta['mal_manual'] = meta.get('mal_manual') or 0
-        meta['tvdb_manual'] = meta.get('tvdb_manual') or 0
-        meta['tvmaze_manual'] = meta.get('tvmaze_manual') or 0
+        meta["tmdb_manual"] = meta.get("tmdb_manual") or 0
+        meta["imdb_manual"] = meta.get("imdb_manual") or 0
+        meta["mal_manual"] = meta.get("mal_manual") or 0
+        meta["tvdb_manual"] = meta.get("tvdb_manual") or 0
+        meta["tvmaze_manual"] = meta.get("tvmaze_manual") or 0
 
         # Set tmdb_id
         try:
-            meta['tmdb_id'] = int(meta['tmdb_manual'])
+            meta["tmdb_id"] = int(meta["tmdb_manual"])
         except (ValueError, TypeError):
-            meta['tmdb_id'] = 0
+            meta["tmdb_id"] = 0
 
         # Set imdb_id with proper handling for 'tt' prefix
         try:
-            if not meta.get('imdb_id'):
-                imdb_value = meta['imdb_manual']
+            if not meta.get("imdb_id"):
+                imdb_value = meta["imdb_manual"]
                 if imdb_value:
-                    if str(imdb_value).startswith('tt'):
-                        meta['imdb_id'] = int(str(imdb_value)[2:])
+                    if str(imdb_value).startswith("tt"):
+                        meta["imdb_id"] = int(str(imdb_value)[2:])
                     else:
-                        meta['imdb_id'] = int(imdb_value)
+                        meta["imdb_id"] = int(imdb_value)
                 else:
-                    meta['imdb_id'] = 0
+                    meta["imdb_id"] = 0
         except (ValueError, TypeError):
-            meta['imdb_id'] = 0
+            meta["imdb_id"] = 0
 
         # Set mal_id
         try:
-            meta['mal_id'] = int(meta['mal_manual'])
+            meta["mal_id"] = int(meta["mal_manual"])
         except (ValueError, TypeError):
-            meta['mal_id'] = 0
+            meta["mal_id"] = 0
 
         # Set tvdb_id
         try:
-            meta['tvdb_id'] = int(meta['tvdb_manual'])
+            meta["tvdb_id"] = int(meta["tvdb_manual"])
         except (ValueError, TypeError):
-            meta['tvdb_id'] = 0
+            meta["tvdb_id"] = 0
 
         try:
-            meta['tvmaze_id'] = int(meta['tvmaze_manual'])
+            meta["tvmaze_id"] = int(meta["tvmaze_manual"])
         except (ValueError, TypeError):
-            meta['tvmaze_id'] = 0
+            meta["tvmaze_id"] = 0
 
-        if not meta.get('category'):
-            meta['category'] = await self.get_cat(video, meta)
+        if not meta.get("category"):
+            meta["category"] = await self.get_cat(video, meta)
         else:
-            meta['category'] = meta['category'].upper()
+            meta["category"] = meta["category"].upper()
 
         ids = None
-        if not meta.get('skip_trackers', False):
-            if meta.get('category') == "TV" and use_sonarr and meta.get('tvdb_id', 0) == 0:
-                ids = await self.sonarr_manager.get_sonarr_data(filename=meta.get('path', ''), title=meta.get('filename'), debug=meta.get('debug', False))
+        if not meta.get("skip_trackers", False):
+            if meta.get("category") == "TV" and use_sonarr and meta.get("tvdb_id", 0) == 0:
+                ids = await self.sonarr_manager.get_sonarr_data(filename=meta.get("path", ""), title=meta.get("filename"), debug=meta.get("debug", False))
                 if ids:
-                    if meta['debug']:
+                    if meta["debug"]:
                         console.print(f"TVDB ID: {ids['tvdb_id']}")
                         console.print(f"IMDB ID: {ids['imdb_id']}")
                         console.print(f"TVMAZE ID: {ids['tvmaze_id']}")
@@ -629,115 +637,122 @@ class Prep:
                         console.print(f"Genres: {ids['genres']}")
                         console.print(f"Release Group: {ids['release_group']}")
                         console.print(f"Year: {ids['year']}")
-                    if 'anime' not in [genre.lower() for genre in ids['genres']]:
-                        meta['not_anime'] = True
-                    if meta.get('tvdb_id', 0) == 0 and ids['tvdb_id'] is not None:
-                        meta['tvdb_id'] = ids['tvdb_id']
-                    if meta.get('imdb_id', 0) == 0 and ids['imdb_id'] is not None:
-                        meta['imdb_id'] = ids['imdb_id']
-                    if meta.get('tvmaze_id', 0) == 0 and ids['tvmaze_id'] is not None:
-                        meta['tvmaze_id'] = ids['tvmaze_id']
-                    if meta.get('tmdb_id', 0) == 0 and ids['tmdb_id'] is not None:
-                        meta['tmdb_id'] = ids['tmdb_id']
-                    if meta.get('manual_year', 0) == 0 and ids['year'] is not None:
-                        meta['manual_year'] = ids['year']
+                    if "anime" not in [genre.lower() for genre in ids["genres"]]:
+                        meta["not_anime"] = True
+                    if meta.get("tvdb_id", 0) == 0 and ids["tvdb_id"] is not None:
+                        meta["tvdb_id"] = ids["tvdb_id"]
+                    if meta.get("imdb_id", 0) == 0 and ids["imdb_id"] is not None:
+                        meta["imdb_id"] = ids["imdb_id"]
+                    if meta.get("tvmaze_id", 0) == 0 and ids["tvmaze_id"] is not None:
+                        meta["tvmaze_id"] = ids["tvmaze_id"]
+                    if meta.get("tmdb_id", 0) == 0 and ids["tmdb_id"] is not None:
+                        meta["tmdb_id"] = ids["tmdb_id"]
+                    if meta.get("manual_year", 0) == 0 and ids["year"] is not None:
+                        meta["manual_year"] = ids["year"]
                 else:
                     ids = None
 
-            if meta.get('category') == "MOVIE" and use_radarr and meta.get('tmdb_id', 0) == 0:
-                ids = await self.radarr_manager.get_radarr_data(filename=meta.get('uuid', ''), debug=meta.get('debug', False))
+            if meta.get("category") == "MOVIE" and use_radarr and meta.get("tmdb_id", 0) == 0:
+                ids = await self.radarr_manager.get_radarr_data(filename=meta.get("uuid", ""), debug=meta.get("debug", False))
                 if ids:
-                    if meta['debug']:
+                    if meta["debug"]:
                         console.print(f"IMDB ID: {ids['imdb_id']}")
                         console.print(f"TMDB ID: {ids['tmdb_id']}")
                         console.print(f"Genres: {ids['genres']}")
                         console.print(f"Year: {ids['year']}")
                         console.print(f"Release Group: {ids['release_group']}")
-                    if meta.get('imdb_id', 0) == 0 and ids['imdb_id'] is not None:
-                        meta['imdb_id'] = ids['imdb_id']
-                    if meta.get('tmdb_id', 0) == 0 and ids['tmdb_id'] is not None:
-                        meta['tmdb_id'] = ids['tmdb_id']
-                    if meta.get('manual_year', 0) == 0 and ids['year'] is not None:
-                        meta['manual_year'] = ids['year']
+                    if meta.get("imdb_id", 0) == 0 and ids["imdb_id"] is not None:
+                        meta["imdb_id"] = ids["imdb_id"]
+                    if meta.get("tmdb_id", 0) == 0 and ids["tmdb_id"] is not None:
+                        meta["tmdb_id"] = ids["tmdb_id"]
+                    if meta.get("manual_year", 0) == 0 and ids["year"] is not None:
+                        meta["manual_year"] = ids["year"]
                 else:
                     ids = None
 
             # check if we've already searched torrents
-            if 'base_torrent_created' not in meta:
-                meta['base_torrent_created'] = False
-            if 'we_checked_them_all' not in meta:
-                meta['we_checked_them_all'] = False
+            if "base_torrent_created" not in meta:
+                meta["base_torrent_created"] = False
+            if "we_checked_them_all" not in meta:
+                meta["we_checked_them_all"] = False
 
             # if not auto qbittorrent search, this also checks with the infohash if passed.
-            if meta.get('infohash') is not None and not meta['base_torrent_created'] and not meta['we_checked_them_all'] and not ids:
+            if meta.get("infohash") is not None and not meta["base_torrent_created"] and not meta["we_checked_them_all"] and not ids:
                 meta = await client.get_ptp_from_hash(meta)
 
-            if not meta.get('edit', False) and not ids:
+            if not meta.get("edit", False) and not ids:
                 # Reuse information from trackers with fallback
-                await self.tracker_data_manager.get_tracker_data(video, meta, search_term, search_file_folder, meta['category'], only_id=only_id)
+                await self.tracker_data_manager.get_tracker_data(video, meta, search_term, search_file_folder, meta["category"], only_id=only_id)
 
-            if meta.get('category', None) == "TV" and use_sonarr and meta.get('tvdb_id', 0) != 0 and ids is None and not meta.get('matched_tracker', None):
-                ids = await self.sonarr_manager.get_sonarr_data(tvdb_id=meta.get('tvdb_id', 0), debug=meta.get('debug', False))
+            if meta.get("category", None) == "TV" and use_sonarr and meta.get("tvdb_id", 0) != 0 and ids is None and not meta.get("matched_tracker", None):
+                ids = await self.sonarr_manager.get_sonarr_data(tvdb_id=meta.get("tvdb_id", 0), debug=meta.get("debug", False))
                 if ids:
-                    if meta['debug']:
+                    if meta["debug"]:
                         console.print(f"TVDB ID: {ids['tvdb_id']}")
                         console.print(f"IMDB ID: {ids['imdb_id']}")
                         console.print(f"TVMAZE ID: {ids['tvmaze_id']}")
                         console.print(f"TMDB ID: {ids['tmdb_id']}")
                         console.print(f"Genres: {ids['genres']}")
-                    if 'anime' not in [genre.lower() for genre in ids['genres']]:
-                        meta['not_anime'] = True
-                    if meta.get('tvdb_id', 0) == 0 and ids['tvdb_id'] is not None:
-                        meta['tvdb_id'] = ids['tvdb_id']
-                    if meta.get('imdb_id', 0) == 0 and ids['imdb_id'] is not None:
-                        meta['imdb_id'] = ids['imdb_id']
-                    if meta.get('tvmaze_id', 0) == 0 and ids['tvmaze_id'] is not None:
-                        meta['tvmaze_id'] = ids['tvmaze_id']
-                    if meta.get('tmdb_id', 0) == 0 and ids['tmdb_id'] is not None:
-                        meta['tmdb_id'] = ids['tmdb_id']
-                    if meta.get('manual_year', 0) == 0 and ids['year'] is not None:
-                        meta['manual_year'] = ids['year']
+                    if "anime" not in [genre.lower() for genre in ids["genres"]]:
+                        meta["not_anime"] = True
+                    if meta.get("tvdb_id", 0) == 0 and ids["tvdb_id"] is not None:
+                        meta["tvdb_id"] = ids["tvdb_id"]
+                    if meta.get("imdb_id", 0) == 0 and ids["imdb_id"] is not None:
+                        meta["imdb_id"] = ids["imdb_id"]
+                    if meta.get("tvmaze_id", 0) == 0 and ids["tvmaze_id"] is not None:
+                        meta["tvmaze_id"] = ids["tvmaze_id"]
+                    if meta.get("tmdb_id", 0) == 0 and ids["tmdb_id"] is not None:
+                        meta["tmdb_id"] = ids["tmdb_id"]
+                    if meta.get("manual_year", 0) == 0 and ids["year"] is not None:
+                        meta["manual_year"] = ids["year"]
                 else:
                     ids = None
 
-            if meta.get('category', None) == "MOVIE" and use_radarr and meta.get('tmdb_id', 0) != 0 and ids is None and not meta.get('matched_tracker', None):
-                ids = await self.radarr_manager.get_radarr_data(tmdb_id=meta.get('tmdb_id', 0), debug=meta.get('debug', False))
+            if meta.get("category", None) == "MOVIE" and use_radarr and meta.get("tmdb_id", 0) != 0 and ids is None and not meta.get("matched_tracker", None):
+                ids = await self.radarr_manager.get_radarr_data(tmdb_id=meta.get("tmdb_id", 0), debug=meta.get("debug", False))
                 if ids:
-                    if meta['debug']:
+                    if meta["debug"]:
                         console.print(f"IMDB ID: {ids['imdb_id']}")
                         console.print(f"TMDB ID: {ids['tmdb_id']}")
                         console.print(f"Genres: {ids['genres']}")
                         console.print(f"Year: {ids['year']}")
                         console.print(f"Release Group: {ids['release_group']}")
-                    if meta.get('imdb_id', 0) == 0 and ids['imdb_id'] is not None:
-                        meta['imdb_id'] = ids['imdb_id']
-                    if meta.get('tmdb_id', 0) == 0 and ids['tmdb_id'] is not None:
-                        meta['tmdb_id'] = ids['tmdb_id']
-                    if meta.get('manual_year', 0) == 0 and ids['year'] is not None:
-                        meta['manual_year'] = ids['year']
+                    if meta.get("imdb_id", 0) == 0 and ids["imdb_id"] is not None:
+                        meta["imdb_id"] = ids["imdb_id"]
+                    if meta.get("tmdb_id", 0) == 0 and ids["tmdb_id"] is not None:
+                        meta["tmdb_id"] = ids["tmdb_id"]
+                    if meta.get("manual_year", 0) == 0 and ids["year"] is not None:
+                        meta["manual_year"] = ids["year"]
                 else:
                     ids = None
 
         # if there's no region/distributor info, lets ping some unit3d trackers and see if we get it
-        ping_unit3d_config = self.config['DEFAULT'].get('ping_unit3d', False)
-        if (not meta.get('region') or not meta.get('distributor')) and meta['is_disc'] == "BDMV" and ping_unit3d_config and not meta.get('edit', False) and not meta.get('emby', False) and not meta.get('site_check', False):
+        ping_unit3d_config = self.config["DEFAULT"].get("ping_unit3d", False)
+        if (
+            (not meta.get("region") or not meta.get("distributor"))
+            and meta["is_disc"] == "BDMV"
+            and ping_unit3d_config
+            and not meta.get("edit", False)
+            and not meta.get("emby", False)
+            and not meta.get("site_check", False)
+        ):
             await self.tracker_data_manager.ping_unit3d(meta)
 
         # the first user override check that allows to set metadata ids.
         # it relies on imdb or tvdb already being set.
-        user_overrides = self.config['DEFAULT'].get('user_overrides', False)
-        if user_overrides and (meta.get('imdb_id') != 0 or meta.get('tvdb_id') != 0) and not meta.get('emby', False):
+        user_overrides = self.config["DEFAULT"].get("user_overrides", False)
+        if user_overrides and (meta.get("imdb_id") != 0 or meta.get("tvdb_id") != 0) and not meta.get("emby", False):
             meta = await self.overrides.get_source_override(meta, other_id=True)
-            category = meta.get('category')
-            meta['category'] = str(category).upper() if category is not None else ''
+            category = meta.get("category")
+            meta["category"] = str(category).upper() if category is not None else ""
             # set a flag so that the other check later doesn't run
-            meta['no_override'] = True
+            meta["no_override"] = True
 
-        emby_cat = meta.get('emby_cat')
-        if emby_cat is not None and str(emby_cat).upper() != str(meta.get('category') or '').upper():
+        emby_cat = meta.get("emby_cat")
+        if emby_cat is not None and str(emby_cat).upper() != str(meta.get("category") or "").upper():
             return meta
 
-        if meta['debug']:
+        if meta["debug"]:
             console.print("ID inputs into prep")
             console.print("category:", meta.get("category"))
             console.print(f"Raw TVDB ID: {meta['tvdb_id']} (type: {type(meta['tvdb_id']).__name__})")
@@ -746,22 +761,22 @@ class Prep:
             console.print(f"Raw TVMAZE ID: {meta['tvmaze_id']} (type: {type(meta['tvmaze_id']).__name__})")
             console.print(f"Raw MAL ID: {meta['mal_id']} (type: {type(meta['mal_id']).__name__})")
 
-        if meta.get('mal_id', 0) != 0:
-            meta['anime'] = True
-            meta['not_anime'] = True
+        if meta.get("mal_id", 0) != 0:
+            meta["anime"] = True
+            meta["not_anime"] = True
 
         console.print("[yellow]Building meta data.....")
 
         # set a timer to check speed
-        if meta['debug']:
+        if meta["debug"]:
             meta_middle_time = time.time()
             console.print(f"Source/tracker data processed in {meta_middle_time - meta_start_time:.2f} seconds")
 
-        manual_language = meta.get('manual_language')
+        manual_language = meta.get("manual_language")
         if isinstance(manual_language, str) and manual_language:
-            meta['original_language'] = manual_language.lower()
+            meta["original_language"] = manual_language.lower()
 
-        meta['type'] = await video_manager.get_type(video, meta['scene'], meta['is_disc'], meta)
+        meta["type"] = await video_manager.get_type(video, meta["scene"], meta["is_disc"], meta)
 
         # if it's not an anime, we can run season/episode checks now to speed the process
         if meta.get("not_anime", False) and meta.get("category") == "TV":
@@ -770,31 +785,36 @@ class Prep:
         mi_data: dict[str, Any] = mi or {}
 
         # Run a check against mediainfo to see if it has tmdb/imdb
-        if (meta.get('tmdb_id') == 0 or meta.get('imdb_id') == 0) and not meta.get('emby', False):
-            meta['category'], meta['tmdb_id'], meta['imdb_id'], meta['tvdb_id'] = await self.tmdb_manager.get_tmdb_imdb_from_mediainfo(
-                mi_data, meta
-            )
+        if (meta.get("tmdb_id") == 0 or meta.get("imdb_id") == 0) and not meta.get("emby", False):
+            meta["category"], meta["tmdb_id"], meta["imdb_id"], meta["tvdb_id"] = await self.tmdb_manager.get_tmdb_imdb_from_mediainfo(mi_data, meta)
 
         # Flag for emby if no IDs were found
-        if meta.get('imdb_id', 0) == 0 and meta.get('tvdb_id', 0) == 0 and meta.get('tmdb_id', 0) == 0 and meta.get('tvmaze_id', 0) == 0 and meta.get('mal_id', 0) == 0 and meta.get('emby', False):
-            meta['no_ids'] = True
+        if (
+            meta.get("imdb_id", 0) == 0
+            and meta.get("tvdb_id", 0) == 0
+            and meta.get("tmdb_id", 0) == 0
+            and meta.get("tvmaze_id", 0) == 0
+            and meta.get("mal_id", 0) == 0
+            and meta.get("emby", False)
+        ):
+            meta["no_ids"] = True
 
-        meta['video_duration'] = await video_manager.get_video_duration(meta)
-        duration = meta.get('video_duration', None)
+        meta["video_duration"] = await video_manager.get_video_duration(meta)
+        duration = meta.get("video_duration", None)
 
-        unattended = not (not meta['unattended'] or meta['unattended'] and meta.get('unattended_confirm', False))
-        debug = bool(meta.get('emby_debug', False) or meta['debug'])
+        unattended = not (not meta["unattended"] or meta["unattended"] and meta.get("unattended_confirm", False))
+        debug = bool(meta.get("emby_debug", False) or meta["debug"])
 
         # run a search to find tmdb and imdb ids if we don't have them
-        if int(meta.get('tmdb_id') or 0) == 0 and int(meta.get('imdb_id') or 0) == 0:
-            if meta.get('category') == "TV":
-                year = meta.get('manual_year', '') or meta.get('search_year', '') or meta.get('year', '')
-            elif meta.get('emby_debug', False):
+        if int(meta.get("tmdb_id") or 0) == 0 and int(meta.get("imdb_id") or 0) == 0:
+            if meta.get("category") == "TV":
+                year = meta.get("manual_year", "") or meta.get("search_year", "") or meta.get("year", "")
+            elif meta.get("emby_debug", False):
                 year = ""
             else:
-                year = meta.get('manual_year', '') or meta.get('year', '') or meta.get('search_year', '')
+                year = meta.get("manual_year", "") or meta.get("year", "") or meta.get("search_year", "")
             year_value = _normalize_search_year(year)
-            category_pref = meta.get('category') or ''
+            category_pref = meta.get("category") or ""
             tmdb_task: asyncio.Task[tuple[int, str]] = asyncio.create_task(
                 self.tmdb_manager.get_tmdb_id(
                     filename,
@@ -803,7 +823,7 @@ class Prep:
                     untouched_filename,
                     attempted=0,
                     debug=debug,
-                    secondary_title=meta.get('secondary_title', None),
+                    secondary_title=meta.get("secondary_title", None),
                     unattended=unattended,
                 )
             )
@@ -814,7 +834,7 @@ class Prep:
                     quickie=True,
                     category=category_pref,
                     debug=debug,
-                    secondary_title=meta.get('secondary_title', None),
+                    secondary_title=meta.get("secondary_title", None),
                     untouched_filename=untouched_filename,
                     duration=duration,
                     unattended=unattended,
@@ -822,81 +842,81 @@ class Prep:
             )
             tmdb_result, imdb_result = await asyncio.gather(tmdb_task, imdb_task)
             tmdb_id, category = tmdb_result
-            meta['category'] = category
-            meta['tmdb_id'] = _to_int(tmdb_id)
-            meta['imdb_id'] = _to_int(imdb_result)
-            meta['quickie_search'] = True
-            meta['no_ids'] = True
+            meta["category"] = category
+            meta["tmdb_id"] = _to_int(tmdb_id)
+            meta["imdb_id"] = _to_int(imdb_result)
+            meta["quickie_search"] = True
+            meta["no_ids"] = True
 
         # If we have an IMDb ID but no TMDb ID, fetch TMDb ID from IMDb
-        if int(meta.get('imdb_id') or 0) != 0 and int(meta.get('tmdb_id') or 0) == 0:
-            imdb_id_value = _to_int(meta.get('imdb_id'))
-            tvdb_id_value = _to_int(meta.get('tvdb_id'))
-            search_year_value = _normalize_search_year(meta.get('search_year'))
+        if int(meta.get("imdb_id") or 0) != 0 and int(meta.get("tmdb_id") or 0) == 0:
+            imdb_id_value = _to_int(meta.get("imdb_id"))
+            tvdb_id_value = _to_int(meta.get("tvdb_id"))
+            search_year_value = _normalize_search_year(meta.get("search_year"))
             category, tmdb_id, original_language, filename_search = await self.tmdb_manager.get_tmdb_from_imdb(
                 imdb_id_value,
                 tvdb_id_value if tvdb_id_value else None,
                 search_year_value,
                 filename,
-                debug=meta.get('debug', False),
-                mode=meta.get('mode', 'discord'),
-                category_preference=meta.get('category'),
-                imdb_info=meta.get('imdb_info', None)
+                debug=meta.get("debug", False),
+                mode=meta.get("mode", "discord"),
+                category_preference=meta.get("category"),
+                imdb_info=meta.get("imdb_info", None),
             )
 
-            meta['category'] = category
-            meta['tmdb_id'] = _to_int(tmdb_id)
-            meta['original_language'] = original_language
-            meta['no_ids'] = filename_search
+            meta["category"] = category
+            meta["tmdb_id"] = _to_int(tmdb_id)
+            meta["original_language"] = original_language
+            meta["no_ids"] = filename_search
 
         no_original_language = False
-        if meta.get('original_language', None) is None:
+        if meta.get("original_language", None) is None:
             no_original_language = True
 
         # if we have all of the ids, search everything all at once
-        if int(meta.get('imdb_id') or 0) != 0 and int(meta.get('tvdb_id') or 0) != 0 and int(meta.get('tmdb_id') or 0) != 0 and int(meta.get('tvmaze_id') or 0) != 0:
+        if int(meta.get("imdb_id") or 0) != 0 and int(meta.get("tvdb_id") or 0) != 0 and int(meta.get("tmdb_id") or 0) != 0 and int(meta.get("tvmaze_id") or 0) != 0:
             meta = await self.metadata_searching_manager.all_ids(meta)
 
         # Check if IMDb, TMDb, and TVDb IDs are all present
-        elif int(meta.get('imdb_id') or 0) != 0 and int(meta.get('tvdb_id') or 0) != 0 and int(meta.get('tmdb_id') or 0) != 0 and not meta.get('quickie_search', False):
+        elif int(meta.get("imdb_id") or 0) != 0 and int(meta.get("tvdb_id") or 0) != 0 and int(meta.get("tmdb_id") or 0) != 0 and not meta.get("quickie_search", False):
             meta = await self.metadata_searching_manager.imdb_tmdb_tvdb(meta, filename)
 
         # Check if both IMDb and TVDB IDs are present
-        elif int(meta.get('imdb_id') or 0) != 0 and int(meta.get('tvdb_id') or 0) != 0 and not meta.get('quickie_search', False):
+        elif int(meta.get("imdb_id") or 0) != 0 and int(meta.get("tvdb_id") or 0) != 0 and not meta.get("quickie_search", False):
             meta = await self.metadata_searching_manager.imdb_tvdb(meta, filename)
 
         # Check if both IMDb and TMDb IDs are present
-        elif int(meta.get('imdb_id') or 0) != 0 and int(meta.get('tmdb_id') or 0) != 0 and not meta.get('quickie_search', False):
+        elif int(meta.get("imdb_id") or 0) != 0 and int(meta.get("tmdb_id") or 0) != 0 and not meta.get("quickie_search", False):
             meta = await self.metadata_searching_manager.imdb_tmdb(meta, filename)
 
         # we should have tmdb id one way or another, so lets get data if needed
-        if int(meta.get('tmdb_id') or 0) != 0:
+        if int(meta.get("tmdb_id") or 0) != 0:
             await self.tmdb_manager.set_tmdb_metadata(meta, filename)
 
         # If there was no original language set before the combined metadata searching, tvdb changes mean we might have set a bad tvdb series name
         # Now that we have original language, we can safely kill the tvdb series name if it was en original to account for the change
-        if meta.get('tvdb_series_name', None) and meta.get('original_language', 'en') == 'en' and meta.get('tmdb_id', 0) != 0 and no_original_language:
-            meta['tvdb_series_name'] = None
+        if meta.get("tvdb_series_name", None) and meta.get("original_language", "en") == "en" and meta.get("tmdb_id", 0) != 0 and no_original_language:
+            meta["tvdb_series_name"] = None
 
         # If there's a mismatch between IMDb and TMDb IDs, try to resolve it
-        if meta.get('imdb_mismatch', False) and "subsplease" not in meta.get('uuid', '').lower():
-            if meta['debug']:
+        if meta.get("imdb_mismatch", False) and "subsplease" not in meta.get("uuid", "").lower():
+            if meta["debug"]:
                 console.print("[yellow]IMDb ID mismatch detected, attempting to resolve...[/yellow]")
             # with refactored tmdb, it quite likely to be correct
-            meta['imdb_id'] = meta.get('mismatched_imdb_id', 0)
-            meta['imdb_info'] = None
+            meta["imdb_id"] = meta.get("mismatched_imdb_id", 0)
+            meta["imdb_info"] = None
 
         # Get IMDb ID if not set
-        if meta.get('imdb_id') == 0:
+        if meta.get("imdb_id") == 0:
             try:
-                search_year_value = _normalize_search_year(meta.get('search_year'))
-                meta['imdb_id'] = await imdb_manager.search_imdb(
+                search_year_value = _normalize_search_year(meta.get("search_year"))
+                meta["imdb_id"] = await imdb_manager.search_imdb(
                     filename,
                     search_year_value,
                     quickie=False,
-                    category=meta.get('category', None),
+                    category=meta.get("category", None),
                     debug=debug,
-                    secondary_title=meta.get('secondary_title', None),
+                    secondary_title=meta.get("secondary_title", None),
                     untouched_filename=untouched_filename,
                     attempted=0,
                     duration=duration,
@@ -907,49 +927,49 @@ class Prep:
                 raise Exception(f"Error searching IMDb: {e}") from e
 
         # user might have skipped tmdb earlier, lets double check
-        if meta.get('imdb_id') != 0 and meta.get('tmdb_id') == 0:
+        if meta.get("imdb_id") != 0 and meta.get("tmdb_id") == 0:
             console.print("[yellow]No TMDB ID found, attempting to fetch from IMDb...[/yellow]")
-            imdb_id_value = _to_int(meta.get('imdb_id'))
-            tvdb_id_value = _to_int(meta.get('tvdb_id'))
-            search_year_value = _normalize_search_year(meta.get('search_year'))
+            imdb_id_value = _to_int(meta.get("imdb_id"))
+            tvdb_id_value = _to_int(meta.get("tvdb_id"))
+            search_year_value = _normalize_search_year(meta.get("search_year"))
             category, tmdb_id, original_language, filename_search = await self.tmdb_manager.get_tmdb_from_imdb(
                 imdb_id_value,
                 tvdb_id_value if tvdb_id_value else None,
                 search_year_value,
                 filename,
-                debug=meta.get('debug', False),
-                mode=meta.get('mode', 'discord'),
-                category_preference=meta.get('category'),
-                imdb_info=meta.get('imdb_info', None)
+                debug=meta.get("debug", False),
+                mode=meta.get("mode", "discord"),
+                category_preference=meta.get("category"),
+                imdb_info=meta.get("imdb_info", None),
             )
 
-            meta['category'] = category
-            meta['tmdb_id'] = _to_int(tmdb_id)
-            meta['original_language'] = original_language
-            meta['no_ids'] = filename_search
+            meta["category"] = category
+            meta["tmdb_id"] = _to_int(tmdb_id)
+            meta["original_language"] = original_language
+            meta["no_ids"] = filename_search
 
-        tmdb_id_value = _to_int(meta.get('tmdb_id'))
+        tmdb_id_value = _to_int(meta.get("tmdb_id"))
         if tmdb_id_value != 0:
             await self.tmdb_manager.set_tmdb_metadata(meta, filename)
 
         # Ensure IMDb info is retrieved if it wasn't already fetched
-        imdb_id_value = _to_int(meta.get('imdb_id'))
-        if meta.get('imdb_info', None) is None and imdb_id_value != 0:
-            imdb_info = await imdb_manager.get_imdb_info_api(imdb_id_value, manual_language=meta.get('manual_language'), debug=meta.get('debug', False))
-            meta['imdb_info'] = imdb_info
+        imdb_id_value = _to_int(meta.get("imdb_id"))
+        if meta.get("imdb_info", None) is None and imdb_id_value != 0:
+            imdb_info = await imdb_manager.get_imdb_info_api(imdb_id_value, manual_language=meta.get("manual_language"), debug=meta.get("debug", False))
+            meta["imdb_info"] = imdb_info
 
-        check_valid_data = meta.get('imdb_info', {}).get('title', "")
+        check_valid_data = meta.get("imdb_info", {}).get("title", "")
         if check_valid_data:
             try:
-                title = meta['title'].lower().strip()
+                title = meta["title"].lower().strip()
             except KeyError:
                 console.print("[red]Title is missing from TMDB....")
                 sys.exit(1)
-            aka = meta.get('imdb_info', {}).get('title', "").strip().lower()
-            imdb_aka = meta.get('imdb_info', {}).get('aka', "").strip().lower()
-            year = str(meta.get('imdb_info', {}).get('year', ""))
+            aka = meta.get("imdb_info", {}).get("title", "").strip().lower()
+            imdb_aka = meta.get("imdb_info", {}).get("aka", "").strip().lower()
+            year = str(meta.get("imdb_info", {}).get("year", ""))
 
-            if aka and not meta.get('aka'):
+            if aka and not meta.get("aka"):
                 aka_trimmed = aka[4:].strip().lower() if aka.lower().startswith("aka") else aka.lower()
                 difference = SequenceMatcher(None, title, aka_trimmed).ratio()
                 if difference >= 0.7 or not aka_trimmed or aka_trimmed in title:
@@ -961,117 +981,120 @@ class Prep:
 
                 if aka is not None:
                     if f"({year})" in aka:
-                        aka = meta.get('imdb_info', {}).get('title', "").replace(f"({year})", "").strip()
+                        aka = meta.get("imdb_info", {}).get("title", "").replace(f"({year})", "").strip()
                     else:
-                        aka = meta.get('imdb_info', {}).get('title', "").strip()
-                    meta['aka'] = f"AKA {aka.strip()}"
-                    meta['title'] = meta['title'].strip()
+                        aka = meta.get("imdb_info", {}).get("title", "").strip()
+                    meta["aka"] = f"AKA {aka.strip()}"
+                    meta["title"] = meta["title"].strip()
                 elif imdb_aka is not None:
                     if f"({year})" in imdb_aka:
-                        imdb_aka = meta.get('imdb_info', {}).get('aka', "").replace(f"({year})", "").strip()
+                        imdb_aka = meta.get("imdb_info", {}).get("aka", "").replace(f"({year})", "").strip()
                     else:
-                        imdb_aka = meta.get('imdb_info', {}).get('aka', "").strip()
-                    meta['aka'] = f"AKA {imdb_aka.strip()}"
-                    meta['title'] = meta['title'].strip()
+                        imdb_aka = meta.get("imdb_info", {}).get("aka", "").strip()
+                    meta["aka"] = f"AKA {imdb_aka.strip()}"
+                    meta["title"] = meta["title"].strip()
 
-        if meta.get('aka', None) is None:
-            meta['aka'] = ""
+        if meta.get("aka", None) is None:
+            meta["aka"] = ""
 
         # if it was skipped earlier, make sure we have the season/episode data
-        if not meta.get('not_anime', False) and meta.get('category') == "TV":
+        if not meta.get("not_anime", False) and meta.get("category") == "TV":
             meta = await self.season_episode_manager.get_season_episode(video, meta)
 
-        if meta['category'] == "TV" and meta.get('tv_pack'):
+        if meta["category"] == "TV" and meta.get("tv_pack"):
             await self.season_episode_manager.check_season_pack_completeness(meta)
 
         # lets check for tv movies
-        meta['tv_movie'] = False
-        if meta['imdb_id'] != 0:
-            is_tv_movie = meta.get('imdb_info', {}).get('type', '')
+        meta["tv_movie"] = False
+        if meta["imdb_id"] != 0:
+            is_tv_movie = meta.get("imdb_info", {}).get("type", "")
             if is_tv_movie:
-                tv_movie_keywords = ['tv movie', 'tv special', 'tvmovie']
-                if any(re.search(rf'(^|,\s*){re.escape(keyword)}(\s*,|$)', is_tv_movie, re.IGNORECASE) for keyword in tv_movie_keywords):
-                    if meta['debug']:
+                tv_movie_keywords = ["tv movie", "tv special", "tvmovie"]
+                if any(re.search(rf"(^|,\s*){re.escape(keyword)}(\s*,|$)", is_tv_movie, re.IGNORECASE) for keyword in tv_movie_keywords):
+                    if meta["debug"]:
                         console.print(f"[yellow]Identified as TV Movie based on IMDb type: {is_tv_movie}[/yellow]")
-                    meta['tv_movie'] = True
+                    meta["tv_movie"] = True
 
-        if meta['category'] == "TV" or meta.get('tv_movie', False):
+        if meta["category"] == "TV" or meta.get("tv_movie", False):
             both_ids_searched = False
-            search_year_value = _normalize_search_year(meta.get('search_year'))
-            if meta.get('tvmaze_id', 0) == 0 and meta.get('tvdb_id', 0) == 0:
+            search_year_value = _normalize_search_year(meta.get("search_year"))
+            if meta.get("tvmaze_id", 0) == 0 and meta.get("tvdb_id", 0) == 0:
                 tvmaze, tvdb, tvdb_data, tvdb_name = await self.metadata_searching_manager.get_tvmaze_tvdb(
                     filename,
                     search_year_value or "",
-                    meta.get('imdb_id', 0),
-                    meta.get('tmdb_id', 0),
-                    meta.get('manual_data'),
-                    meta.get('tvmaze_manual', 0),
-                    year=meta.get('year', ''),
-                    debug=meta.get('debug', False),
-                    tv_movie=meta.get('tv_movie', False)
+                    meta.get("imdb_id", 0),
+                    meta.get("tmdb_id", 0),
+                    meta.get("manual_data"),
+                    meta.get("tvmaze_manual", 0),
+                    year=meta.get("year", ""),
+                    debug=meta.get("debug", False),
+                    tv_movie=meta.get("tv_movie", False),
                 )
                 both_ids_searched = True
                 if tvmaze:
-                    meta['tvmaze_id'] = tvmaze
-                    if meta['debug']:
+                    meta["tvmaze_id"] = tvmaze
+                    if meta["debug"]:
                         console.print(f"[blue]Found TVMAZE ID from search: {tvmaze}[/blue]")
                 if tvdb:
-                    meta['tvdb_id'] = tvdb
-                    if meta['debug']:
+                    meta["tvdb_id"] = tvdb
+                    if meta["debug"]:
                         console.print(f"[blue]Found TVDB ID from search: {tvdb}[/blue]")
                 if tvdb_data:
-                    meta['tvdb_search_results'] = tvdb_data
-                    if meta['debug']:
+                    meta["tvdb_search_results"] = tvdb_data
+                    if meta["debug"]:
                         console.print("[blue]Found TVDB search results from search.[/blue]")
                 if tvdb_name:
-                    meta['tvdb_series_name'] = tvdb_name
-                    if meta['debug']:
+                    meta["tvdb_series_name"] = tvdb_name
+                    if meta["debug"]:
                         console.print(f"[blue]Found TVDB series name from search: {tvdb_name}[/blue]")
-            if meta.get('tvmaze_id', 0) == 0 and not both_ids_searched:
-                if meta['debug']:
+            if meta.get("tvmaze_id", 0) == 0 and not both_ids_searched:
+                if meta["debug"]:
                     console.print("[yellow]No TVMAZE ID found, attempting to fetch...[/yellow]")
-                meta['tvmaze_id'] = await tvmaze_manager.search_tvmaze(
-                    filename, search_year_value or "", meta.get('imdb_id', 0), meta.get('tvdb_id', 0),
-                    manual_date=meta.get('manual_date'),
-                    tvmaze_manual=meta.get('tvmaze_manual'),
-                    debug=meta.get('debug', False),
-                    return_full_tuple=False
+                meta["tvmaze_id"] = await tvmaze_manager.search_tvmaze(
+                    filename,
+                    search_year_value or "",
+                    meta.get("imdb_id", 0),
+                    meta.get("tvdb_id", 0),
+                    manual_date=meta.get("manual_date"),
+                    tvmaze_manual=meta.get("tvmaze_manual"),
+                    debug=meta.get("debug", False),
+                    return_full_tuple=False,
                 )
-            if meta.get('tvdb_id', 0) == 0:
-                if meta['debug']:
+            if meta.get("tvdb_id", 0) == 0:
+                if meta["debug"]:
                     console.print("[yellow]No TVDB ID found, attempting to fetch...[/yellow]")
                 try:
-                    series_results, series_id = await self.tvdb_handler.search_tvdb_series(filename=filename, year=meta.get('year', ''), debug=meta.get('debug', False))
+                    series_results, series_id = await self.tvdb_handler.search_tvdb_series(filename=filename, year=meta.get("year", ""), debug=meta.get("debug", False))
                     if series_id:
-                        meta['tvdb_id'] = series_id
+                        meta["tvdb_id"] = series_id
                         console.print(f"[blue]Found TVDB series ID from search: {series_id}[/blue]")
                     if series_results:
-                        meta['tvdb_search_results'] = series_results
+                        meta["tvdb_search_results"] = series_results
                 except Exception as e:
                     console.print(f"[red]Error searching TVDB: {e}[/red]")
 
             # all your episode data belongs to us
             meta = await self.metadata_searching_manager.get_tv_data(meta)
 
-            if meta.get('tvdb_imdb_id', None):
-                imdb = meta['tvdb_imdb_id'].replace('tt', '')
-                if imdb.isdigit() and imdb != meta.get('imdb_id', 0):
+            if meta.get("tvdb_imdb_id", None):
+                imdb = meta["tvdb_imdb_id"].replace("tt", "")
+                if imdb.isdigit() and imdb != meta.get("imdb_id", 0):
                     episode_info = await imdb_manager.get_imdb_from_episode(imdb, debug=True)
                     if episode_info:
-                        series_id = episode_info.get('series', {}).get('series_id', None)
+                        series_id = episode_info.get("series", {}).get("series_id", None)
                         if series_id:
-                            series_imdb = series_id.replace('tt', '')
-                            if series_imdb.isdigit() and int(series_imdb) != meta.get('imdb_id', 0):
-                                if meta['debug']:
+                            series_imdb = series_id.replace("tt", "")
+                            if series_imdb.isdigit() and int(series_imdb) != meta.get("imdb_id", 0):
+                                if meta["debug"]:
                                     console.print(f"[yellow]Updating IMDb ID from episode data: {series_imdb}")
-                                meta['imdb_id'] = int(series_imdb)
-                                imdb_info = await imdb_manager.get_imdb_info_api(meta['imdb_id'], manual_language=meta.get('manual_language'), debug=meta.get('debug', False))
-                                meta['imdb_info'] = imdb_info
-                                check_valid_data = meta.get('imdb_info', {}).get('title', "")
+                                meta["imdb_id"] = int(series_imdb)
+                                imdb_info = await imdb_manager.get_imdb_info_api(meta["imdb_id"], manual_language=meta.get("manual_language"), debug=meta.get("debug", False))
+                                meta["imdb_info"] = imdb_info
+                                check_valid_data = meta.get("imdb_info", {}).get("title", "")
                                 if check_valid_data:
-                                    title = meta.get('title', "").strip()
-                                    aka = meta.get('imdb_info', {}).get('aka', "").strip()
-                                    year = str(meta.get('imdb_info', {}).get('year', ""))
+                                    title = meta.get("title", "").strip()
+                                    aka = meta.get("imdb_info", {}).get("aka", "").strip()
+                                    year = str(meta.get("imdb_info", {}).get("year", ""))
 
                                     if aka:
                                         aka_trimmed = aka[4:].strip().lower() if aka.lower().startswith("aka") else aka.lower()
@@ -1081,184 +1104,201 @@ class Prep:
 
                                         if aka is not None:
                                             if f"({year})" in aka:
-                                                aka = meta.get('imdb_info', {}).get('aka', "").replace(f"({year})", "").strip()
+                                                aka = meta.get("imdb_info", {}).get("aka", "").replace(f"({year})", "").strip()
                                             else:
-                                                aka = meta.get('imdb_info', {}).get('aka', "").strip()
-                                            meta['aka'] = f"AKA {aka.strip()}"
+                                                aka = meta.get("imdb_info", {}).get("aka", "").strip()
+                                            meta["aka"] = f"AKA {aka.strip()}"
                                         else:
-                                            meta['aka'] = ""
+                                            meta["aka"] = ""
                                     else:
-                                        meta['aka'] = ""
+                                        meta["aka"] = ""
 
-            if meta.get('tvdb_series_name') and meta['category'] == "TV":
-                series_name = meta.get('tvdb_series_name')
-                if series_name and meta.get('title') != series_name:
-                    if meta['debug']:
+            if meta.get("tvdb_series_name") and meta["category"] == "TV":
+                series_name = meta.get("tvdb_series_name")
+                if series_name and meta.get("title") != series_name:
+                    if meta["debug"]:
                         console.print(f"[yellow]tvdb series name: {series_name}")
-                    year_match = re.search(r'\b(19|20)\d{2}\b', series_name)
+                    year_match = re.search(r"\b(19|20)\d{2}\b", series_name)
                     if year_match:
                         extracted_year = year_match.group(0)
-                        series_name = re.sub(r'\s*\b(19|20)\d{2}\b\s*', '', series_name).strip()
-                    series_name = series_name.replace('(', '').replace(')', '').strip()
-                    should_use_tvdb_series_name = (
-                        series_name
-                        and not _tvdb_title_drops_existing_leading_article(meta.get('title'), series_name)
-                    )
+                        series_name = re.sub(r"\s*\b(19|20)\d{2}\b\s*", "", series_name).strip()
+                    series_name = series_name.replace("(", "").replace(")", "").strip()
+                    should_use_tvdb_series_name = series_name and not _tvdb_title_drops_existing_leading_article(meta.get("title"), series_name)
                     if should_use_tvdb_series_name:
-                        meta['title'] = series_name
+                        meta["title"] = series_name
 
         # bluray.com data if config
-        get_bluray_info = self.config['DEFAULT'].get('get_bluray_info', False)
-        meta['bluray_score'] = int(float(self.config['DEFAULT'].get('bluray_score', 100)))
-        meta['bluray_single_score'] = int(float(self.config['DEFAULT'].get('bluray_single_score', 100)))
-        meta['use_bluray_images'] = self.config['DEFAULT'].get('use_bluray_images', False)
-        if meta.get('is_disc') in ("BDMV", "DVD") and get_bluray_info and (meta.get('distributor') is None or meta.get('region') is None) and meta.get('imdb_id') != 0 and not meta.get('emby', False) and not meta.get('edit', False) and not meta.get('site_check', False):
+        get_bluray_info = self.config["DEFAULT"].get("get_bluray_info", False)
+        meta["bluray_score"] = int(float(self.config["DEFAULT"].get("bluray_score", 100)))
+        meta["bluray_single_score"] = int(float(self.config["DEFAULT"].get("bluray_single_score", 100)))
+        meta["use_bluray_images"] = self.config["DEFAULT"].get("use_bluray_images", False)
+        if (
+            meta.get("is_disc") in ("BDMV", "DVD")
+            and get_bluray_info
+            and (meta.get("distributor") is None or meta.get("region") is None)
+            and meta.get("imdb_id") != 0
+            and not meta.get("emby", False)
+            and not meta.get("edit", False)
+            and not meta.get("site_check", False)
+        ):
             releases = await get_bluray_releases(meta)
 
-            if releases and meta.get('is_disc') in ("BDMV", "DVD") and meta.get('use_bluray_images', False):
+            if releases and meta.get("is_disc") in ("BDMV", "DVD") and meta.get("use_bluray_images", False):
                 # and if we getting bluray/dvd images, we'll rehost them
-                    url_host_mapping = {
-                        "ibb.co": "imgbb",
-                        "pixhost.to": "pixhost",
-                        "imgbox.com": "imgbox",
-                    }
+                url_host_mapping = {
+                    "ibb.co": "imgbb",
+                    "pixhost.to": "pixhost",
+                    "imgbox.com": "imgbox",
+                }
 
-                    approved_image_hosts = ['imgbox', 'imgbb', 'pixhost']
-                    await self.rehost_images_manager.check_hosts(
-                        meta,
-                        "covers",
-                        url_host_mapping=url_host_mapping,
-                        img_host_index=1,
-                        approved_image_hosts=approved_image_hosts,
-                    )
+                approved_image_hosts = ["imgbox", "imgbb", "pixhost"]
+                await self.rehost_images_manager.check_hosts(
+                    meta,
+                    "covers",
+                    url_host_mapping=url_host_mapping,
+                    img_host_index=1,
+                    approved_image_hosts=approved_image_hosts,
+                )
 
         # user override check that only sets data after metadata setting
-        if user_overrides and not meta.get('no_override', False) and not meta.get('emby', False):
+        if user_overrides and not meta.get("no_override", False) and not meta.get("emby", False):
             meta = await self.overrides.get_source_override(meta)
 
-        meta['video'] = video
+        meta["video"] = video
 
-        if not meta.get('emby', False):
-            meta['container'] = await video_manager.get_container(meta)
+        if not meta.get("emby", False):
+            meta["container"] = await video_manager.get_container(meta)
 
-            meta['audio'], meta['channels'], meta['has_commentary'] = await self.audio_manager.get_audio_v2(mi_data, meta, bdinfo)
+            meta["audio"], meta["channels"], meta["has_commentary"] = await self.audio_manager.get_audio_v2(mi_data, meta, bdinfo)
 
-            meta['3D'] = await video_manager.is_3d(bdinfo)
+            meta["3D"] = await video_manager.is_3d(bdinfo)
 
-            is_disc_value = str(meta.get('is_disc') or "")
-            meta['source'], meta['type'] = await get_source(meta['type'], video, str(meta.get('path') or ""), is_disc_value, meta, folder_id, base_dir)
+            is_disc_value = str(meta.get("is_disc") or "")
+            meta["source"], meta["type"] = await get_source(meta["type"], video, str(meta.get("path") or ""), is_disc_value, meta, folder_id, base_dir)
 
-            meta['uhd'] = await video_manager.get_uhd(
-                meta['type'],
-                guessit_fn(str(meta.get('path') or "")),
-                str(meta.get('resolution', '')),
-                str(meta.get('path') or ""),
+            meta["uhd"] = await video_manager.get_uhd(
+                meta["type"],
+                guessit_fn(str(meta.get("path") or "")),
+                str(meta.get("resolution", "")),
+                str(meta.get("path") or ""),
             )
-            meta['hdr'] = await video_manager.get_hdr(mi_data, bdinfo)
+            meta["hdr"] = await video_manager.get_hdr(mi_data, bdinfo)
 
-            meta['distributor'] = await get_distributor(meta['distributor'])
-            if meta['distributor'] is None:
-                meta['distributor'] = ""
+            meta["distributor"] = await get_distributor(meta["distributor"])
+            if meta["distributor"] is None:
+                meta["distributor"] = ""
 
-            if meta.get('is_disc', None) == "BDMV":  # Blu-ray Specific
-                meta['region'] = await get_region(bdinfo, meta.get('region', None))
-                meta['video_codec'] = await video_manager.get_video_codec(bdinfo)
+            if meta.get("is_disc", None) == "BDMV":  # Blu-ray Specific
+                meta["region"] = await get_region(bdinfo, meta.get("region", None))
+                meta["video_codec"] = await video_manager.get_video_codec(bdinfo)
             else:
-                meta['video_encode'], meta['video_codec'], meta['has_encode_settings'], meta['bit_depth'] = await video_manager.get_video_encode(mi_data, meta['type'], bdinfo)
+                meta["video_encode"], meta["video_codec"], meta["has_encode_settings"], meta["bit_depth"] = await video_manager.get_video_encode(mi_data, meta["type"], bdinfo)
 
-            if meta['region'] is None:
-                meta['region'] = ""
+            if meta["region"] is None:
+                meta["region"] = ""
 
-            if meta.get('no_edition') is False:
-                manual_edition = meta.get('manual_edition') or ""
-                meta['edition'], meta['repack'], meta['webdv'] = await get_edition(meta['uuid'], bdinfo, meta['filelist'], manual_edition, meta)
-                if "REPACK" in meta.get('edition', ""):
-                    repack_match = re.search(r"REPACK[\d]?", meta['edition'])
+            if meta.get("no_edition") is False:
+                manual_edition = meta.get("manual_edition") or ""
+                meta["edition"], meta["repack"], meta["webdv"] = await get_edition(meta["uuid"], bdinfo, meta["filelist"], manual_edition, meta)
+                if "REPACK" in meta.get("edition", ""):
+                    repack_match = re.search(r"REPACK[\d]?", meta["edition"])
                     if repack_match:
-                        meta['repack'] = repack_match.group(0)
-                    meta['edition'] = re.sub(r"REPACK[\d]?", "", meta['edition']).strip().replace('  ', ' ')
+                        meta["repack"] = repack_match.group(0)
+                    meta["edition"] = re.sub(r"REPACK[\d]?", "", meta["edition"]).strip().replace("  ", " ")
             else:
-                meta['edition'] = ""
+                meta["edition"] = ""
 
-            meta['valid_mi_settings'] = True
-            if not meta['is_disc'] and meta['type'] in ["ENCODE"] and meta['video_codec'] not in ["AV1"]:
-                valid_mi_settings = validate_mediainfo(meta, debug=meta['debug'], settings=True)
+            meta["valid_mi_settings"] = True
+            if not meta["is_disc"] and meta["type"] in ["ENCODE"] and meta["video_codec"] not in ["AV1"]:
+                valid_mi_settings = validate_mediainfo(meta, debug=meta["debug"], settings=True)
                 if not valid_mi_settings:
                     console.print("[red]MediaInfo validation failed. This file does not contain encode settings.")
-                    meta['valid_mi_settings'] = False
+                    meta["valid_mi_settings"] = False
                     await asyncio.sleep(2)
 
-            meta.get('stream', False)
-            meta['stream'] = await self.stream_optimized(meta['stream'])
+            meta.get("stream", False)
+            meta["stream"] = await self.stream_optimized(meta["stream"])
 
-            if meta.get('tag', None) is None:
-                if meta.get('we_need_tag', False):
-                    meta['tag'] = await get_tag(meta['scene_name'], meta)
+            if meta.get("tag", None) is None:
+                if meta.get("we_need_tag", False):
+                    meta["tag"] = await get_tag(meta["scene_name"], meta)
                 else:
-                    meta['tag'] = await get_tag(video, meta)
+                    meta["tag"] = await get_tag(video, meta)
                     # all lowercase filenames will have bad group tag, it's probably a scene release.
                     # some extracted files do not match release name so lets double check if it really is a scene release
-                    if not meta.get('scene') and meta['tag']:
+                    if not meta.get("scene") and meta["tag"]:
                         base = os.path.basename(video)
                         match = re.match(r"^(.+)\.[a-zA-Z0-9]{3}$", os.path.basename(video))
-                        if match and (not meta['is_disc'] or meta.get('keep_folder', False)):
+                        if match and (not meta["is_disc"] or meta.get("keep_folder", False)):
                             base = match.group(1)
                             is_all_lowercase = base.islower()
                             if is_all_lowercase:
-                                release_name, _, _ = await self.scene_manager.is_scene(videopath, meta, meta.get('imdb_id', 0), lower=True)
+                                release_name, _, _ = await self.scene_manager.is_scene(videopath, meta, meta.get("imdb_id", 0), lower=True)
                                 if release_name:
                                     try:
-                                        meta['scene_name'] = release_name
-                                        meta['tag'] = await get_tag(release_name, meta)
+                                        meta["scene_name"] = release_name
+                                        meta["tag"] = await get_tag(release_name, meta)
                                     except Exception:
                                         console.print("[red]Error getting tag from scene name, check group tag.[/red]")
 
             else:
-                if not meta['tag'].startswith('-') and meta['tag'] != "":
-                    meta['tag'] = f"-{meta['tag']}"
+                if not meta["tag"].startswith("-") and meta["tag"] != "":
+                    meta["tag"] = f"-{meta['tag']}"
 
             meta = await tag_override(meta)
 
-            if meta['tag'][1:].startswith(meta['channels']):
-                meta['tag'] = meta['tag'].replace(f"-{meta['channels']}", '')
+            if meta["tag"][1:].startswith(meta["channels"]):
+                meta["tag"] = meta["tag"].replace(f"-{meta['channels']}", "")
 
-            if meta.get('no_tag', False):
-                meta['tag'] = ""
+            if meta.get("no_tag", False):
+                meta["tag"] = ""
 
-            if meta.get('tag') == "-SubsPlease":  # SubsPlease-specific
-                tracks = meta.get('mediainfo', {}).get('media', {}).get('track', [])  # Get all tracks
-                bitrate = tracks[1].get('BitRate', '') if len(tracks) > 1 and not isinstance(tracks[1].get('BitRate', ''), dict) else ''  # Check that bitrate is not a dict
-                bitrate_oldMediaInfo = tracks[0].get('OverallBitRate', '') if len(tracks) > 0 and not isinstance(tracks[0].get('OverallBitRate', ''), dict) else ''  # Check for old MediaInfo
-                meta['episode_title'] = ""
-                if (bitrate.isdigit() and int(bitrate) >= 8000000) or (bitrate_oldMediaInfo.isdigit() and int(bitrate_oldMediaInfo) >= 8000000) and meta.get('resolution') == "1080p":  # 8Mbps for 1080p
-                    meta['service'] = "CR"
-                elif (bitrate.isdigit() or bitrate_oldMediaInfo.isdigit()) and meta.get('resolution') == "1080p":  # Only assign if at least one bitrate is present, otherwise leave it to user
-                    meta['service'] = "HIDI"
-                elif (bitrate.isdigit() and int(bitrate) >= 4000000) or (bitrate_oldMediaInfo.isdigit() and int(bitrate_oldMediaInfo) >= 4000000) and meta.get('resolution') == "720p":  # 4Mbps for 720p
-                    meta['service'] = "CR"
-                elif (bitrate.isdigit() or bitrate_oldMediaInfo.isdigit()) and meta.get('resolution') == "720p":
-                    meta['service'] = "HIDI"
+            if meta.get("tag") == "-SubsPlease":  # SubsPlease-specific
+                tracks = meta.get("mediainfo", {}).get("media", {}).get("track", [])  # Get all tracks
+                bitrate = tracks[1].get("BitRate", "") if len(tracks) > 1 and not isinstance(tracks[1].get("BitRate", ""), dict) else ""  # Check that bitrate is not a dict
+                bitrate_oldMediaInfo = (
+                    tracks[0].get("OverallBitRate", "") if len(tracks) > 0 and not isinstance(tracks[0].get("OverallBitRate", ""), dict) else ""
+                )  # Check for old MediaInfo
+                meta["episode_title"] = ""
+                if (
+                    (bitrate.isdigit() and int(bitrate) >= 8000000)
+                    or (bitrate_oldMediaInfo.isdigit() and int(bitrate_oldMediaInfo) >= 8000000)
+                    and meta.get("resolution") == "1080p"
+                ):  # 8Mbps for 1080p
+                    meta["service"] = "CR"
+                elif (bitrate.isdigit() or bitrate_oldMediaInfo.isdigit()) and meta.get(
+                    "resolution"
+                ) == "1080p":  # Only assign if at least one bitrate is present, otherwise leave it to user
+                    meta["service"] = "HIDI"
+                elif (
+                    (bitrate.isdigit() and int(bitrate) >= 4000000)
+                    or (bitrate_oldMediaInfo.isdigit() and int(bitrate_oldMediaInfo) >= 4000000)
+                    and meta.get("resolution") == "720p"
+                ):  # 4Mbps for 720p
+                    meta["service"] = "CR"
+                elif (bitrate.isdigit() or bitrate_oldMediaInfo.isdigit()) and meta.get("resolution") == "720p":
+                    meta["service"] = "HIDI"
 
-            if meta.get('service', None) in (None, ''):
-                meta['service'], meta['service_longname'] = await get_service(video, meta.get('tag', ''), meta['audio'], meta['filename'])
-            elif meta.get('service'):
+            if meta.get("service", None) in (None, ""):
+                meta["service"], meta["service_longname"] = await get_service(video, meta.get("tag", ""), meta["audio"], meta["filename"])
+            elif meta.get("service"):
                 services = cast(dict[str, str], await get_service(get_services_only=True))
-                service_code = str(meta.get('service') or '')
-                meta['service_longname'] = max((k for k, v in services.items() if v == service_code), key=len, default=service_code)
+                service_code = str(meta.get("service") or "")
+                meta["service_longname"] = max((k for k, v in services.items() if v == service_code), key=len, default=service_code)
 
             # Parse NFO for scene releases to get service
-            if meta['scene'] and not meta.get('service') and meta['category'] == "TV":
+            if meta["scene"] and not meta.get("service") and meta["category"] == "TV":
                 await self.parse_scene_nfo(meta)
 
             # Combine genres from TMDB and IMDb
-            tmdb_genres = str(meta.get('genres') or '')
-            imdb_genres = str(meta.get('imdb_info', {}).get('genres') or '')
+            tmdb_genres = str(meta.get("genres") or "")
+            imdb_genres = str(meta.get("imdb_info", {}).get("genres") or "")
 
             all_genres: list[str] = []
             if tmdb_genres:
-                all_genres.extend([g.strip() for g in tmdb_genres.split(',') if g.strip()])
+                all_genres.extend([g.strip() for g in tmdb_genres.split(",") if g.strip()])
             if imdb_genres:
-                all_genres.extend([g.strip() for g in imdb_genres.split(',') if g.strip()])
+                all_genres.extend([g.strip() for g in imdb_genres.split(",") if g.strip()])
 
             seen: set[str] = set()
             unique_genres: list[str] = []
@@ -1268,70 +1308,70 @@ class Prep:
                     seen.add(genre_lower)
                     unique_genres.append(genre)
 
-            meta['combined_genres'] = ', '.join(unique_genres) if unique_genres else ''
+            meta["combined_genres"] = ", ".join(unique_genres) if unique_genres else ""
 
         # return duplicate ids so I don't have to catch every site file
         # this has the other advantage of stringing imdb for this object
-        meta['tmdb'] = meta.get('tmdb_id')
-        imdb_id_value = _to_int(meta.get('imdb_id'))
+        meta["tmdb"] = meta.get("tmdb_id")
+        imdb_id_value = _to_int(meta.get("imdb_id"))
         if imdb_id_value != 0:
             imdb_str = str(imdb_id_value).zfill(7)
-            meta['imdb'] = imdb_str
+            meta["imdb"] = imdb_str
         else:
-            meta['imdb'] = '0'
-        meta['mal'] = meta.get('mal_id')
-        meta['tvdb'] = meta.get('tvdb_id')
-        meta['tvmaze'] = meta.get('tvmaze_id')
+            meta["imdb"] = "0"
+        meta["mal"] = meta.get("mal_id")
+        meta["tvdb"] = meta.get("tvdb_id")
+        meta["tvmaze"] = meta.get("tvmaze_id")
 
         # we finished the metadata, time it
-        if meta['debug']:
+        if meta["debug"]:
             meta_finish_time = time.time()
             console.print(f"Metadata processed in {meta_finish_time - meta_start_time:.2f} seconds")
 
         return meta
 
     async def get_cat(self, _video: str, meta: dict[str, Any]) -> Optional[str]:
-        if meta.get('manual_category'):
-            manual_category = meta.get('manual_category')
+        if meta.get("manual_category"):
+            manual_category = meta.get("manual_category")
             return manual_category.upper() if isinstance(manual_category, str) else None
 
         path_patterns = [
-            r'(?i)[\\/](?:tv|tvshows|tv.shows|series|shows)[\\/]',
-            r'(?i)[\\/](?:season\s*\d+|s\d+)[\\/]',
-            r'(?i)[\\/](?:s\d{1,2}e\d{1,2}|s\d{1,2}|season\s*\d+)',
-            r'(?i)(?:tv pack|season\s*\d+)'
+            r"(?i)[\\/](?:tv|tvshows|tv.shows|series|shows)[\\/]",
+            r"(?i)[\\/](?:season\s*\d+|s\d+)[\\/]",
+            r"(?i)[\\/](?:s\d{1,2}e\d{1,2}|s\d{1,2}|season\s*\d+)",
+            r"(?i)(?:tv pack|season\s*\d+)",
         ]
 
         filename_patterns = [
-            r'(?i)s\d{1,2}e\d{1,2}',
-            r'(?i)s\d{1,2}',
-            r'(?i)\b\d{1,2}x\d{2}\b',
-            r'(?i)(?:season|series)\s*\d+',
-            r'(?i)e\d{2,3}\s*\-',
-            r'(?i)\d{4}\.\d{1,2}\.\d{1,2}'
+            r"(?i)s\d{1,2}e\d{1,2}",
+            r"(?i)s\d{1,2}",
+            r"(?i)\b\d{1,2}x\d{2}\b",
+            r"(?i)(?:season|series)\s*\d+",
+            r"(?i)e\d{2,3}\s*\-",
+            r"(?i)\d{4}\.\d{1,2}\.\d{1,2}",
         ]
 
-        path = meta.get('path', '')
-        uuid = meta.get('uuid', '')
-        if meta.get('debug', False):
+        path = meta.get("path", "")
+        uuid = meta.get("uuid", "")
+        if meta.get("debug", False):
             console.print(f"[cyan]Checking category for path: {path} and uuid: {uuid}[/cyan]")
 
         for pattern in path_patterns:
             if re.search(pattern, path):
-                if meta.get('debug', False):
+                if meta.get("debug", False):
                     console.print(f"[cyan]Matched TV pattern in path: {pattern}[/cyan]")
                 return "TV"
 
         for pattern in filename_patterns:
             if re.search(pattern, uuid) or re.search(pattern, os.path.basename(path)):
-                if meta.get('debug', False):
+                if meta.get("debug", False):
                     console.print(f"[cyan]Matched TV pattern in filename: {pattern}[/cyan]")
                 return "TV"
 
         if "subsplease" in path.lower() or "subsplease" in uuid.lower():
-            anime_pattern = r'(?:\s-\s)?(\d{1,3})\s*\((?:\d+p|480p|480i|576i|576p|720p|1080i|1080p|2160p)\)'
+            anime_pattern = r"(?:\s-\s)?(\d{1,3})\s*\((?:\d+p|480p|480i|576i|576p|720p|1080i|1080p|2160p)\)"
             if re.search(anime_pattern, path.lower()) or re.search(anime_pattern, uuid.lower()):
-                if meta.get('debug', False):
+                if meta.get("debug", False):
                     console.print(f"[cyan]Matched Anime pattern for SubsPlease: {anime_pattern}[/cyan]")
                 return "TV"
 
@@ -1343,24 +1383,24 @@ class Prep:
 
     async def parse_scene_nfo(self, meta: dict[str, Any]) -> None:
         try:
-            nfo_file = meta.get('scene_nfo_file', '')
+            nfo_file = meta.get("scene_nfo_file", "")
 
             if not nfo_file:
-                if meta['debug']:
+                if meta["debug"]:
                     console.print("[yellow]No NFO file found for scene release[/yellow]")
                 return
 
-            if meta['debug']:
+            if meta["debug"]:
                 console.print(f"[cyan]Parsing NFO file: {nfo_file}[/cyan]")
 
-            async with aiofiles.open(nfo_file, encoding='utf-8', errors='ignore') as f:
+            async with aiofiles.open(nfo_file, encoding="utf-8", errors="ignore") as f:
                 nfo_content = await f.read()
 
             # Parse Source field
-            source_match = re.search(r'^Source\s*:\s*(.+?)$', nfo_content, re.MULTILINE | re.IGNORECASE)
+            source_match = re.search(r"^Source\s*:\s*(.+?)$", nfo_content, re.MULTILINE | re.IGNORECASE)
             if source_match:
                 nfo_source = source_match.group(1).strip()
-                if meta['debug']:
+                if meta["debug"]:
                     console.print(f"[cyan]Found source in NFO: {nfo_source}[/cyan]")
 
                 # Check if source matches any service
@@ -1369,12 +1409,12 @@ class Prep:
                 # Exact match
                 for service_name, service_code in services.items():
                     if nfo_source.upper() == service_name.upper() or nfo_source.upper() == service_code.upper():
-                        meta['service'] = service_code
-                        meta['service_longname'] = service_name
-                        if meta['debug']:
+                        meta["service"] = service_code
+                        meta["service_longname"] = service_name
+                        if meta["debug"]:
                             console.print(f"[green]Matched service: {service_code} ({service_name})[/green]")
                         break
 
         except Exception as e:
-            if meta['debug']:
+            if meta["debug"]:
                 console.print(f"[red]Error parsing NFO file: {e}[/red]")

--- a/src/trackers/IS.py
+++ b/src/trackers/IS.py
@@ -333,7 +333,7 @@ class IS:
             upload_cookies=self.session.cookies,
             upload_url="https://immortalseed.me/upload.php",
             additional_files=files,
-            success_text="Download Torrent (SSL)",
+            success_list=["Download Torrent (SSL)", "Thank you for uploading"],
         )
 
         return is_uploaded

--- a/src/trackers/NBL.py
+++ b/src/trackers/NBL.py
@@ -71,7 +71,7 @@ class NBL:
             'tvmazeid': int(meta.get('tvmaze_id', 0)),
             'mediainfo': mi_dump,
             'category': await self.get_cat_id(meta),
-            'ignoredupes': 'on'
+            'ignoredupes': '1'
         }
 
         try:

--- a/src/trackers/NBL.py
+++ b/src/trackers/NBL.py
@@ -27,23 +27,86 @@ class NBL:
     def __init__(self, config: Config) -> None:
         self.config: Config = config
         self.common = COMMON(config)
-        self.tracker = 'NBL'
-        self.source_flag = 'NBL'
-        self.upload_url = 'https://nebulance.io/api.php'
-        self.search_url = 'https://nebulance.io/api.php'
-        self.torrent_url = 'https://nebulance.io/torrents.php?id='
-        self.api_key = str(self.config['TRACKERS'][self.tracker]['api_key']).strip()
-        self.banned_groups = ['0neshot', '3LTON', '4yEo', '[Oj]', 'AFG', 'AkihitoSubs', 'AniHLS', 'Anime Time', 'AnimeRG', 'AniURL', 'ASW', 'BakedFish',
-                              'bonkai77', 'Cleo', 'DeadFish', 'DeeJayAhmed', 'ELiTE', 'EMBER', 'eSc', 'EVO', 'FGT', 'FUM', 'GERMini', 'HAiKU', 'Hi10', 'ION10',
-                              'JacobSwaggedUp', 'JIVE', 'Judas', 'LOAD', 'MeGusta', 'Mr.Deadpool', 'mSD', 'NemDiggers', 'neoHEVC', 'NhaNc3', 'NOIVTC',
-                              'PlaySD', 'playXD', 'project-gxs', 'PSA', 'QaS', 'Ranger', 'RAPiDCOWS', 'Raze', 'Reaktor', 'REsuRRecTioN', 'RMTeam', 'ROBOTS',
-                              'SpaceFish', 'SPASM', 'SSA', 'Telly', 'Tenrai-Sensei', 'TM', 'Trix', 'URANiME', 'VipapkStudios', 'ViSiON', 'Wardevil', 'xRed',
-                              'XS', 'YakuboEncodes', 'YuiSubs', 'ZKBL', 'ZmN', 'ZMNT']
+        self.tracker = "NBL"
+        self.source_flag = "NBL"
+        self.upload_url = "https://nebulance.io/api.php"
+        self.search_url = "https://nebulance.io/api.php"
+        self.torrent_url = "https://nebulance.io/torrents.php?id="
+        self.api_key = str(self.config["TRACKERS"][self.tracker]["api_key"]).strip()
+        self.banned_groups = [
+            "0neshot",
+            "3LTON",
+            "4yEo",
+            "[Oj]",
+            "AFG",
+            "AkihitoSubs",
+            "AniHLS",
+            "Anime Time",
+            "AnimeRG",
+            "AniURL",
+            "ASW",
+            "BakedFish",
+            "bonkai77",
+            "Cleo",
+            "DeadFish",
+            "DeeJayAhmed",
+            "ELiTE",
+            "EMBER",
+            "eSc",
+            "EVO",
+            "FGT",
+            "FUM",
+            "GERMini",
+            "HAiKU",
+            "Hi10",
+            "ION10",
+            "JacobSwaggedUp",
+            "JIVE",
+            "Judas",
+            "LOAD",
+            "MeGusta",
+            "Mr.Deadpool",
+            "mSD",
+            "NemDiggers",
+            "neoHEVC",
+            "NhaNc3",
+            "NOIVTC",
+            "PlaySD",
+            "playXD",
+            "project-gxs",
+            "PSA",
+            "QaS",
+            "Ranger",
+            "RAPiDCOWS",
+            "Raze",
+            "Reaktor",
+            "REsuRRecTioN",
+            "RMTeam",
+            "ROBOTS",
+            "SpaceFish",
+            "SPASM",
+            "SSA",
+            "Telly",
+            "Tenrai-Sensei",
+            "TM",
+            "Trix",
+            "URANiME",
+            "VipapkStudios",
+            "ViSiON",
+            "Wardevil",
+            "xRed",
+            "XS",
+            "YakuboEncodes",
+            "YuiSubs",
+            "ZKBL",
+            "ZmN",
+            "ZMNT",
+        ]
 
         pass
 
     async def get_cat_id(self, meta: Meta) -> int:
-        cat_id = 3 if meta.get('tv_pack', 0) == 1 else 1
+        cat_id = 3 if meta.get("tv_pack", 0) == 1 else 1
         return cat_id
 
     async def edit_desc(self, _meta: Meta) -> None:
@@ -53,100 +116,95 @@ class NBL:
     async def upload(self, meta: Meta, _disctype: str) -> bool:
         await self.common.create_torrent_for_upload(meta, self.tracker, self.source_flag)
 
-        if meta['bdinfo'] is not None:
-            async with aiofiles.open(f"{meta['base_dir']}/tmp/{meta['uuid']}/BD_SUMMARY_00.txt", encoding='utf-8') as f:
+        if meta["bdinfo"] is not None:
+            async with aiofiles.open(f"{meta['base_dir']}/tmp/{meta['uuid']}/BD_SUMMARY_00.txt", encoding="utf-8") as f:
                 mi_dump = await f.read()
         else:
-            async with aiofiles.open(f"{meta['base_dir']}/tmp/{meta['uuid']}/MEDIAINFO.txt", encoding='utf-8') as f:
+            async with aiofiles.open(f"{meta['base_dir']}/tmp/{meta['uuid']}/MEDIAINFO.txt", encoding="utf-8") as f:
                 mi_dump = await f.read()
         torrent_file_path = f"{meta['base_dir']}/tmp/{meta['uuid']}/[{self.tracker}].torrent"
-        async with aiofiles.open(torrent_file_path, 'rb') as f:
+        async with aiofiles.open(torrent_file_path, "rb") as f:
             torrent_bytes = await f.read()
-        files: dict[str, tuple[str, bytes, str]] = {
-            'file_input': ('torrent.torrent', torrent_bytes, 'application/x-bittorrent')
-        }
+        files: dict[str, tuple[str, bytes, str]] = {"file_input": ("torrent.torrent", torrent_bytes, "application/x-bittorrent")}
         data: dict[str, Any] = {
-            'action': 'upload',
-            'api_key': self.api_key,
-            'tvmazeid': int(meta.get('tvmaze_id', 0)),
-            'mediainfo': mi_dump,
-            'category': await self.get_cat_id(meta),
-            'ignoredupes': '1'
+            "action": "upload",
+            "api_key": self.api_key,
+            "tvmazeid": int(meta.get("tvmaze_id", 0)),
+            "mediainfo": mi_dump,
+            "category": await self.get_cat_id(meta),
+            "ignoredupes": "1",
         }
 
         try:
-            if not meta['debug']:
+            if not meta["debug"]:
                 async with httpx.AsyncClient(timeout=30) as client:
                     response = await client.post(url=self.upload_url, files=files, data=data)
                     if response.status_code in [200, 201]:
                         try:
                             response_data = response.json()
-                            meta['tracker_status'][self.tracker]['status_message'] = response_data
-                            match = re.search(r"https://nebulance\.io/torrents\.php\?id=(\d+)", response_data.get('link', ''))
+                            meta["tracker_status"][self.tracker]["status_message"] = response_data
+                            match = re.search(r"https://nebulance\.io/torrents\.php\?id=(\d+)", response_data.get("link", ""))
                             if match:
                                 torrent_id = match.group(1)
-                                meta['tracker_status'][self.tracker]['torrent_id'] = torrent_id
+                                meta["tracker_status"][self.tracker]["torrent_id"] = torrent_id
                             return True
                         except json.JSONDecodeError:
-                            meta['tracker_status'][self.tracker]['status_message'] = "data error: NBL json decode error, the API is probably down"
+                            meta["tracker_status"][self.tracker]["status_message"] = "data error: NBL json decode error, the API is probably down"
                             return False
                     else:
-                        response_data = {
-                            "error": f"Unexpected status code: {response.status_code}",
-                            "response_content": response.text
-                        }
-                        meta['tracker_status'][self.tracker]['status_message'] = response_data
+                        response_data = {"error": f"Unexpected status code: {response.status_code}", "response_content": response.text}
+                        meta["tracker_status"][self.tracker]["status_message"] = response_data
                     return False
             else:
                 console.print("[cyan]NBL Request Data:")
                 console.print(data)
-                meta['tracker_status'][self.tracker]['status_message'] = "Debug mode enabled, not uploading."
+                meta["tracker_status"][self.tracker]["status_message"] = "Debug mode enabled, not uploading."
                 await self.common.create_torrent_for_upload(meta, f"{self.tracker}" + "_DEBUG", f"{self.tracker}" + "_DEBUG", announce_url="https://fake.tracker")
                 return True  # Debug mode - simulated success
         except Exception as e:
-            meta['tracker_status'][self.tracker]['status_message'] = f"data error: Upload failed: {e}"
+            meta["tracker_status"][self.tracker]["status_message"] = f"data error: Upload failed: {e}"
             return False
 
     async def search_existing(self, meta: Meta, _disctype: str) -> Union[list[dict[str, Any]], bool]:
-        if meta['category'] != 'TV':
-            if meta['tvmaze_id'] != 0:
-                if not meta['unattended'] or (meta['unattended'] and meta.get('unattended_confirm', False)):
+        if meta["category"] != "TV":
+            if meta["tvmaze_id"] != 0:
+                if not meta["unattended"] or (meta["unattended"] and meta.get("unattended_confirm", False)):
                     console.print("[red]Only TV or TV Movies are allowed at NBL, this has a tvmaze ID[/red]")
                     if cli_ui.ask_yes_no("Do you want to upload it?", default=False):
                         pass
                     else:
-                        meta['skipping'] = "NBL"
+                        meta["skipping"] = "NBL"
                         return []
                 else:
-                    meta['skipping'] = "NBL"
+                    meta["skipping"] = "NBL"
                     return []
             else:
-                if not meta['unattended']:
+                if not meta["unattended"]:
                     console.print("[red]Only TV Is allowed at NBL")
-                meta['skipping'] = "NBL"
+                meta["skipping"] = "NBL"
                 return []
 
-        if meta['is_disc'] != "BDMV" and not await self.common.check_language_requirements(
+        if meta["is_disc"] != "BDMV" and not await self.common.check_language_requirements(
             meta, self.tracker, languages_to_check=["english"], check_audio=True, check_subtitle=True, original_language=True
         ):
             return False
 
-        if meta['valid_mi'] is False:
+        if meta["valid_mi"] is False:
             console.print(f"[bold red]No unique ID in mediainfo, skipping {self.tracker} upload.")
             return False
 
-        if meta.get('is_disc') is not None:
-            if not meta['unattended']:
-                console.print('[bold red]NBL does not allow raw discs')
-            meta['skipping'] = "NBL"
+        if meta.get("is_disc") is not None:
+            if not meta["unattended"]:
+                console.print("[bold red]NBL does not allow raw discs")
+            meta["skipping"] = "NBL"
             return []
 
         dupes: list[dict[str, Any]] = []
 
         season = meta.get("season_int", 0)
-        tvmaze_data = meta.get('tvmaze_episode_data', {})
+        tvmaze_data = meta.get("tvmaze_episode_data", {})
         if tvmaze_data:
-            season = tvmaze_data.get('season_number', season)
+            season = tvmaze_data.get("season_number", season)
 
         params: dict[str, Any] = {
             "action": "search",
@@ -168,12 +226,12 @@ class NBL:
         else:
             params["series"] = meta["title"]
 
-        params['tags'] = [meta['resolution']]
-        params['per_page'] = 100
+        params["tags"] = [meta["resolution"]]
+        params["per_page"] = 100
 
         response: Optional[httpx.Response] = None
         try:
-            max_pages = int(self.config['TRACKERS'][self.tracker].get('search_max_pages', 10))
+            max_pages = int(self.config["TRACKERS"][self.tracker].get("search_max_pages", 10))
             async with httpx.AsyncClient(timeout=10.0) as client:
                 for page in range(max_pages):
                     page_params = dict(params)
@@ -187,67 +245,60 @@ class NBL:
                                 error_data = cast(dict[str, Any], response.json())
                             except json.JSONDecodeError:
                                 error_data = {}
-                            error = error_data.get('error', {})
-                            message = str(error.get('message', '')) if isinstance(error, dict) else ''
+                            error = error_data.get("error", {})
+                            message = str(error.get("message", "")) if isinstance(error, dict) else ""
                             if "out of range" in message.lower() and "valid pages" in message.lower():
                                 break
                         console.print(f"[bold red]NBL HTTP request failed. Status: {response.status_code}")
                         console.print(f"[bold red]NBL Search Response Content (page {page}): {response.text}")
-                        meta['skipping'] = "NBL"
+                        meta["skipping"] = "NBL"
                         break
 
                     try:
                         data = cast(dict[str, Any], response.json())
                     except json.JSONDecodeError:
                         console.print("[bold yellow]NBL response content is not valid JSON. Skipping this API call.")
-                        meta['skipping'] = "NBL"
+                        meta["skipping"] = "NBL"
                         break
 
-                    items_value = data.get('items')
+                    items_value = data.get("items")
                     if not isinstance(items_value, list):
-                        result = cast(dict[str, Any], data.get('result', {}))
-                        items_value = result.get('items', [])
+                        result = cast(dict[str, Any], data.get("result", {}))
+                        items_value = result.get("items", [])
                     items = cast(list[dict[str, Any]], items_value) if isinstance(items_value, list) else []
                     if not items:
                         break
 
                     for each in items:
-                        tags_value = each.get('tags', [])
+                        tags_value = each.get("tags", [])
                         tags = cast(list[Any], tags_value) if isinstance(tags_value, list) else []
-                        if meta['resolution'] in tags:
-                            file_list_value = each.get('file_list', [])
+                        if meta["resolution"] in tags:
+                            file_list_value = each.get("file_list", [])
                             file_list = cast(list[Any], file_list_value) if isinstance(file_list_value, list) else []
-                            files_str = ', '.join(str(item) for item in file_list) if file_list else str(cast(Any, file_list_value))
+                            files_str = ", ".join(str(item) for item in file_list) if file_list else str(cast(Any, file_list_value))
                             result = {
-                                'name': str(each.get('rls_name', '')),
-                                'files': files_str,
-                                'size': int(each.get('size', 0)),
-                                'link': f"https://nebulance.io/torrents.php?id={each.get('group_id', '')}",
-                                'file_count': len(file_list) if file_list else 1,
-                                'download': str(each.get('download', '')),
+                                "name": str(each.get("rls_name", "")),
+                                "files": files_str,
+                                "size": int(each.get("size", 0)),
+                                "link": f"https://nebulance.io/torrents.php?id={each.get('group_id', '')}",
+                                "file_count": len(file_list) if file_list else 1,
+                                "download": str(each.get("download", "")),
                             }
                             dupes.append(result)
 
         except httpx.TimeoutException:
             console.print("[bold red]NBL request timed out after 10 seconds")
-            meta['skipping'] = "NBL"
+            meta["skipping"] = "NBL"
         except httpx.RequestError as e:
             console.print(f"[bold red]NBL an error occurred while making the request: {e}")
-            meta['skipping'] = "NBL"
+            meta["skipping"] = "NBL"
         except KeyError as e:
             console.print(f"[bold red]Unexpected KeyError: {e}")
-            if response is not None and 'result' not in response.json():
+            if response is not None and "result" not in response.json():
                 console.print("[red]NBL API returned an unexpected response. Please manually check for dupes.")
-                dupes.append({
-                    'name': "ERROR: PLEASE CHECK FOR EXISTING RELEASES MANUALLY",
-                    'files': '',
-                    'size': 0,
-                    'link': '',
-                    'file_count': 0,
-                    'download': ''
-                })
+                dupes.append({"name": "ERROR: PLEASE CHECK FOR EXISTING RELEASES MANUALLY", "files": "", "size": 0, "link": "", "file_count": 0, "download": ""})
         except Exception as e:
-            meta['skipping'] = "NBL"
+            meta["skipping"] = "NBL"
             console.print(f"[bold red]NBL unexpected error: {e}")
             console.print_exception()
 

--- a/src/trackers/PTP.py
+++ b/src/trackers/PTP.py
@@ -477,6 +477,77 @@ class PTP:
             # img_url = ptpimg_upload(image_url, ptpimg_api)
         return img_url
 
+    def _selected_poster_host(self, meta: dict[str, Any]) -> str:
+        default_config = cast(dict[str, Any], self.config.get('DEFAULT', {}))
+        return str(meta.get('imghost') or default_config.get('img_host_1') or '').strip()
+
+    def _poster_already_on_selected_host(self, image_url: str, selected_host: str) -> bool:
+        if not selected_host:
+            return False
+        hostname = (urlparse(image_url).hostname or '').lower()
+        host_aliases = {
+            'imgbb': ('ibb.co', 'imgbb.com'),
+            'imgbox': ('imgbox.com',),
+            'pixhost': ('pixhost.to',),
+            'lensdump': ('lensdump.com',),
+            'onlyimage': ('onlyimage.org',),
+            'ptpimg': ('ptpimg.me',),
+            'ptscreens': ('ptscreens.com',),
+            'passtheimage': ('passtheima.ge',),
+            'seedpool_cdn': ('cdn.seedpool.org',),
+            'utppm': ('utp.pm',),
+        }
+        aliases = host_aliases.get(selected_host, (selected_host,))
+        return any(hostname == alias or hostname.endswith(f".{alias}") for alias in aliases)
+
+    def _poster_extension(self, image_url: str, content_type: str) -> str:
+        url_extension = Path(urlparse(image_url).path).suffix.lower()
+        if url_extension in {'.jpg', '.jpeg', '.png', '.webp'}:
+            return url_extension
+
+        content_type = content_type.split(';', 1)[0].strip().lower()
+        content_type_extensions = {
+            'image/jpeg': '.jpg',
+            'image/png': '.png',
+            'image/webp': '.webp',
+        }
+        return content_type_extensions.get(content_type, '.jpg')
+
+    async def rehost_poster_to_selected_host(self, meta: dict[str, Any], image_url: str) -> str:
+        selected_host = self._selected_poster_host(meta)
+        if not selected_host or meta.get('skip_imghost_upload', False):
+            return image_url
+        if self._poster_already_on_selected_host(image_url, selected_host):
+            return image_url
+
+        tmp_dir = Path(meta['base_dir']) / "tmp" / meta['uuid']
+        try:
+            tmp_dir.mkdir(parents=True, exist_ok=True)
+            async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
+                response = await client.get(image_url)
+                response.raise_for_status()
+            poster_path = tmp_dir / f"PTP_POSTER{self._poster_extension(image_url, response.headers.get('content-type', ''))}"
+            await asyncio.to_thread(poster_path.write_bytes, response.content)
+
+            original_imghost = meta.get('imghost')
+            meta['imghost'] = selected_host
+            try:
+                uploaded_images, _ = await self.uploadscreens_manager.upload_screens(meta, 1, 1, 0, 1, [str(poster_path)], {})
+            finally:
+                if original_imghost is None:
+                    meta.pop('imghost', None)
+                else:
+                    meta['imghost'] = original_imghost
+
+            if uploaded_images:
+                uploaded_url = uploaded_images[0].get('raw_url') or uploaded_images[0].get('img_url')
+                if isinstance(uploaded_url, str) and uploaded_url:
+                    return uploaded_url
+        except Exception as e:
+            console.print(f"[red]PTP poster rehost to {selected_host} failed: {e}")
+
+        return image_url
+
     def get_type(self, imdb_info: dict[str, Any], meta: dict[str, Any]) -> Optional[str]:
         ptpType = None
         if imdb_info['type'] is not None:
@@ -1504,12 +1575,18 @@ class PTP:
             cover = meta["imdb_info"].get("cover")
             if cover is None:
                 cover = meta.get('poster')
-            if isinstance(cover, str) and "ptpimg" not in cover:
-                cover = await self.ptpimg_url_rehost(cover)
+            if isinstance(cover, str) and cover.strip():
+                cover = await self.rehost_poster_to_selected_host(meta, cover)
+            elif isinstance(cover, str):
+                cover = None
             while cover is None:
-                cover = cli_ui.ask_string("No Poster was found. Please input a link to a poster: \n", default="")
-                if "ptpimg" not in str(cover) and str(cover).endswith(('.jpg', '.png')):
-                    cover = await self.ptpimg_url_rehost(str(cover))
+                cover_input = str(cli_ui.ask_string("No Poster was found. Please input a link to a poster: \n", default="") or "").strip()
+                if not cover_input:
+                    continue
+                if not cover_input.lower().endswith(('.jpg', '.jpeg', '.png', '.webp')):
+                    console.print("[red]Poster URL must end with .jpg, .jpeg, .png, or .webp")
+                    continue
+                cover = await self.rehost_poster_to_selected_host(meta, cover_input)
             new_data = {
                 "title": tinfo.get("title", meta["imdb_info"].get("title", meta["title"])),
                 "year": tinfo.get("year", meta["imdb_info"].get("year", meta["year"])),

--- a/src/trackers/PTP.py
+++ b/src/trackers/PTP.py
@@ -30,38 +30,71 @@ from src.uploadscreens import UploadScreensManager
 
 
 class PTP:
-
     def __init__(self, config: dict[str, Any]) -> None:
         self.config = config
         self.rehost_images_manager = RehostImagesManager(config)
         self.takescreens_manager = TakeScreensManager(config)
         self.uploadscreens_manager = UploadScreensManager(config)
-        self.tracker = 'PTP'
-        self.source_flag = 'PTP'
-        self.api_user = config['TRACKERS']['PTP'].get('ApiUser', '').strip()
-        self.api_key = config['TRACKERS']['PTP'].get('ApiKey', '').strip()
-        announce_url = config['TRACKERS']['PTP'].get('announce_url', '').strip()
-        if announce_url and announce_url.startswith('http://'):
+        self.tracker = "PTP"
+        self.source_flag = "PTP"
+        self.api_user = config["TRACKERS"]["PTP"].get("ApiUser", "").strip()
+        self.api_key = config["TRACKERS"]["PTP"].get("ApiKey", "").strip()
+        announce_url = config["TRACKERS"]["PTP"].get("announce_url", "").strip()
+        if announce_url and announce_url.startswith("http://"):
             console.print("[red]PTP announce URL is using plaintext HTTP.\n")
-            console.print("[red]PTP is turning off their plaintext HTTP tracker soon. You must update your announce URLS. See PTP/forums.php?page=1&action=viewthread&threadid=46663")
+            console.print(
+                "[red]PTP is turning off their plaintext HTTP tracker soon. You must update your announce URLS. See PTP/forums.php?page=1&action=viewthread&threadid=46663"
+            )
             console.print("[yellow]Modifying the url to use HTTPS. Update your config file to avoid this message in the future.")
-            self.announce_url = announce_url.replace('http://', 'https://').replace(':2710', '')
+            self.announce_url = announce_url.replace("http://", "https://").replace(":2710", "")
         else:
             self.announce_url = announce_url
-        self.username = config['TRACKERS']['PTP'].get('username', '').strip()
-        self.password = config['TRACKERS']['PTP'].get('password', '').strip()
-        self.web_source = self._is_true(config['TRACKERS']['PTP'].get('add_web_source_to_desc', True))
-        self.user_agent = f'Upload Assistant/2.3 ({platform.system()} {platform.release()})'
-        self.banned_groups = ['aXXo', 'BMDru', 'BRrip', 'CM8', 'CrEwSaDe', 'CTFOH', 'd3g', 'DNL', 'FaNGDiNG0', 'HD2DVD', 'HDT', 'HDTime', 'ION10', 'iPlanet',
-                              'KiNGDOM', 'mHD', 'mSD', 'nHD', 'nikt0', 'nSD', 'NhaNc3', 'OFT', 'PRODJi', 'SANTi', 'SPiRiT', 'STUTTERSHIT', 'ViSION', 'VXT',
-                              'WAF', 'x0r', 'YIFY', 'LAMA', 'WORLD']
-        self.approved_image_hosts = ['ptpimg', 'pixhost']
+        self.username = config["TRACKERS"]["PTP"].get("username", "").strip()
+        self.password = config["TRACKERS"]["PTP"].get("password", "").strip()
+        self.web_source = self._is_true(config["TRACKERS"]["PTP"].get("add_web_source_to_desc", True))
+        self.user_agent = f"Upload Assistant/2.3 ({platform.system()} {platform.release()})"
+        self.banned_groups = [
+            "aXXo",
+            "BMDru",
+            "BRrip",
+            "CM8",
+            "CrEwSaDe",
+            "CTFOH",
+            "d3g",
+            "DNL",
+            "FaNGDiNG0",
+            "HD2DVD",
+            "HDT",
+            "HDTime",
+            "ION10",
+            "iPlanet",
+            "KiNGDOM",
+            "mHD",
+            "mSD",
+            "nHD",
+            "nikt0",
+            "nSD",
+            "NhaNc3",
+            "OFT",
+            "PRODJi",
+            "SANTi",
+            "SPiRiT",
+            "STUTTERSHIT",
+            "ViSION",
+            "VXT",
+            "WAF",
+            "x0r",
+            "YIFY",
+            "LAMA",
+            "WORLD",
+        ]
+        self.approved_image_hosts = ["ptpimg", "pixhost"]
 
         self.sub_lang_map = {
             ("Arabic", "ara", "ar"): 22,
-            ("Brazilian Portuguese", "Brazilian", "Portuguese-BR", 'pt-br', 'pt-BR'): 49,
+            ("Brazilian Portuguese", "Brazilian", "Portuguese-BR", "pt-br", "pt-BR"): 49,
             ("Bulgarian", "bul", "bg"): 29,
-            ("Chinese", "chi", "zh", "Chinese (Simplified)", "Chinese (Traditional)", 'cmn-Hant', 'cmn-Hans', 'yue-Hant', 'yue-Hans'): 14,
+            ("Chinese", "chi", "zh", "Chinese (Simplified)", "Chinese (Traditional)", "cmn-Hant", "cmn-Hans", "yue-Hant", "yue-Hans"): 14,
             ("Croatian", "hrv", "hr", "scr"): 23,
             ("Czech", "cze", "cz", "cs"): 30,
             ("Danish", "dan", "da"): 10,
@@ -75,7 +108,7 @@ class PTP:
             ("German", "ger", "de"): 6,
             ("Greek", "gre", "el"): 26,
             ("Hebrew", "heb", "he"): 40,
-            ("Hindi" "hin", "hi"): 41,
+            ("Hindihin", "hi"): 41,
             ("Hungarian", "hun", "hu"): 24,
             ("Icelandic", "ice", "is"): 28,
             ("Indonesian", "ind", "id"): 47,
@@ -112,14 +145,14 @@ class PTP:
         _meta: dict[str, Any],
     ) -> tuple[Optional[int], Optional[Union[int, str]], Optional[str]]:
         headers = {
-            'ApiUser': self.api_user,
-            'ApiKey': self.api_key,
+            "ApiUser": self.api_user,
+            "ApiKey": self.api_key,
             "User-Agent": self.user_agent,
         }
-        url = 'https://passthepopcorn.me/torrents.php'
+        url = "https://passthepopcorn.me/torrents.php"
         search_value = search_term or _search_file_folder
         params = {
-            'searchstr': search_value,
+            "searchstr": search_value,
         }
 
         try:
@@ -129,31 +162,31 @@ class PTP:
 
             if response.status_code == 200:
                 data = response.json()
-                movies = cast(list[dict[str, Any]], data.get('Movies', []))
+                movies = cast(list[dict[str, Any]], data.get("Movies", []))
                 for movie in movies:
-                    imdb_value = movie.get('ImdbId')
-                    torrents = cast(list[dict[str, Any]], movie.get('Torrents', []) or [])
+                    imdb_value = movie.get("ImdbId")
+                    torrents = cast(list[dict[str, Any]], movie.get("Torrents", []) or [])
                     ptp_torrent_id: Optional[Union[int, str]] = None
                     ptp_torrent_hash: Optional[str] = None
 
-                    normalized_search = str(search_value or '').lower()
+                    normalized_search = str(search_value or "").lower()
                     if normalized_search:
                         for torrent in torrents:
-                            release_name = str(torrent.get('ReleaseName', '')).lower()
+                            release_name = str(torrent.get("ReleaseName", "")).lower()
                             if normalized_search in release_name:
-                                ptp_torrent_id = torrent.get('Id')
-                                ptp_torrent_hash = torrent.get('InfoHash')
+                                ptp_torrent_id = torrent.get("Id")
+                                ptp_torrent_hash = torrent.get("InfoHash")
                                 break
 
                     if ptp_torrent_id is None and torrents:
                         first = torrents[0]
-                        ptp_torrent_id = first.get('Id')
-                        ptp_torrent_hash = first.get('InfoHash')
+                        ptp_torrent_id = first.get("Id")
+                        ptp_torrent_hash = first.get("InfoHash")
 
                     if imdb_value:
                         return int(imdb_value or 0), ptp_torrent_id, ptp_torrent_hash
 
-                console.print(f'[yellow]Could not find any release matching [bold yellow]{search_value}[/bold yellow] on PTP')
+                console.print(f"[yellow]Could not find any release matching [bold yellow]{search_value}[/bold yellow] on PTP")
                 return None, None, None
 
             elif response.status_code in [400, 401, 403]:
@@ -165,30 +198,24 @@ class PTP:
             else:
                 return None, None, None
         except Exception as e:
-            console.print(f'[red]An error occurred: {str(e)}[/red]')
+            console.print(f"[red]An error occurred: {str(e)}[/red]")
             return None, None, None
 
     async def get_imdb_from_torrent_id(self, ptp_torrent_id: Union[int, str]) -> tuple[Optional[int], Optional[str]]:
-        params = {
-            'torrentid': ptp_torrent_id
-        }
-        headers = {
-            'ApiUser': self.api_user,
-            'ApiKey': self.api_key,
-            'User-Agent': self.user_agent
-        }
-        url = 'https://passthepopcorn.me/torrents.php'
+        params = {"torrentid": ptp_torrent_id}
+        headers = {"ApiUser": self.api_user, "ApiKey": self.api_key, "User-Agent": self.user_agent}
+        url = "https://passthepopcorn.me/torrents.php"
         async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
             response = await client.get(url, params=params, headers=headers)
         await asyncio.sleep(1)
         try:
             if response.status_code == 200:
                 response = response.json()
-                imdb_id = int(response.get('ImdbId', 0) or 0)
+                imdb_id = int(response.get("ImdbId", 0) or 0)
                 ptp_infohash = None
-                for torrent in response['Torrents']:
-                    if torrent.get('Id', 0) == str(ptp_torrent_id):
-                        ptp_infohash = torrent.get('InfoHash', None)
+                for torrent in response["Torrents"]:
+                    if torrent.get("Id", 0) == str(ptp_torrent_id):
+                        ptp_infohash = torrent.get("InfoHash", None)
                 return imdb_id, ptp_infohash
             elif int(response.status_code) in [400, 401, 403]:
                 console.print(response.text)
@@ -202,16 +229,9 @@ class PTP:
             return None, None
 
     async def get_ptp_description(self, ptp_torrent_id: Union[int, str], meta: dict[str, Any], is_disc: str) -> list[Any]:
-        params = {
-            'id': ptp_torrent_id,
-            'action': 'get_description'
-        }
-        headers = {
-            'ApiUser': self.api_user,
-            'ApiKey': self.api_key,
-            'User-Agent': self.user_agent
-        }
-        url = 'https://passthepopcorn.me/torrents.php'
+        params = {"id": ptp_torrent_id, "action": "get_description"}
+        headers = {"ApiUser": self.api_user, "ApiKey": self.api_key, "User-Agent": self.user_agent}
+        url = "https://passthepopcorn.me/torrents.php"
         console.print(f"[yellow]Requesting description from {url} with ID {ptp_torrent_id}")
         async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
             response = await client.get(url, params=params, headers=headers)
@@ -224,46 +244,42 @@ class PTP:
         bbcode = BBCODE()
         desc, imagelist = bbcode.clean_ptp_description(ptp_desc, is_disc)
 
-        if not meta.get('only_id'):
+        if not meta.get("only_id"):
             console.print("[bold green]Successfully grabbed description from PTP")
             console.print(f"Description after cleaning:\n{desc[:1000]}...", markup=False)  # Show first 1000 characters for brevity
 
-            if not meta.get('skipit') and not meta['unattended']:
+            if not meta.get("skipit") and not meta["unattended"]:
                 # Allow user to edit or discard the description
                 console.print("[cyan]Do you want to edit, discard or keep the description?[/cyan]")
                 edit_choice = cli_ui.ask_string("Enter 'e' to edit, 'd' to discard, or press Enter to keep it as is: ")
 
-                if (edit_choice or "").lower() == 'e':
+                if (edit_choice or "").lower() == "e":
                     edited_description = click.edit(desc)
                     if edited_description:
                         desc = edited_description.strip()
-                        meta['description'] = desc
-                        meta['saved_description'] = True
+                        meta["description"] = desc
+                        meta["saved_description"] = True
                     console.print(f"[green]Final description after editing:[/green] {desc}")
-                elif (edit_choice or "").lower() == 'd':
+                elif (edit_choice or "").lower() == "d":
                     desc = None
                     console.print("[yellow]Description discarded.[/yellow]")
                 else:
                     console.print("[green]Keeping the original description.[/green]")
-                    meta['description'] = desc
-                    meta['saved_description'] = True
+                    meta["description"] = desc
+                    meta["saved_description"] = True
             else:
-                meta['description'] = desc
-                meta['saved_description'] = True
-        imagelist = imagelist if meta.get('keep_images') else []
+                meta["description"] = desc
+                meta["saved_description"] = True
+        imagelist = imagelist if meta.get("keep_images") else []
 
         return imagelist
 
     async def get_group_by_imdb(self, imdb: Union[int, str]) -> Optional[str]:
         params = {
-            'imdb': imdb,
+            "imdb": imdb,
         }
-        headers = {
-            'ApiUser': self.api_user,
-            'ApiKey': self.api_key,
-            'User-Agent': self.user_agent
-        }
-        url = 'https://passthepopcorn.me/torrents.php'
+        headers = {"ApiUser": self.api_user, "ApiKey": self.api_key, "User-Agent": self.user_agent}
+        url = "https://passthepopcorn.me/torrents.php"
         async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
             response = await client.get(url=url, headers=headers, params=params)
         await asyncio.sleep(1)
@@ -283,29 +299,29 @@ class PTP:
                     console.print(f"[red]Response body (truncated): {response.text[:200]}[/red]")
                 return None
 
-            if response_data.get('TotalResults'):  # Search results page
-                total_results = int(response_data.get('TotalResults', 0))
+            if response_data.get("TotalResults"):  # Search results page
+                total_results = int(response_data.get("TotalResults", 0))
                 if total_results == 0:
                     console.print(f"[yellow]No results found for IMDb: tt{imdb}[/yellow]")
                     return None
                 elif total_results == 1:
                     # Single result - use it
-                    movie = response_data.get('Movies', [{}])[0]
-                    groupID: Optional[str] = str(movie.get('GroupId')) if movie.get('GroupId') is not None else None
-                    title = movie.get('Title', 'Unknown')
-                    year = movie.get('Year', 'Unknown')
+                    movie = response_data.get("Movies", [{}])[0]
+                    groupID: Optional[str] = str(movie.get("GroupId")) if movie.get("GroupId") is not None else None
+                    title = movie.get("Title", "Unknown")
+                    year = movie.get("Year", "Unknown")
                     console.print(f"[green]Found single match for IMDb: [yellow]tt{imdb}[/yellow] -> Group ID: [yellow]{groupID}[/yellow][/green]")
                     console.print(f"[green]Title: [yellow]{title}[/yellow] ([yellow]{year}[/yellow])")
                     return groupID
                 else:
                     # Multiple results - let user choose
                     console.print(f"[yellow]Found {total_results} matches for IMDb: tt{imdb}[/yellow]")
-                    movies = cast(list[dict[str, Any]], response_data.get('Movies', []))
+                    movies = cast(list[dict[str, Any]], response_data.get("Movies", []))
                     choices: list[str] = []
                     for _i, movie in enumerate(movies):
-                        title = movie.get('Title', 'Unknown')
-                        year = movie.get('Year', 'Unknown')
-                        group_id = movie.get('GroupId', 'Unknown')
+                        title = movie.get("Title", "Unknown")
+                        year = movie.get("Year", "Unknown")
+                        group_id = movie.get("GroupId", "Unknown")
                         choice_text = f"{title} ({year}) - Group ID: {group_id}"
                         choices.append(choice_text)
 
@@ -320,9 +336,9 @@ class PTP:
                         # Match selection directly to movie data to avoid index issues from cli_ui sorting
                         groupID = None
                         for movie in movies:
-                            title = movie.get('Title', 'Unknown')
-                            year = movie.get('Year', 'Unknown')
-                            group_id = movie.get('GroupId', 'Unknown')
+                            title = movie.get("Title", "Unknown")
+                            year = movie.get("Year", "Unknown")
+                            group_id = movie.get("GroupId", "Unknown")
                             if f"{title} ({year}) - Group ID: {group_id}" == selected:
                                 groupID = str(group_id)
                                 break
@@ -335,8 +351,8 @@ class PTP:
                         return None
             elif response_data.get("Page") == "Browse":  # No Releases on Site with ID
                 return None
-            elif response_data.get('Page') == "Details":  # Group Found
-                groupID = response_data.get('GroupId')
+            elif response_data.get("Page") == "Details":  # Group Found
+                groupID = response_data.get("GroupId")
                 console.print(f"[green]Matched IMDb: [yellow]tt{imdb}[/yellow] to Group ID: [yellow]{groupID}[/yellow][/green]")
                 console.print(f"[green]Title: [yellow]{response_data.get('Name')}[/yellow] ([yellow]{response_data.get('Year')}[/yellow])")
                 return str(groupID) if groupID is not None else None
@@ -348,16 +364,8 @@ class PTP:
         return None
 
     async def get_torrent_info(self, imdb: Union[int, str], meta: dict[str, Any]) -> dict[str, Any]:
-        params = {
-            'imdb': imdb,
-            'action': 'torrent_info',
-            'fast': 1
-        }
-        headers = {
-            'ApiUser': self.api_user,
-            'ApiKey': self.api_key,
-            'User-Agent': self.user_agent
-        }
+        params = {"imdb": imdb, "action": "torrent_info", "fast": 1}
+        headers = {"ApiUser": self.api_user, "ApiKey": self.api_key, "User-Agent": self.user_agent}
         url = "https://passthepopcorn.me/ajax.php"
         async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
             response = await client.get(url=url, params=params, headers=headers)
@@ -368,9 +376,9 @@ class PTP:
             # console.print(f"[blue]Raw info API Response: {response}[/blue]")
             # title, plot, art, year, tags, Countries, Languages
             tinfo = {key: value for key, value in response[0].items() if value not in (None, "")}
-            if tinfo['tags'] == "":
-                tags = await self.get_tags([meta.get("genres", ""), meta.get("keywords", ""), meta['imdb_info']['genres']])
-                tinfo['tags'] = ", ".join(tags)
+            if tinfo["tags"] == "":
+                tags = await self.get_tags([meta.get("genres", ""), meta.get("keywords", ""), meta["imdb_info"]["genres"]])
+                tinfo["tags"] = ", ".join(tags)
         except Exception:
             pass
         return tinfo
@@ -382,24 +390,52 @@ class PTP:
             "album_desc": meta.get("overview", ""),
         }
         tags = await self.get_tags([meta.get("genres", ""), meta.get("keywords", "")])
-        tinfo['tags'] = ", ".join(tags)
+        tinfo["tags"] = ", ".join(tags)
         return tinfo
 
     async def get_tags(self, check_against: Any) -> list[str]:
         tags: list[str] = []
         ptp_tags = [
-            "action", "adventure", "animation", "arthouse", "asian", "biography", "camp", "comedy",
-            "crime", "cult", "documentary", "drama", "experimental", "exploitation", "family", "fantasy", "film.noir",
-            "history", "horror", "martial.arts", "musical", "mystery", "performance", "philosophy", "politics", "romance",
-            "sci.fi", "short", "silent", "sport", "thriller", "video.art", "war", "western"
+            "action",
+            "adventure",
+            "animation",
+            "arthouse",
+            "asian",
+            "biography",
+            "camp",
+            "comedy",
+            "crime",
+            "cult",
+            "documentary",
+            "drama",
+            "experimental",
+            "exploitation",
+            "family",
+            "fantasy",
+            "film.noir",
+            "history",
+            "horror",
+            "martial.arts",
+            "musical",
+            "mystery",
+            "performance",
+            "philosophy",
+            "politics",
+            "romance",
+            "sci.fi",
+            "short",
+            "silent",
+            "sport",
+            "thriller",
+            "video.art",
+            "war",
+            "western",
         ]
 
         check_against_list = cast(list[Any], check_against) if isinstance(check_against, list) else [check_against]
-        normalized_check_against: list[str] = [
-            x.lower().replace(' ', '').replace('-', '') for x in check_against_list if isinstance(x, str)
-        ]
+        normalized_check_against: list[str] = [x.lower().replace(" ", "").replace("-", "") for x in check_against_list if isinstance(x, str)]
         for each in ptp_tags:
-            clean_tag = each.replace('.', '')
+            clean_tag = each.replace(".", "")
             if any(clean_tag in item for item in normalized_check_against):
                 tags.append(each)
 
@@ -408,23 +444,19 @@ class PTP:
     async def search_existing(self, groupID: Union[int, str], meta: dict[str, Any], _disctype: str) -> list[str]:
         # Map resolutions to SD / HD / UHD
         quality = None
-        if meta.get('sd', 0) == 1:  # 1 is SD
+        if meta.get("sd", 0) == 1:  # 1 is SD
             quality = "Standard Definition"
-        elif meta['resolution'] in ["1440p", "1080p", "1080i", "720p"]:
+        elif meta["resolution"] in ["1440p", "1080p", "1080i", "720p"]:
             quality = "High Definition"
-        elif meta['resolution'] in ["2160p", "4320p", "8640p"]:
+        elif meta["resolution"] in ["2160p", "4320p", "8640p"]:
             quality = "Ultra High Definition"
 
         # Prepare request parameters and headers
         params = {
-            'id': groupID,
+            "id": groupID,
         }
-        headers = {
-            'ApiUser': self.api_user,
-            'ApiKey': self.api_key,
-            'User-Agent': self.user_agent
-        }
-        url = 'https://passthepopcorn.me/torrents.php'
+        headers = {"ApiUser": self.api_user, "ApiKey": self.api_key, "User-Agent": self.user_agent}
+        url = "https://passthepopcorn.me/torrents.php"
 
         try:
             async with httpx.AsyncClient(timeout=10.0, follow_redirects=True) as client:
@@ -434,11 +466,11 @@ class PTP:
                     existing: list[str] = []
                     try:
                         data = response.json()
-                        torrents = cast(list[dict[str, Any]], data.get('Torrents', []))
+                        torrents = cast(list[dict[str, Any]], data.get("Torrents", []))
                         existing.extend(
                             f"[{torrent.get('Resolution')}] {torrent.get('ReleaseName', 'RELEASE NAME NOT FOUND')}"
                             for torrent in torrents
-                            if torrent.get('Quality') == quality and quality is not None
+                            if torrent.get("Quality") == quality and quality is not None
                         )
                     except ValueError:
                         console.print("[red]Failed to parse JSON response from API.")
@@ -456,20 +488,16 @@ class PTP:
         return []
 
     async def ptpimg_url_rehost(self, image_url: str) -> str:
-        payload = {
-            'format': 'json',
-            'api_key': self.config["DEFAULT"]["ptpimg_api"],
-            'link-upload': image_url
-        }
-        headers = {'referer': 'https://ptpimg.me/index.php'}
+        payload = {"format": "json", "api_key": self.config["DEFAULT"]["ptpimg_api"], "link-upload": image_url}
+        headers = {"referer": "https://ptpimg.me/index.php"}
         url = "https://ptpimg.me/upload.php"
 
         async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
             response = await client.post(url, headers=headers, data=payload)
         try:
             response = response.json()
-            ptpimg_code = response[0]['code']
-            ptpimg_ext = response[0]['ext']
+            ptpimg_code = response[0]["code"]
+            ptpimg_ext = response[0]["ext"]
             img_url = f"https://ptpimg.me/{ptpimg_code}.{ptpimg_ext}"
         except Exception:
             console.print("[red]PTPIMG image rehost failed")
@@ -478,49 +506,49 @@ class PTP:
         return img_url
 
     def _selected_poster_host(self, meta: dict[str, Any]) -> str:
-        default_config = cast(dict[str, Any], self.config.get('DEFAULT', {}))
-        return str(meta.get('imghost') or default_config.get('img_host_1') or '').strip()
+        default_config = cast(dict[str, Any], self.config.get("DEFAULT", {}))
+        return str(meta.get("imghost") or default_config.get("img_host_1") or "").strip()
 
     def _poster_already_on_selected_host(self, image_url: str, selected_host: str) -> bool:
         if not selected_host:
             return False
-        hostname = (urlparse(image_url).hostname or '').lower()
+        hostname = (urlparse(image_url).hostname or "").lower()
         host_aliases = {
-            'imgbb': ('ibb.co', 'imgbb.com'),
-            'imgbox': ('imgbox.com',),
-            'pixhost': ('pixhost.to',),
-            'lensdump': ('lensdump.com',),
-            'onlyimage': ('onlyimage.org',),
-            'ptpimg': ('ptpimg.me',),
-            'ptscreens': ('ptscreens.com',),
-            'passtheimage': ('passtheima.ge',),
-            'seedpool_cdn': ('cdn.seedpool.org',),
-            'utppm': ('utp.pm',),
+            "imgbb": ("ibb.co", "imgbb.com"),
+            "imgbox": ("imgbox.com",),
+            "pixhost": ("pixhost.to",),
+            "lensdump": ("lensdump.com",),
+            "onlyimage": ("onlyimage.org",),
+            "ptpimg": ("ptpimg.me",),
+            "ptscreens": ("ptscreens.com",),
+            "passtheimage": ("passtheima.ge",),
+            "seedpool_cdn": ("cdn.seedpool.org",),
+            "utppm": ("utp.pm",),
         }
         aliases = host_aliases.get(selected_host, (selected_host,))
         return any(hostname == alias or hostname.endswith(f".{alias}") for alias in aliases)
 
     def _poster_extension(self, image_url: str, content_type: str) -> str:
         url_extension = Path(urlparse(image_url).path).suffix.lower()
-        if url_extension in {'.jpg', '.jpeg', '.png', '.webp'}:
+        if url_extension in {".jpg", ".jpeg", ".png", ".webp"}:
             return url_extension
 
-        content_type = content_type.split(';', 1)[0].strip().lower()
+        content_type = content_type.split(";", 1)[0].strip().lower()
         content_type_extensions = {
-            'image/jpeg': '.jpg',
-            'image/png': '.png',
-            'image/webp': '.webp',
+            "image/jpeg": ".jpg",
+            "image/png": ".png",
+            "image/webp": ".webp",
         }
-        return content_type_extensions.get(content_type, '.jpg')
+        return content_type_extensions.get(content_type, ".jpg")
 
     async def rehost_poster_to_selected_host(self, meta: dict[str, Any], image_url: str) -> str:
         selected_host = self._selected_poster_host(meta)
-        if not selected_host or meta.get('skip_imghost_upload', False):
+        if not selected_host or meta.get("skip_imghost_upload", False):
             return image_url
         if self._poster_already_on_selected_host(image_url, selected_host):
             return image_url
 
-        tmp_dir = Path(meta['base_dir']) / "tmp" / meta['uuid']
+        tmp_dir = Path(meta["base_dir"]) / "tmp" / meta["uuid"]
         try:
             tmp_dir.mkdir(parents=True, exist_ok=True)
             async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
@@ -529,18 +557,18 @@ class PTP:
             poster_path = tmp_dir / f"PTP_POSTER{self._poster_extension(image_url, response.headers.get('content-type', ''))}"
             await asyncio.to_thread(poster_path.write_bytes, response.content)
 
-            original_imghost = meta.get('imghost')
-            meta['imghost'] = selected_host
+            original_imghost = meta.get("imghost")
+            meta["imghost"] = selected_host
             try:
                 uploaded_images, _ = await self.uploadscreens_manager.upload_screens(meta, 1, 1, 0, 1, [str(poster_path)], {})
             finally:
                 if original_imghost is None:
-                    meta.pop('imghost', None)
+                    meta.pop("imghost", None)
                 else:
-                    meta['imghost'] = original_imghost
+                    meta["imghost"] = original_imghost
 
             if uploaded_images:
-                uploaded_url = uploaded_images[0].get('raw_url') or uploaded_images[0].get('img_url')
+                uploaded_url = uploaded_images[0].get("raw_url") or uploaded_images[0].get("img_url")
                 if isinstance(uploaded_url, str) and uploaded_url:
                     return uploaded_url
         except Exception as e:
@@ -550,10 +578,10 @@ class PTP:
 
     def get_type(self, imdb_info: dict[str, Any], meta: dict[str, Any]) -> Optional[str]:
         ptpType = None
-        if imdb_info['type'] is not None:
-            imdbType = imdb_info.get('type', 'movie').lower()
-            if imdbType in ("movie", "tv movie", 'tvmovie'):
-                ptpType = "Feature Film" if int(imdb_info.get('runtime', '60')) >= 45 or int(imdb_info.get('runtime', '60')) == 0 else "Short Film"
+        if imdb_info["type"] is not None:
+            imdbType = imdb_info.get("type", "movie").lower()
+            if imdbType in ("movie", "tv movie", "tvmovie"):
+                ptpType = "Feature Film" if int(imdb_info.get("runtime", "60")) >= 45 or int(imdb_info.get("runtime", "60")) == 0 else "Short Film"
             if imdbType == "short":
                 ptpType = "Short Film"
             elif imdbType == "tv mini series":
@@ -566,7 +594,7 @@ class PTP:
             keywords = meta.get("keywords", "").lower()
             tmdb_type = meta.get("tmdb_type", "movie").lower()
             if tmdb_type == "movie":
-                ptpType = "Feature Film" if int(meta.get('runtime', 60)) >= 45 or int(meta.get('runtime', 60)) == 0 else "Short Film"
+                ptpType = "Feature Film" if int(meta.get("runtime", 60)) >= 45 or int(meta.get("runtime", 60)) == 0 else "Short Film"
             if tmdb_type == "miniseries" or "miniseries" in keywords:
                 ptpType = "Miniseries"
             if "short" in keywords or "short film" in keywords:
@@ -575,7 +603,7 @@ class PTP:
                 ptpType = "Stand-up Comedy"
             elif "concert" in keywords:
                 ptpType = "Live Performance"
-        if ptpType is None and meta.get('mode', 'discord') == 'cli':
+        if ptpType is None and meta.get("mode", "discord") == "cli":
             ptpTypeList = ["Feature Film", "Short Film", "Miniseries", "Stand-up Comedy", "Concert", "Movie Collection"]
             ptpType = cli_ui.ask_choice("Select the proper type", choices=ptpTypeList)
             if ptpType == "Concert":
@@ -584,19 +612,19 @@ class PTP:
 
     def get_codec(self, meta: dict[str, Any]) -> str:
         codec = ""
-        if meta['is_disc'] == "BDMV":
-            bdinfo = meta['bdinfo']
+        if meta["is_disc"] == "BDMV":
+            bdinfo = meta["bdinfo"]
             bd_sizes = [25, 50, 66, 100]
             for each in bd_sizes:
-                if bdinfo['size'] < each:
+                if bdinfo["size"] < each:
                     codec = f"BD{each}"
                     break
             if not codec:
                 codec = f"BD{bd_sizes[-1]}"
-        elif meta['is_disc'] == "DVD":
-            if "DVD5" in meta['dvd_size']:
+        elif meta["is_disc"] == "DVD":
+            if "DVD5" in meta["dvd_size"]:
                 codec = "DVD5"
-            elif "DVD9" in meta['dvd_size']:
+            elif "DVD9" in meta["dvd_size"]:
                 codec = "DVD9"
         else:
             codecmap = {
@@ -605,18 +633,18 @@ class PTP:
                 "HEVC": "H.265",
                 "H.265": "H.265",
             }
-            searchcodec_value = meta.get('video_codec', meta.get('video_encode'))
-            searchcodec = searchcodec_value if isinstance(searchcodec_value, str) else ''
+            searchcodec_value = meta.get("video_codec", meta.get("video_encode"))
+            searchcodec = searchcodec_value if isinstance(searchcodec_value, str) else ""
             codec = codecmap.get(searchcodec, searchcodec)
-            if meta.get('has_encode_settings') is True:
+            if meta.get("has_encode_settings") is True:
                 codec = codec.replace("H.", "x")
         return codec
 
     def get_resolution(self, meta: dict[str, Any]) -> tuple[str, Optional[str]]:
         other_res = None
-        res = meta.get('resolution', "OTHER")
-        if (res == "OTHER" and meta['is_disc'] != "BDMV") or (meta['sd'] == 1 and meta['type'] == "WEBDL") or (meta['sd'] == 1 and meta['type'] == "DVDRIP"):
-            video_mi = meta['mediainfo']['media']['track'][1]
+        res = meta.get("resolution", "OTHER")
+        if (res == "OTHER" and meta["is_disc"] != "BDMV") or (meta["sd"] == 1 and meta["type"] == "WEBDL") or (meta["sd"] == 1 and meta["type"] == "DVDRIP"):
+            video_mi = meta["mediainfo"]["media"]["track"][1]
             other_res = f"{video_mi['Width']}x{video_mi['Height']}"
             res = "Other"
         if meta["is_disc"] == "DVD":
@@ -627,29 +655,16 @@ class PTP:
         container = None
         if meta["is_disc"] == "BDMV":
             container = "m2ts"
-        elif meta['is_disc'] == "DVD":
+        elif meta["is_disc"] == "DVD":
             container = "VOB IFO"
         else:
-            ext = os.path.splitext(meta['filelist'][0])[1]
-            containermap = {
-                '.mkv': "MKV",
-                '.mp4': 'MP4'
-            }
-            container = containermap.get(ext, 'Other')
+            ext = os.path.splitext(meta["filelist"][0])[1]
+            containermap = {".mkv": "MKV", ".mp4": "MP4"}
+            container = containermap.get(ext, "Other")
         return container
 
     def get_source(self, source: str) -> str:
-        sources = {
-            "Blu-ray": "Blu-ray",
-            "BluRay": "Blu-ray",
-            "HD DVD": "HD-DVD",
-            "HDDVD": "HD-DVD",
-            "Web": "WEB",
-            "HDTV": "HDTV",
-            'UHDTV': 'HDTV',
-            "NTSC": "DVD",
-            "PAL": "DVD"
-        }
+        sources = {"Blu-ray": "Blu-ray", "BluRay": "Blu-ray", "HD DVD": "HD-DVD", "HDDVD": "HD-DVD", "Web": "WEB", "HDTV": "HDTV", "UHDTV": "HDTV", "NTSC": "DVD", "PAL": "DVD"}
         source_id = sources.get(source, "OtherR")
         return source_id
 
@@ -657,24 +672,24 @@ class PTP:
         sub_lang_map = self.sub_lang_map
 
         sub_langs: list[int] = []
-        if meta.get('is_disc', '') != 'BDMV':
-            mi = meta['mediainfo']
-            if meta.get('is_disc', '') == "DVD":
-                mi = json.loads(MediaInfo.parse(meta['discs'][0]['ifo'], output='JSON'))
-            for track in mi['media']['track']:
-                if track['@type'] == "Text":
-                    language = track.get('Language_String2', track.get('Language'))
+        if meta.get("is_disc", "") != "BDMV":
+            mi = meta["mediainfo"]
+            if meta.get("is_disc", "") == "DVD":
+                mi = json.loads(MediaInfo.parse(meta["discs"][0]["ifo"], output="JSON"))
+            for track in mi["media"]["track"]:
+                if track["@type"] == "Text":
+                    language = track.get("Language_String2", track.get("Language"))
                     if language == "en":
-                        if track.get('Forced', "") == "Yes":
+                        if track.get("Forced", "") == "Yes":
                             language = "en (Forced)"
-                        title = track.get('Title', "")
+                        title = track.get("Title", "")
                         if isinstance(title, str) and "intertitles" in title.lower():
                             language = "en (Intertitles)"
                     for lang, subID in sub_lang_map.items():
                         if language in lang and subID not in sub_langs:
                             sub_langs.append(subID)
         else:
-            for language in meta['bdinfo']['subtitles']:
+            for language in meta["bdinfo"]["subtitles"]:
                 for lang, subID in sub_lang_map.items():
                     if language in lang and subID not in sub_langs:
                         sub_langs.append(subID)
@@ -689,7 +704,7 @@ class PTP:
             "English Hardcoded Subs (Forced)": 50,
             "No English Subs": 14,
             "English Softsubs Exist (Mislabeled)": None,
-            "Hardcoded Subs (Non-English)": "OTHER"
+            "Hardcoded Subs (Non-English)": "OTHER",
         }
         opts = cli_ui.select_choices("Please select any/all applicable options:", choices=list(trumpable_values.keys()))
         trumpable_list: list[int] = []
@@ -727,64 +742,64 @@ class PTP:
         remaster_title: list[str] = []
         # Collections
         # Masters of Cinema, The Criterion Collection, Warner Archive Collection
-        if meta.get('distributor') in ('WARNER ARCHIVE', 'WARNER ARCHIVE COLLECTION', 'WAC'):
-            remaster_title.append('Warner Archive Collection')
-        elif meta.get('distributor') in ('CRITERION', 'CRITERION COLLECTION', 'CC'):
-            remaster_title.append('The Criterion Collection')
-        elif meta.get('distributor') in ('MASTERS OF CINEMA', 'MOC'):
-            remaster_title.append('Masters of Cinema')
+        if meta.get("distributor") in ("WARNER ARCHIVE", "WARNER ARCHIVE COLLECTION", "WAC"):
+            remaster_title.append("Warner Archive Collection")
+        elif meta.get("distributor") in ("CRITERION", "CRITERION COLLECTION", "CC"):
+            remaster_title.append("The Criterion Collection")
+        elif meta.get("distributor") in ("MASTERS OF CINEMA", "MOC"):
+            remaster_title.append("Masters of Cinema")
 
         # Editions
         # Director's Cut, Extended Edition, Rifftrax, Theatrical Cut, Uncut, Unrated
-        if "director's cut" in meta.get('edition', '').lower():
+        if "director's cut" in meta.get("edition", "").lower():
             remaster_title.append("Director's Cut")
-        elif "extended" in meta.get('edition', '').lower():
+        elif "extended" in meta.get("edition", "").lower():
             remaster_title.append("Extended Edition")
-        elif "theatrical" in meta.get('edition', '').lower() or "rifftrax" in meta.get('edition', '').lower():
+        elif "theatrical" in meta.get("edition", "").lower() or "rifftrax" in meta.get("edition", "").lower():
             remaster_title.append("Theatrical Cut")
-        elif "uncut" in meta.get('edition', '').lower():
+        elif "uncut" in meta.get("edition", "").lower():
             remaster_title.append("Uncut")
-        elif "unrated" in meta.get('edition', '').lower():
+        elif "unrated" in meta.get("edition", "").lower():
             remaster_title.append("Unrated")
         else:
-            if meta.get('edition') not in ('', None):
-                remaster_title.append(meta['edition'])
+            if meta.get("edition") not in ("", None):
+                remaster_title.append(meta["edition"])
 
         # Features
         # 2-Disc Set, 2in1, 2D/3D Edition, 3D Anaglyph, 3D Full SBS, 3D Half OU, 3D Half SBS,
         # 4K Restoration, 4K Remaster,
         # Extras, Remux,
-        if meta.get('type') == "REMUX":
+        if meta.get("type") == "REMUX":
             remaster_title.append("Remux")
 
         # DTS:X, Dolby Atmos, Dual Audio, English Dub, With Commentary,
-        if "DTS:X" in meta['audio']:
-            remaster_title.append('DTS:X')
-        if "Atmos" in meta['audio']:
-            remaster_title.append('Dolby Atmos')
-        if "Dual" in meta['audio']:
-            remaster_title.append('Dual Audio')
-        if "Dubbed" in meta['audio']:
-            remaster_title.append('English Dub')
+        if "DTS:X" in meta["audio"]:
+            remaster_title.append("DTS:X")
+        if "Atmos" in meta["audio"]:
+            remaster_title.append("Dolby Atmos")
+        if "Dual" in meta["audio"]:
+            remaster_title.append("Dual Audio")
+        if "Dubbed" in meta["audio"]:
+            remaster_title.append("English Dub")
 
         # HDR10, HDR10+, Dolby Vision, 10-bit,
         # if "Hi10P" in meta.get('video_encode', ''):
         #     remaster_title.append('10-bit')
-        if meta.get('hdr', '').strip() == '' and meta.get('bit_depth') == '10':
-            remaster_title.append('10-bit')
-        if "DV" in meta.get('hdr', ''):
-            remaster_title.append('Dolby Vision')
-        if "HDR" in meta.get('hdr', ''):
-            if "HDR10+" in meta['hdr']:
-                remaster_title.append('HDR10+')
+        if meta.get("hdr", "").strip() == "" and meta.get("bit_depth") == "10":
+            remaster_title.append("10-bit")
+        if "DV" in meta.get("hdr", ""):
+            remaster_title.append("Dolby Vision")
+        if "HDR" in meta.get("hdr", ""):
+            if "HDR10+" in meta["hdr"]:
+                remaster_title.append("HDR10+")
             else:
-                remaster_title.append('HDR10')
-        if "HLG" in meta.get('hdr', ''):
-            remaster_title.append('HLG')
+                remaster_title.append("HDR10")
+        if "HLG" in meta.get("hdr", ""):
+            remaster_title.append("HLG")
 
         # with commentary always last
-        if meta.get('has_commentary', False) is True:
-            remaster_title.append('With Commentary')
+        if meta.get("has_commentary", False) is True:
+            remaster_title.append("With Commentary")
 
         output = " / ".join(remaster_title) if remaster_title != [] else ""
         return output
@@ -825,7 +840,7 @@ class PTP:
     async def edit_desc(self, meta: dict[str, Any]) -> None:
         async with aiofiles.open(f"{meta['base_dir']}/tmp/{meta['uuid']}/DESCRIPTION.txt", encoding="utf-8") as base_file:
             base = await base_file.read()
-        if meta.get('scene_nfo_file'):
+        if meta.get("scene_nfo_file"):
             # Remove NFO from description
             meta_description = re.sub(
                 r"\[center\]\[spoiler=.*? NFO:\]\[code\](.*?)\[/code\]\[/spoiler\]\[/center\]",
@@ -834,90 +849,90 @@ class PTP:
                 flags=re.DOTALL,
             )
             base = meta_description
-        multi_screens = int(self.config['DEFAULT'].get('multiScreens', 2))
+        multi_screens = int(self.config["DEFAULT"].get("multiScreens", 2))
         if multi_screens < 2:
             multi_screens = 2
             console.print("[yellow]PTP requires at least 2 screenshots for multi disc/file content, overriding config")
 
-        image_list_value: Any = (meta['PTP_images_key'] if 'PTP_images_key' in meta else meta.get('image_list', [])) if not meta.get('skip_imghost_upload', False) else []
+        image_list_value: Any = (meta["PTP_images_key"] if "PTP_images_key" in meta else meta.get("image_list", [])) if not meta.get("skip_imghost_upload", False) else []
         image_list = cast(list[dict[str, Any]], image_list_value) if isinstance(image_list_value, list) else []
         images: list[dict[str, Any]] = image_list
 
         # Check for saved pack_image_links.json file
-        pack_images_file = os.path.join(meta['base_dir'], "tmp", meta['uuid'], "pack_image_links.json")
+        pack_images_file = os.path.join(meta["base_dir"], "tmp", meta["uuid"], "pack_image_links.json")
         pack_images_data: dict[str, Any] = {}
         if os.path.exists(pack_images_file):
             try:
-                async with aiofiles.open(pack_images_file, encoding='utf-8') as f:
+                async with aiofiles.open(pack_images_file, encoding="utf-8") as f:
                     content = await f.read()
                     pack_images_data = cast(dict[str, Any], json.loads(content)) if content.strip() else {}
 
                     # Filter out keys with non-approved image hosts
-                    keys = cast(dict[str, Any], pack_images_data.get('keys', {}))
+                    keys = cast(dict[str, Any], pack_images_data.get("keys", {}))
                     keys_to_remove: list[str] = []
                     for key_name, key_data in keys.items():
                         key_data_dict = cast(dict[str, Any], key_data)
                         images_to_keep: list[dict[str, Any]] = []
-                        for img in cast(list[dict[str, Any]], key_data_dict.get('images', [])):
-                            raw_url = str(img.get('raw_url', ''))
+                        for img in cast(list[dict[str, Any]], key_data_dict.get("images", [])):
+                            raw_url = str(img.get("raw_url", ""))
                             # Extract hostname from URL (e.g., ptpimg.me -> ptpimg)
                             try:
                                 parsed_url = urlparse(raw_url)
                                 hostname = parsed_url.netloc
                                 # Get the main domain name (first part before the dot)
-                                host_key = hostname.split('.')[0] if hostname else ''
+                                host_key = hostname.split(".")[0] if hostname else ""
 
                                 if host_key in self.approved_image_hosts:
                                     images_to_keep.append(img)
-                                elif meta['debug']:
+                                elif meta["debug"]:
                                     console.print(f"[yellow]Filtering out image from non-approved host: {hostname}[/yellow]")
                             except Exception:
                                 # If URL parsing fails, skip this image
-                                if meta['debug']:
+                                if meta["debug"]:
                                     console.print(f"[yellow]Could not parse URL: {raw_url}[/yellow]")
                                 continue
 
                         if images_to_keep:
                             # Update the key with only approved images
-                            pack_images_data['keys'][key_name]['images'] = images_to_keep
-                            pack_images_data['keys'][key_name]['count'] = len(images_to_keep)
+                            pack_images_data["keys"][key_name]["images"] = images_to_keep
+                            pack_images_data["keys"][key_name]["count"] = len(images_to_keep)
                         else:
                             # Mark key for removal if no approved images
                             keys_to_remove.append(key_name)
 
                     # Remove keys with no approved images
                     for key_name in keys_to_remove:
-                        del pack_images_data['keys'][key_name]
-                        if meta['debug']:
+                        del pack_images_data["keys"][key_name]
+                        if meta["debug"]:
                             console.print(f"[yellow]Removed key '{key_name}' - no approved image hosts[/yellow]")
 
                     # Recalculate total count
-                    keys = cast(dict[str, Any], pack_images_data.get('keys', {}))
-                    pack_images_data['total_count'] = sum(cast(dict[str, Any], key_data).get('count', 0) for key_data in keys.values())
+                    keys = cast(dict[str, Any], pack_images_data.get("keys", {}))
+                    pack_images_data["total_count"] = sum(cast(dict[str, Any], key_data).get("count", 0) for key_data in keys.values())
 
-                    if pack_images_data.get('total_count', 0) < 3:
+                    if pack_images_data.get("total_count", 0) < 3:
                         pack_images_data = {}  # Invalidate if less than 3 images total
-                        if meta['debug']:
+                        if meta["debug"]:
                             console.print("[yellow]Invalidating pack images - less than 3 approved images total[/yellow]")
                     else:
-                        if meta['debug']:
+                        if meta["debug"]:
                             console.print(f"[green]Loaded previously uploaded images from {pack_images_file}")
                             console.print(f"[blue]Found {pack_images_data.get('total_count', 0)} approved images across {len(pack_images_data.get('keys', {}))} keys[/blue]")
             except Exception as e:
                 console.print(f"[yellow]Warning: Could not load pack image data: {str(e)}[/yellow]")
 
         desc = io.StringIO()
-        discs = cast(list[dict[str, Any]], meta.get('discs', []))
-        filelist = cast(list[str], meta.get('filelist', []))
+        discs = cast(list[dict[str, Any]], meta.get("discs", []))
+        filelist = cast(list[str], meta.get("filelist", []))
 
         # Handle single disc case
         if len(discs) == 1:
             each = discs[0]
             new_screens: list[str] = []
             bdinfo_keys: list[str] = []
-            if each['type'] == "BDMV":
+            if each["type"] == "BDMV":
                 bdinfo_keys = [key for key in each if key.startswith("bdinfo")]
-                bdinfo = cast(dict[str, Any], meta.get('bdinfo', {}))
+                bdinfo = cast(dict[str, Any], meta.get("bdinfo", {}))
                 if len(bdinfo_keys) > 1:
                     edition = str(bdinfo.get("edition", "Unknown Edition"))
                     desc.write(f"[b]{edition}[/b]\n\n")
@@ -927,18 +942,18 @@ class PTP:
                     desc.write(base2ptp)
                     desc.write("\n\n")
                 try:
-                    if meta.get('tonemapped', False) and self.config['DEFAULT'].get('tonemapped_header', None):
-                        tonemapped_header = self.config['DEFAULT'].get('tonemapped_header')
+                    if meta.get("tonemapped", False) and self.config["DEFAULT"].get("tonemapped_header", None):
+                        tonemapped_header = self.config["DEFAULT"].get("tonemapped_header")
                         tonemapped_header = self.convert_bbcode(tonemapped_header)
                         desc.write(tonemapped_header)
                         desc.write("\n\n")
                 except Exception as e:
                     console.print(f"[yellow]Warning: Error setting tonemapped header: {str(e)}[/yellow]")
-                for img_index in range(len(images[:int(meta['screens'])])):
-                    raw_url = str(image_list[img_index].get('raw_url', ''))
+                for img_index in range(len(images[: int(meta["screens"])])):
+                    raw_url = str(image_list[img_index].get("raw_url", ""))
                     desc.write(f"[img]{raw_url}[/img]\n")
                 desc.write("\n")
-            elif each['type'] == "DVD":
+            elif each["type"] == "DVD":
                 desc.write(f"[b][size=3]{each['name']}:[/size][/b]\n")
                 desc.write(f"[mediainfo]{each['ifo_mi_full']}[/mediainfo]\n")
                 desc.write(f"[mediainfo]{each['vob_mi_full']}[/mediainfo]\n\n")
@@ -946,15 +961,15 @@ class PTP:
                 if base2ptp.strip() != "":
                     desc.write(base2ptp)
                     desc.write("\n\n")
-                for img_index in range(len(images[:int(meta['screens'])])):
-                    raw_url = image_list[img_index]['raw_url']
+                for img_index in range(len(images[: int(meta["screens"])])):
+                    raw_url = image_list[img_index]["raw_url"]
                     desc.write(f"[img]{raw_url}[/img]\n")
                 desc.write("\n")
             if len(bdinfo_keys) > 1:
-                meta['retry_count'] = meta.get('retry_count', 0)
+                meta["retry_count"] = meta.get("retry_count", 0)
 
                 for i, key in enumerate(bdinfo_keys[1:], start=1):  # Skip the first bdinfo
-                    new_images_key = f'new_images_playlist_{i}'
+                    new_images_key = f"new_images_playlist_{i}"
                     bdinfo = each[key]
                     edition = bdinfo.get("edition", "Unknown Edition")
 
@@ -963,70 +978,70 @@ class PTP:
                     summary = each.get(summary_key, "No summary available")
 
                     # Check for saved images first
-                    if pack_images_data and 'keys' in pack_images_data and new_images_key in pack_images_data['keys']:
-                        saved_images = cast(list[dict[str, Any]], pack_images_data['keys'][new_images_key]['images'])
+                    if pack_images_data and "keys" in pack_images_data and new_images_key in pack_images_data["keys"]:
+                        saved_images = cast(list[dict[str, Any]], pack_images_data["keys"][new_images_key]["images"])
                         if saved_images:
-                            if meta['debug']:
+                            if meta["debug"]:
                                 console.print(f"[yellow]Using saved images from pack_image_links.json for {new_images_key}")
 
                             meta[new_images_key] = []
                             for img in saved_images:
-                                meta[new_images_key].append({
-                                    'img_url': str(img.get('img_url', '')),
-                                    'raw_url': str(img.get('raw_url', '')),
-                                    'web_url': str(img.get('web_url', ''))
-                                })
+                                meta[new_images_key].append(
+                                    {"img_url": str(img.get("img_url", "")), "raw_url": str(img.get("raw_url", "")), "web_url": str(img.get("web_url", ""))}
+                                )
 
                     if new_images_key in meta and meta[new_images_key]:
                         desc.write(f"\n[b]{edition}[/b]\n\n")
                         # Use the summary corresponding to the current bdinfo
                         desc.write(f"[mediainfo]{summary}[/mediainfo]\n\n")
-                        if meta['debug']:
+                        if meta["debug"]:
                             console.print("[yellow]Using original uploaded images for first disc")
                         for img in meta[new_images_key]:
-                            raw_url = str(img.get('raw_url', ''))
+                            raw_url = str(img.get("raw_url", ""))
                             desc.write(f"[img]{raw_url}[/img]\n")
                     else:
                         desc.write(f"\n[b]{edition}[/b]\n")
                         # Use the summary corresponding to the current bdinfo
                         desc.write(f"[mediainfo]{summary}[/mediainfo]\n\n")
-                        meta['retry_count'] += 1
+                        meta["retry_count"] += 1
                         meta[new_images_key] = []
                         new_screens = [os.path.basename(f) for f in glob.glob(os.path.join(f"{meta['base_dir']}/tmp/{meta['uuid']}", f"PLAYLIST_{i}-*.png"))]
                         if not new_screens:
-                            use_vs = meta.get('vapoursynth', False)
+                            use_vs = meta.get("vapoursynth", False)
                             try:
-                                await self.takescreens_manager.disc_screenshots(meta, f"PLAYLIST_{i}", bdinfo, meta['uuid'], meta['base_dir'], use_vs, [], meta.get('ffdebug', False), multi_screens, True)
+                                await self.takescreens_manager.disc_screenshots(
+                                    meta, f"PLAYLIST_{i}", bdinfo, meta["uuid"], meta["base_dir"], use_vs, [], meta.get("ffdebug", False), multi_screens, True
+                                )
                             except Exception as e:
                                 console.print(f"Error during BDMV screenshot capture: {e}", markup=False)
                             new_screens = [os.path.basename(f) for f in glob.glob(os.path.join(f"{meta['base_dir']}/tmp/{meta['uuid']}", f"PLAYLIST_{i}-*.png"))]
                         uploaded_images: list[dict[str, Any]] = []
-                        if new_screens and not meta.get('skip_imghost_upload', False):
-                            uploaded_images, _ = await self.uploadscreens_manager.upload_screens(meta, multi_screens, 1, 0, multi_screens, new_screens, {new_images_key: meta[new_images_key]}, allowed_hosts=self.approved_image_hosts)
-                            if uploaded_images and not meta.get('skip_imghost_upload', False):
+                        if new_screens and not meta.get("skip_imghost_upload", False):
+                            uploaded_images, _ = await self.uploadscreens_manager.upload_screens(
+                                meta, multi_screens, 1, 0, multi_screens, new_screens, {new_images_key: meta[new_images_key]}, allowed_hosts=self.approved_image_hosts
+                            )
+                            if uploaded_images and not meta.get("skip_imghost_upload", False):
                                 await self.save_image_links(meta, new_images_key, uploaded_images)
                             for img in uploaded_images:
-                                meta[new_images_key].append({
-                                    'img_url': str(img.get('img_url', '')),
-                                    'raw_url': str(img.get('raw_url', '')),
-                                    'web_url': str(img.get('web_url', ''))
-                                })
+                                meta[new_images_key].append(
+                                    {"img_url": str(img.get("img_url", "")), "raw_url": str(img.get("raw_url", "")), "web_url": str(img.get("web_url", ""))}
+                                )
 
                             for img in uploaded_images:
-                                raw_url = str(img.get('raw_url', ''))
+                                raw_url = str(img.get("raw_url", ""))
                                 desc.write(f"[img]{raw_url}[/img]\n")
 
                         meta_filename = f"{meta['base_dir']}/tmp/{meta['uuid']}/meta.json"
-                        async with aiofiles.open(meta_filename, 'w', encoding='utf-8') as f:
+                        async with aiofiles.open(meta_filename, "w", encoding="utf-8") as f:
                             await f.write(json.dumps(meta, indent=4))
 
         # Handle multiple discs case
         elif len(discs) > 1:
-            if 'retry_count' not in meta:
-                meta['retry_count'] = 0
+            if "retry_count" not in meta:
+                meta["retry_count"] = 0
             for i, each in enumerate(discs):
-                new_images_key = f'new_images_disc_{i}'
-                if each['type'] == "BDMV":
+                new_images_key = f"new_images_disc_{i}"
+                if each["type"] == "BDMV":
                     if i == 0:
                         desc.write(f"[mediainfo]{each['summary']}[/mediainfo]\n\n")
                         base2ptp = self.convert_bbcode(base)
@@ -1034,15 +1049,15 @@ class PTP:
                             desc.write(base2ptp)
                             desc.write("\n\n")
                         try:
-                            if meta.get('tonemapped', False) and self.config['DEFAULT'].get('tonemapped_header', None):
-                                tonemapped_header = self.config['DEFAULT'].get('tonemapped_header')
+                            if meta.get("tonemapped", False) and self.config["DEFAULT"].get("tonemapped_header", None):
+                                tonemapped_header = self.config["DEFAULT"].get("tonemapped_header")
                                 tonemapped_header = self.convert_bbcode(tonemapped_header)
                                 desc.write(tonemapped_header)
                                 desc.write("\n\n")
                         except Exception as e:
                             console.print(f"[yellow]Warning: Error setting tonemapped header: {str(e)}[/yellow]")
                         for img_index in range(min(multi_screens, len(image_list))):
-                            raw_url = str(image_list[img_index].get('raw_url', ''))
+                            raw_url = str(image_list[img_index].get("raw_url", ""))
                             desc.write(f"[img]{raw_url}[/img]\n")
                         desc.write("\n")
                     else:
@@ -1052,54 +1067,63 @@ class PTP:
                             desc.write(base2ptp)
                             desc.write("\n\n")
                         # Check for saved images first
-                        if pack_images_data and 'keys' in pack_images_data and new_images_key in pack_images_data['keys']:
-                            saved_images = cast(list[dict[str, Any]], pack_images_data['keys'][new_images_key]['images'])
+                        if pack_images_data and "keys" in pack_images_data and new_images_key in pack_images_data["keys"]:
+                            saved_images = cast(list[dict[str, Any]], pack_images_data["keys"][new_images_key]["images"])
                             if saved_images:
-                                if meta['debug']:
+                                if meta["debug"]:
                                     console.print(f"[yellow]Using saved images from pack_image_links.json for {new_images_key}")
 
                                 meta[new_images_key] = []
                                 for img in saved_images:
-                                    meta[new_images_key].append({
-                                        'img_url': str(img.get('img_url', '')),
-                                        'raw_url': str(img.get('raw_url', '')),
-                                        'web_url': str(img.get('web_url', ''))
-                                    })
+                                    meta[new_images_key].append(
+                                        {"img_url": str(img.get("img_url", "")), "raw_url": str(img.get("raw_url", "")), "web_url": str(img.get("web_url", ""))}
+                                    )
                         if new_images_key in meta and meta[new_images_key]:
                             for img in meta[new_images_key]:
-                                raw_url = str(img.get('raw_url', ''))
+                                raw_url = str(img.get("raw_url", ""))
                                 desc.write(f"[img]{raw_url}[/img]\n")
                             desc.write("\n")
                         else:
-                            meta['retry_count'] += 1
+                            meta["retry_count"] += 1
                             meta[new_images_key] = []
                             new_screens = [os.path.basename(f) for f in glob.glob(os.path.join(f"{meta['base_dir']}/tmp/{meta['uuid']}", f"FILE_{i}-*.png"))]
                             if not new_screens:
                                 try:
-                                    await self.takescreens_manager.disc_screenshots(meta, f"FILE_{i}", each['bdinfo'], meta['uuid'], meta['base_dir'], meta.get('vapoursynth', False), [], meta.get('ffdebug', False), multi_screens, True)
+                                    await self.takescreens_manager.disc_screenshots(
+                                        meta,
+                                        f"FILE_{i}",
+                                        each["bdinfo"],
+                                        meta["uuid"],
+                                        meta["base_dir"],
+                                        meta.get("vapoursynth", False),
+                                        [],
+                                        meta.get("ffdebug", False),
+                                        multi_screens,
+                                        True,
+                                    )
                                 except Exception as e:
                                     console.print(f"Error during BDMV screenshot capture: {e}", markup=False)
                             new_screens = [os.path.basename(f) for f in glob.glob(os.path.join(f"{meta['base_dir']}/tmp/{meta['uuid']}", f"FILE_{i}-*.png"))]
                             uploaded_images: list[dict[str, Any]] = []
-                            if new_screens and not meta.get('skip_imghost_upload', False):
-                                uploaded_images, _ = await self.uploadscreens_manager.upload_screens(meta, multi_screens, 1, 0, multi_screens, new_screens, {new_images_key: meta[new_images_key]}, allowed_hosts=self.approved_image_hosts)
-                            if uploaded_images and not meta.get('skip_imghost_upload', False):
+                            if new_screens and not meta.get("skip_imghost_upload", False):
+                                uploaded_images, _ = await self.uploadscreens_manager.upload_screens(
+                                    meta, multi_screens, 1, 0, multi_screens, new_screens, {new_images_key: meta[new_images_key]}, allowed_hosts=self.approved_image_hosts
+                                )
+                            if uploaded_images and not meta.get("skip_imghost_upload", False):
                                 await self.save_image_links(meta, new_images_key, uploaded_images)
                                 for img in uploaded_images:
-                                    meta[new_images_key].append({
-                                        'img_url': str(img.get('img_url', '')),
-                                        'raw_url': str(img.get('raw_url', '')),
-                                        'web_url': str(img.get('web_url', ''))
-                                    })
-                                    raw_url = str(img.get('raw_url', ''))
+                                    meta[new_images_key].append(
+                                        {"img_url": str(img.get("img_url", "")), "raw_url": str(img.get("raw_url", "")), "web_url": str(img.get("web_url", ""))}
+                                    )
+                                    raw_url = str(img.get("raw_url", ""))
                                     desc.write(f"[img]{raw_url}[/img]\n")
                                 desc.write("\n")
 
                             meta_filename = f"{meta['base_dir']}/tmp/{meta['uuid']}/meta.json"
-                            async with aiofiles.open(meta_filename, 'w', encoding='utf-8') as f:
+                            async with aiofiles.open(meta_filename, "w", encoding="utf-8") as f:
                                 await f.write(json.dumps(meta, indent=4))
 
-                elif each['type'] == "DVD":
+                elif each["type"] == "DVD":
                     if i == 0:
                         desc.write(f"[b][size=3]{each['name']}:[/size][/b]\n")
                         desc.write(f"[mediainfo]{each['ifo_mi_full']}[/mediainfo]\n")
@@ -1109,7 +1133,7 @@ class PTP:
                             desc.write(base2ptp)
                             desc.write("\n\n")
                         for img_index in range(min(multi_screens, len(image_list))):
-                            raw_url = image_list[img_index]['raw_url']
+                            raw_url = image_list[img_index]["raw_url"]
                             desc.write(f"[img]{raw_url}[/img]\n")
                         desc.write("\n")
                     else:
@@ -1121,26 +1145,22 @@ class PTP:
                             desc.write(base2ptp)
                             desc.write("\n\n")
                         # Check for saved images first
-                        if pack_images_data and 'keys' in pack_images_data and new_images_key in pack_images_data['keys']:
-                            saved_images = pack_images_data['keys'][new_images_key]['images']
+                        if pack_images_data and "keys" in pack_images_data and new_images_key in pack_images_data["keys"]:
+                            saved_images = pack_images_data["keys"][new_images_key]["images"]
                             if saved_images:
-                                if meta['debug']:
+                                if meta["debug"]:
                                     console.print(f"[yellow]Using saved images from pack_image_links.json for {new_images_key}")
 
                                 meta[new_images_key] = []
                                 for img in saved_images:
-                                    meta[new_images_key].append({
-                                        'img_url': img.get('img_url', ''),
-                                        'raw_url': img.get('raw_url', ''),
-                                        'web_url': img.get('web_url', '')
-                                    })
+                                    meta[new_images_key].append({"img_url": img.get("img_url", ""), "raw_url": img.get("raw_url", ""), "web_url": img.get("web_url", "")})
                         if new_images_key in meta and meta[new_images_key]:
                             for img in meta[new_images_key]:
-                                raw_url = img['raw_url']
+                                raw_url = img["raw_url"]
                                 desc.write(f"[img]{raw_url}[/img]\n")
                             desc.write("\n")
                         else:
-                            meta['retry_count'] += 1
+                            meta["retry_count"] += 1
                             meta[new_images_key] = []
                             new_screens = [os.path.basename(f) for f in glob.glob(os.path.join(f"{meta['base_dir']}/tmp/{meta['uuid']}", f"{meta['discs'][i]['name']}-*.png"))]
                             if not new_screens:
@@ -1150,52 +1170,50 @@ class PTP:
                                     console.print(f"Error during DVD screenshot capture: {e}", markup=False)
                             new_screens = [os.path.basename(f) for f in glob.glob(os.path.join(f"{meta['base_dir']}/tmp/{meta['uuid']}", f"{meta['discs'][i]['name']}-*.png"))]
                             uploaded_images: list[dict[str, Any]] = []
-                            if new_screens and not meta.get('skip_imghost_upload', False):
-                                uploaded_images, _ = await self.uploadscreens_manager.upload_screens(meta, multi_screens, 1, 0, multi_screens, new_screens, {new_images_key: meta[new_images_key]}, allowed_hosts=self.approved_image_hosts)
-                            if uploaded_images and not meta.get('skip_imghost_upload', False):
+                            if new_screens and not meta.get("skip_imghost_upload", False):
+                                uploaded_images, _ = await self.uploadscreens_manager.upload_screens(
+                                    meta, multi_screens, 1, 0, multi_screens, new_screens, {new_images_key: meta[new_images_key]}, allowed_hosts=self.approved_image_hosts
+                                )
+                            if uploaded_images and not meta.get("skip_imghost_upload", False):
                                 await self.save_image_links(meta, new_images_key, uploaded_images)
                                 for img in uploaded_images:
-                                    meta[new_images_key].append({
-                                        'img_url': img['img_url'],
-                                        'raw_url': img['raw_url'],
-                                        'web_url': img['web_url']
-                                    })
-                                    raw_url = img['raw_url']
+                                    meta[new_images_key].append({"img_url": img["img_url"], "raw_url": img["raw_url"], "web_url": img["web_url"]})
+                                    raw_url = img["raw_url"]
                                     desc.write(f"[img]{raw_url}[/img]\n")
                                 desc.write("\n")
 
                         meta_filename = f"{meta['base_dir']}/tmp/{meta['uuid']}/meta.json"
-                        async with aiofiles.open(meta_filename, 'w', encoding='utf-8') as f:
+                        async with aiofiles.open(meta_filename, "w", encoding="utf-8") as f:
                             await f.write(json.dumps(meta, indent=4))
 
         # Handle single file case
         elif len(filelist) == 1:
-            if meta['type'] == 'WEBDL' and meta.get('service_longname', '') != '' and meta.get('description') is None and self.web_source is True:
+            if meta["type"] == "WEBDL" and meta.get("service_longname", "") != "" and meta.get("description") is None and self.web_source is True:
                 desc.write(f"[quote][align=center]This release is sourced from {meta['service_longname']}[/align][/quote]")
-            async with aiofiles.open(f"{meta['base_dir']}/tmp/{meta['uuid']}/MEDIAINFO.txt", encoding='utf-8') as mi_file:
+            async with aiofiles.open(f"{meta['base_dir']}/tmp/{meta['uuid']}/MEDIAINFO.txt", encoding="utf-8") as mi_file:
                 mi_dump = await mi_file.read()
             desc.write(f"[mediainfo]{mi_dump}[/mediainfo]\n")
             base2ptp = self.convert_bbcode(base)
             if base2ptp.strip() != "":
                 desc.write(base2ptp)
                 desc.write("\n\n")
-            if meta.get('comparison') and 'comparison_groups' in meta and meta['comparison_groups']:
+            if meta.get("comparison") and "comparison_groups" in meta and meta["comparison_groups"]:
                 desc.write("\n")
 
-                comparison_groups = meta['comparison_groups']
+                comparison_groups = meta["comparison_groups"]
                 group_keys = sorted(comparison_groups.keys(), key=lambda x: int(x))
-                comparison_names = [comparison_groups[key].get('name', f'Group {key}') for key in group_keys]
-                comparison_header = ', '.join(comparison_names)
+                comparison_names = [comparison_groups[key].get("name", f"Group {key}") for key in group_keys]
+                comparison_header = ", ".join(comparison_names)
                 desc.write(f"[comparison={comparison_header}]\n")
 
-                num_images = min([len(comparison_groups[key]['urls']) for key in group_keys])
+                num_images = min([len(comparison_groups[key]["urls"]) for key in group_keys])
 
                 for img_index in range(num_images):
                     for key in group_keys:
                         group = comparison_groups[key]
-                        if img_index < len(group['urls']):
-                            img_data = group['urls'][img_index]
-                            raw_url = img_data.get('raw_url', '')
+                        if img_index < len(group["urls"]):
+                            img_data = group["urls"][img_index]
+                            raw_url = img_data.get("raw_url", "")
                             if raw_url:
                                 desc.write(f"[img]{raw_url}[/img] ")
                     desc.write("\n")
@@ -1203,16 +1221,16 @@ class PTP:
                 desc.write("[/comparison]\n\n")
 
             try:
-                if meta.get('tonemapped', False) and self.config['DEFAULT'].get('tonemapped_header', None):
-                    tonemapped_header = self.config['DEFAULT'].get('tonemapped_header')
+                if meta.get("tonemapped", False) and self.config["DEFAULT"].get("tonemapped_header", None):
+                    tonemapped_header = self.config["DEFAULT"].get("tonemapped_header")
                     tonemapped_header = self.convert_bbcode(tonemapped_header)
                     desc.write(tonemapped_header)
                     desc.write("\n\n")
             except Exception as e:
                 console.print(f"[yellow]Warning: Error setting tonemapped header: {str(e)}[/yellow]")
 
-            for img_index in range(len(images[:int(meta['screens'])])):
-                raw_url = image_list[img_index]['raw_url']
+            for img_index in range(len(images[: int(meta["screens"])])):
+                raw_url = image_list[img_index]["raw_url"]
                 desc.write(f"[img]{raw_url}[/img]\n")
             desc.write("\n")
 
@@ -1220,25 +1238,25 @@ class PTP:
         elif len(filelist) > 1:
             for i, file in enumerate(filelist):
                 if i == 0:
-                    if meta['type'] == 'WEBDL' and meta.get('service_longname', '') != '' and meta.get('description') is None and self.web_source is True:
+                    if meta["type"] == "WEBDL" and meta.get("service_longname", "") != "" and meta.get("description") is None and self.web_source is True:
                         desc.write(f"[quote][align=center]This release is sourced from {meta['service_longname']}[/align][/quote]")
                     base2ptp = self.convert_bbcode(base)
                     if base2ptp.strip() != "":
                         desc.write(base2ptp)
                         desc.write("\n\n")
-                    async with aiofiles.open(f"{meta['base_dir']}/tmp/{meta['uuid']}/MEDIAINFO.txt", encoding='utf-8') as mi_file:
+                    async with aiofiles.open(f"{meta['base_dir']}/tmp/{meta['uuid']}/MEDIAINFO.txt", encoding="utf-8") as mi_file:
                         mi_dump = await mi_file.read()
                     desc.write(f"[mediainfo]{mi_dump}[/mediainfo]\n")
                     try:
-                        if meta.get('tonemapped', False) and self.config['DEFAULT'].get('tonemapped_header', None):
-                            tonemapped_header = self.config['DEFAULT'].get('tonemapped_header')
+                        if meta.get("tonemapped", False) and self.config["DEFAULT"].get("tonemapped_header", None):
+                            tonemapped_header = self.config["DEFAULT"].get("tonemapped_header")
                             tonemapped_header = self.convert_bbcode(tonemapped_header)
                             desc.write(tonemapped_header)
                             desc.write("\n\n")
                     except Exception as e:
                         console.print(f"[yellow]Warning: Error setting tonemapped header: {str(e)}[/yellow]")
                     for img_index in range(min(multi_screens, len(image_list))):
-                        raw_url = image_list[img_index]['raw_url']
+                        raw_url = image_list[img_index]["raw_url"]
                         desc.write(f"[img]{raw_url}[/img]\n")
                     desc.write("\n")
                 else:
@@ -1249,58 +1267,51 @@ class PTP:
                     async with aiofiles.open(temp_mi_path, encoding="utf-8") as mi_file:
                         mi_dump = await mi_file.read()
                     desc.write(f"[mediainfo]{mi_dump}[/mediainfo]\n")
-                    new_images_key = f'new_images_file_{i}'
+                    new_images_key = f"new_images_file_{i}"
                     # Check for saved images first
-                    if pack_images_data and 'keys' in pack_images_data and new_images_key in pack_images_data['keys']:
-                        saved_images = pack_images_data['keys'][new_images_key]['images']
+                    if pack_images_data and "keys" in pack_images_data and new_images_key in pack_images_data["keys"]:
+                        saved_images = pack_images_data["keys"][new_images_key]["images"]
                         if saved_images:
-                            if meta['debug']:
+                            if meta["debug"]:
                                 console.print(f"[yellow]Using saved images from pack_image_links.json for {new_images_key}")
 
                             meta[new_images_key] = []
                             for img in saved_images:
-                                meta[new_images_key].append({
-                                    'img_url': img.get('img_url', ''),
-                                    'raw_url': img.get('raw_url', ''),
-                                    'web_url': img.get('web_url', '')
-                                })
+                                meta[new_images_key].append({"img_url": img.get("img_url", ""), "raw_url": img.get("raw_url", ""), "web_url": img.get("web_url", "")})
                     if new_images_key in meta and meta[new_images_key]:
                         for img in meta[new_images_key]:
-                            raw_url = img['raw_url']
+                            raw_url = img["raw_url"]
                             desc.write(f"[img]{raw_url}[/img]\n")
                         desc.write("\n")
                     else:
-                        meta['retry_count'] = meta.get('retry_count', 0) + 1
+                        meta["retry_count"] = meta.get("retry_count", 0) + 1
                         meta[new_images_key] = []
                         new_screens = [os.path.basename(f) for f in glob.glob(os.path.join(f"{meta['base_dir']}/tmp/{meta['uuid']}", f"FILE_{i}-*.png"))]
                         if not new_screens:
                             try:
-                                await self.takescreens_manager.screenshots(
-                                    file, f"FILE_{i}", meta['uuid'], meta['base_dir'], meta, multi_screens, True, "")
+                                await self.takescreens_manager.screenshots(file, f"FILE_{i}", meta["uuid"], meta["base_dir"], meta, multi_screens, True, "")
                             except Exception as e:
                                 console.print(f"Error during generic screenshot capture: {e}", markup=False)
                         new_screens = [os.path.basename(f) for f in glob.glob(os.path.join(f"{meta['base_dir']}/tmp/{meta['uuid']}", f"FILE_{i}-*.png"))]
-                        if new_screens and not meta.get('skip_imghost_upload', False):
-                            uploaded_images, _ = await self.uploadscreens_manager.upload_screens(meta, multi_screens, 1, 0, multi_screens, new_screens, {new_images_key: meta[new_images_key]}, allowed_hosts=self.approved_image_hosts)
-                            if uploaded_images and not meta.get('skip_imghost_upload', False):
+                        if new_screens and not meta.get("skip_imghost_upload", False):
+                            uploaded_images, _ = await self.uploadscreens_manager.upload_screens(
+                                meta, multi_screens, 1, 0, multi_screens, new_screens, {new_images_key: meta[new_images_key]}, allowed_hosts=self.approved_image_hosts
+                            )
+                            if uploaded_images and not meta.get("skip_imghost_upload", False):
                                 await self.save_image_links(meta, new_images_key, uploaded_images)
                             for img in uploaded_images:
-                                meta[new_images_key].append({
-                                    'img_url': img['img_url'],
-                                    'raw_url': img['raw_url'],
-                                    'web_url': img['web_url']
-                                })
-                                raw_url = img['raw_url']
+                                meta[new_images_key].append({"img_url": img["img_url"], "raw_url": img["raw_url"], "web_url": img["web_url"]})
+                                raw_url = img["raw_url"]
                                 desc.write(f"[img]{raw_url}[/img]\n")
                             desc.write("\n")
 
                     meta_filename = f"{meta['base_dir']}/tmp/{meta['uuid']}/meta.json"
-                    async with aiofiles.open(meta_filename, 'w', encoding='utf-8') as f:
+                    async with aiofiles.open(meta_filename, "w", encoding="utf-8") as f:
                         await f.write(json.dumps(meta, indent=4))
 
         async with aiofiles.open(
             f"{meta['base_dir']}/tmp/{meta['uuid']}/[{self.tracker}]DESCRIPTION.txt",
-            'w',
+            "w",
             encoding="utf-8",
         ) as desc_file:
             await desc_file.write(desc.getvalue())
@@ -1315,7 +1326,7 @@ class PTP:
             console.print("[yellow]No image links to save.[/yellow]")
             return None
 
-        output_dir = os.path.join(meta['base_dir'], "tmp", meta['uuid'])
+        output_dir = os.path.join(meta["base_dir"], "tmp", meta["uuid"])
         os.makedirs(output_dir, exist_ok=True)
         output_file = os.path.join(output_dir, "pack_image_links.json")
 
@@ -1323,7 +1334,7 @@ class PTP:
         existing_data: dict[str, Any] = {}
         if os.path.exists(output_file):
             try:
-                async with aiofiles.open(output_file, encoding='utf-8') as f:
+                async with aiofiles.open(output_file, encoding="utf-8") as f:
                     content = await f.read()
                     existing_data = cast(dict[str, Any], json.loads(content)) if content.strip() else {}
             except Exception as e:
@@ -1331,18 +1342,12 @@ class PTP:
 
         # Create data structure if it doesn't exist yet
         if not existing_data:
-            existing_data = {
-                "keys": {},
-                "total_count": 0
-            }
+            existing_data = {"keys": {}, "total_count": 0}
 
         # Update the data with the new images under the specific key
         keys = cast(dict[str, Any], existing_data.get("keys", {}))
         if image_key not in keys:
-            keys[image_key] = {
-                "count": 0,
-                "images": []
-            }
+            keys[image_key] = {"count": 0, "images": []}
             existing_data["keys"] = keys
 
         # Add new images to the specific key
@@ -1361,10 +1366,10 @@ class PTP:
         existing_data["total_count"] = sum(cast(dict[str, Any], key_data).get("count", 0) for key_data in keys.values())
 
         try:
-            async with aiofiles.open(output_file, 'w', encoding='utf-8') as f:
+            async with aiofiles.open(output_file, "w", encoding="utf-8") as f:
                 await f.write(json.dumps(existing_data, indent=2))
 
-            if meta['debug']:
+            if meta["debug"]:
                 console.print(f"[green]Saved {len(image_list)} new images for key '{image_key}' (total: {existing_data['total_count']}):[/green]")
                 console.print(f"[blue]  - JSON: {output_file}[/blue]")
 
@@ -1382,7 +1387,7 @@ class PTP:
         cookies: dict[str, str] = {}
         if os.path.exists(cookiefile):
             raw_cookies = self.cookie_validator._load_cookies_dict_secure(cookiefile)  # pyright: ignore[reportPrivateUsage]
-            cookies = {name: str(data.get('value', '')) for name, data in raw_cookies.items()}
+            cookies = {name: str(data.get("value", "")) for name, data in raw_cookies.items()}
             async with httpx.AsyncClient(cookies=cookies, timeout=30.0, follow_redirects=True) as client:
                 uploadresponse = await client.get("https://passthepopcorn.me/upload.php")
                 loggedIn = await self.validate_login(uploadresponse)
@@ -1415,9 +1420,9 @@ class PTP:
             await asyncio.sleep(2)
             try:
                 resp = loginresponse.json()
-                if resp['Result'] == "TfaRequired":
-                    data['TfaType'] = "normal"
-                    data['TfaCode'] = cli_ui.ask_string("2FA Required: Please enter PTP 2FA code")
+                if resp["Result"] == "TfaRequired":
+                    data["TfaType"] = "normal"
+                    data["TfaCode"] = cli_ui.ask_string("2FA Required: Please enter PTP 2FA code")
                     loginresponse = await client.post("https://passthepopcorn.me/ajax.php?action=login", data=data, headers=headers)
                     await asyncio.sleep(2)
                     resp = loginresponse.json()
@@ -1468,8 +1473,8 @@ class PTP:
         ptp_subtitles = self.get_subtitles(meta)
         no_audio_found = False
         english_audio = False
-        if meta['is_disc'] == 'BDMV':
-            bdinfo = meta.get('bdinfo', {})
+        if meta["is_disc"] == "BDMV":
+            bdinfo = meta.get("bdinfo", {})
             audio_tracks = bdinfo.get("audio", [])
             if audio_tracks:
                 first_language = str(audio_tracks[0].get("Language", "")).lower()
@@ -1480,9 +1485,9 @@ class PTP:
                 else:
                     english_audio = False
         else:
-            mediainfo = meta.get('mediainfo', {})
+            mediainfo = meta.get("mediainfo", {})
             audio_tracks = [track for track in mediainfo.get("media", {}).get("track", []) if track.get("@type") == "Audio"]
-            if meta['debug']:
+            if meta["debug"]:
                 console.print(f"[Debug] Found {len(audio_tracks)} audio tracks")
 
             if not audio_tracks:
@@ -1490,7 +1495,7 @@ class PTP:
                 console.print("[yellow]No audio tracks found in mediainfo")
             else:
                 first_language = str(audio_tracks[0].get("Language", "")).lower()
-                if meta['debug']:
+                if meta["debug"]:
                     console.print(f"[Debug] First audio track language: {first_language}")
 
                 if not first_language:
@@ -1501,7 +1506,7 @@ class PTP:
                     english_audio = False
 
         ptp_trumpable = None
-        if meta.get('hardcoded_subs'):
+        if meta.get("hardcoded_subs"):
             ptp_trumpable, ptp_subtitles = self.get_trumpable(ptp_subtitles)
             if ptp_trumpable and 50 in ptp_trumpable:
                 ptp_trumpable.remove(50)
@@ -1525,37 +1530,37 @@ class PTP:
             if cli_ui.ask_yes_no("Mark trumpable?", default=True):
                 ptp_trumpable, ptp_subtitles = self.get_trumpable(ptp_subtitles)
 
-        if meta['debug']:
+        if meta["debug"]:
             console.print("ptp_trumpable", ptp_trumpable)
             console.print("ptp_subtitles", ptp_subtitles)
         data: dict[str, Any] = {
             "submit": "true",
             "remaster_year": "",
             "remaster_title": self.get_remaster_title(meta),  # Eg.: Hardcoded English
-            "type": self.get_type(meta['imdb_info'], meta),
+            "type": self.get_type(meta["imdb_info"], meta),
             "codec": "Other",  # Sending the codec as custom.
             "other_codec": self.get_codec(meta),
             "container": "Other",
             "other_container": self.get_container(meta),
             "resolution": resolution,
             "source": "Other",  # Sending the source as custom.
-            "other_source": self.get_source(meta['source']),
+            "other_source": self.get_source(meta["source"]),
             "release_desc": desc,
             "nfo_text": "",
             "subtitles[]": ptp_subtitles,
             "trumpable[]": ptp_trumpable,
-            "AntiCsrfToken": await self.get_AntiCsrfToken(meta)
+            "AntiCsrfToken": await self.get_AntiCsrfToken(meta),
         }
         if data["remaster_year"] != "" or data["remaster_title"] != "":
             data["remaster"] = "on"
-        if meta.get('scene', False) is True:
+        if meta.get("scene", False) is True:
             data["scene"] = "on"
         if resolution == "Other":
             data["other_resolution"] = other_resolution
-        if meta.get('personalrelease', False) is True:
+        if meta.get("personalrelease", False) is True:
             data["internalrip"] = "on"
         # IF SPECIAL (idk how to check for this automatically)
-            # data["special"] = "on"
+        # data["special"] = "on"
         imdb_id_value = meta.get("imdb_id")
         imdb_id_int = int(imdb_id_value) if isinstance(imdb_id_value, (int, str)) else 0
         if imdb_id_int == 0:
@@ -1564,17 +1569,21 @@ class PTP:
             data["imdb"] = str(imdb_id_int).zfill(7)
         if groupID is None:  # If need to make new group
             url = "https://passthepopcorn.me/upload.php"
-            if data["imdb"] == '0':
+            if data["imdb"] == "0":
                 tinfo = await self.get_torrent_info_tmdb(meta)
             else:
                 imdb_value = meta.get("imdb") or "0"
                 tinfo = await self.get_torrent_info(imdb_value, meta)
-            if meta.get('youtube') is None or "youtube" not in str(meta.get('youtube', '')):
-                youtube = "" if meta['unattended'] else cli_ui.ask_string("Unable to find youtube trailer, please link one e.g.(https://www.youtube.com/watch?v=dQw4w9WgXcQ)", default="")
-                meta['youtube'] = youtube
+            if meta.get("youtube") is None or "youtube" not in str(meta.get("youtube", "")):
+                youtube = (
+                    ""
+                    if meta["unattended"]
+                    else cli_ui.ask_string("Unable to find youtube trailer, please link one e.g.(https://www.youtube.com/watch?v=dQw4w9WgXcQ)", default="")
+                )
+                meta["youtube"] = youtube
             cover = meta["imdb_info"].get("cover")
             if cover is None:
-                cover = meta.get('poster')
+                cover = meta.get("poster")
             if isinstance(cover, str) and cover.strip():
                 cover = await self.rehost_poster_to_selected_host(meta, cover)
             elif isinstance(cover, str):
@@ -1583,7 +1592,7 @@ class PTP:
                 cover_input = str(cli_ui.ask_string("No Poster was found. Please input a link to a poster: \n", default="") or "").strip()
                 if not cover_input:
                     continue
-                if not cover_input.lower().endswith(('.jpg', '.jpeg', '.png', '.webp')):
+                if not cover_input.lower().endswith((".jpg", ".jpeg", ".png", ".webp")):
                     console.print("[red]Poster URL must end with .jpg, .jpeg, .png, or .webp")
                     continue
                 cover = await self.rehost_poster_to_selected_host(meta, cover_input)
@@ -1595,21 +1604,19 @@ class PTP:
                 "album_desc": tinfo.get("plot", meta.get("overview", "")),
                 "trailer": meta.get("youtube", ""),
             }
-            if new_data['year'] in ['', '0', 0, None] and meta.get('manual_year') not in [0, '', None]:
-                new_data['year'] = meta['manual_year']
+            if new_data["year"] in ["", "0", 0, None] and meta.get("manual_year") not in [0, "", None]:
+                new_data["year"] = meta["manual_year"]
             while new_data["tags"] == "":
-                if meta.get('mode', 'discord') == 'cli':
-                    console.print('[yellow]Unable to match any tags')
+                if meta.get("mode", "discord") == "cli":
+                    console.print("[yellow]Unable to match any tags")
                     console.print("Valid tags can be found on the PTP upload form")
                     new_data["tags"] = console.input("Please enter at least one tag. Comma separated (action, animation, short):")
             data.update(new_data)
             imdb_info = cast(dict[str, Any], meta.get("imdb_info", {}))
             directors: Union[list[str], tuple[str, ...], None] = None
-            directors_value = imdb_info.get('directors')
+            directors_value = imdb_info.get("directors")
             if isinstance(directors_value, (list, tuple)):
-                director_names = [
-                    str(director) for director in cast(list[Any], directors_value) if isinstance(director, str)
-                ]
+                director_names = [str(director) for director in cast(list[Any], directors_value) if isinstance(director, str)]
                 directors = tuple(director_names)
             if directors:
                 data["artist[]"] = directors
@@ -1622,53 +1629,51 @@ class PTP:
 
     async def upload(self, meta: dict[str, Any], url: str, data: dict[str, Any], _disctype: str) -> bool:
         common = COMMON(config=self.config)
-        base_piece_mb = int(meta.get('base_torrent_piece_mb', 0) or 0)
+        base_piece_mb = int(meta.get("base_torrent_piece_mb", 0) or 0)
         torrent_file_path = f"{meta['base_dir']}/tmp/{meta['uuid']}/[{self.tracker}].torrent"
 
         # Check if the piece size exceeds 16 MiB and regenerate the torrent if needed
-        if base_piece_mb > 16 and not meta.get('nohash', False):
+        if base_piece_mb > 16 and not meta.get("nohash", False):
             console.print("[red]Piece size is OVER 16M and does not work on PTP. Generating a new .torrent")
             tracker_url = self.announce_url.strip() if self.announce_url else "https://fake.tracker"
             piece_size = 16
             torrent_create = f"[{self.tracker}]"
             try:
-                cooldown = int(self.config.get('DEFAULT', {}).get('rehash_cooldown', 0) or 0)
+                cooldown = int(self.config.get("DEFAULT", {}).get("rehash_cooldown", 0) or 0)
             except (ValueError, TypeError):
                 cooldown = 0
             if cooldown > 0:
                 await asyncio.sleep(cooldown)  # Small cooldown before rehashing
 
-            await TorrentCreator.create_torrent(meta, str(meta['path']), torrent_create, tracker_url=tracker_url, piece_size=piece_size)
+            await TorrentCreator.create_torrent(meta, str(meta["path"]), torrent_create, tracker_url=tracker_url, piece_size=piece_size)
             await common.create_torrent_for_upload(meta, self.tracker, self.source_flag, torrent_filename=torrent_create)
         else:
             await common.create_torrent_for_upload(meta, self.tracker, self.source_flag)
 
         # Proceed with the upload process
-        async with aiofiles.open(torrent_file_path, 'rb') as torrentFile:
+        async with aiofiles.open(torrent_file_path, "rb") as torrentFile:
             torrent_bytes = await torrentFile.read()
-        files = {
-            "file_input": ("placeholder.torrent", torrent_bytes, "application/x-bittorent")
-        }
+        files = {"file_input": ("placeholder.torrent", torrent_bytes, "application/x-bittorent")}
         headers = {
             # 'ApiUser' : self.api_user,
             # 'ApiKey' : self.api_key,
             "User-Agent": self.user_agent
         }
-        if meta['debug']:
+        if meta["debug"]:
             debug_data = data.copy()
             # Redact the AntiCsrfToken
-            if 'AntiCsrfToken' in debug_data:
-                debug_data['AntiCsrfToken'] = '[REDACTED]'
+            if "AntiCsrfToken" in debug_data:
+                debug_data["AntiCsrfToken"] = "[REDACTED]"
             console.log(url)
             console.log(Redaction.redact_private_info(debug_data))
-            meta['tracker_status'][self.tracker]['status_message'] = "Debug mode enabled, not uploading."
+            meta["tracker_status"][self.tracker]["status_message"] = "Debug mode enabled, not uploading."
             await common.create_torrent_for_upload(meta, f"{self.tracker}" + "_DEBUG", f"{self.tracker}" + "_DEBUG", announce_url="https://fake.tracker")
             return True  # Debug mode - simulated success
         else:
             failure_path = f"{meta['base_dir']}/tmp/{meta['uuid']}/[{self.tracker}]PTP_upload_failure.html"
             cookiefile = f"{meta['base_dir']}/data/cookies/PTP.json"
             raw_cookies = self.cookie_validator._load_cookies_dict_secure(cookiefile)  # pyright: ignore[reportPrivateUsage]
-            cookies = {name: str(data.get('value', '')) for name, data in raw_cookies.items()}
+            cookies = {name: str(data.get("value", "")) for name, data in raw_cookies.items()}
             async with httpx.AsyncClient(cookies=cookies, timeout=60.0, follow_redirects=True) as client:
                 response = await client.post(url=url, data=data, headers=headers, files=files)
             console.print(f"[cyan]{response.url}")
@@ -1681,21 +1686,21 @@ class PTP:
                 if match is not None:
                     errorMessage = match.group(1)
 
-                async with aiofiles.open(failure_path, 'w', encoding='utf-8') as f:
+                async with aiofiles.open(failure_path, "w", encoding="utf-8") as f:
                     await f.write(responsetext)
-                meta['tracker_status'][self.tracker]['status_message'] = f"data error: see {failure_path} | {errorMessage}"
+                meta["tracker_status"][self.tracker]["status_message"] = f"data error: see {failure_path} | {errorMessage}"
 
             # URL format in case of successful upload: https://passthepopcorn.me/torrents.php?id=9329&torrentid=91868
             match = re.match(r".*?passthepopcorn\.me/torrents\.php\?id=(\d+)&torrentid=(\d+)", str(response.url))
             if match is None:
-                async with aiofiles.open(failure_path, 'w', encoding='utf-8') as f:
+                async with aiofiles.open(failure_path, "w", encoding="utf-8") as f:
                     await f.write(responsetext)
-                meta['tracker_status'][self.tracker]['status_message'] = f"data error: see {failure_path}"
+                meta["tracker_status"][self.tracker]["status_message"] = f"data error: see {failure_path}"
                 return False
 
             # having UA add the torrent link as a comment.
             if match:
-                meta['tracker_status'][self.tracker]['status_message'] = str(response.url)
+                meta["tracker_status"][self.tracker]["status_message"] = str(response.url)
                 await common.create_torrent_ready_to_seed(meta, self.tracker, self.source_flag, self.announce_url, str(response.url))
                 return True
         return False

--- a/src/trackers/PTP.py
+++ b/src/trackers/PTP.py
@@ -566,6 +566,7 @@ class PTP:
                     meta.pop("imghost", None)
                 else:
                     meta["imghost"] = original_imghost
+                poster_path.unlink(missing_ok=True)
 
             if uploaded_images:
                 uploaded_url = uploaded_images[0].get("raw_url") or uploaded_images[0].get("img_url")

--- a/src/tvdb.py
+++ b/src/tvdb.py
@@ -15,6 +15,8 @@ from tvdb_v4_official import TVDB
 
 from src.console import console
 
+YEAR_PATTERN = re.compile(r'\((19\d\d|20[0-3]\d)\)')
+
 
 def _get_tvdb_k() -> str:
     k = (
@@ -50,47 +52,86 @@ def _as_dict_list(value: Any) -> list[dict[str, Any]]:
     return []
 
 
-def _extract_year_from_slug(slug: Any) -> Optional[str]:
-    if not isinstance(slug, str) or not slug:
-        return None
-
-    match = re.search(r'(19|20)\d{2}(?!\d)', slug)
-    if not match:
-        return None
-    return match.group(0)
+def _english_alias_names(aliases: list[dict[str, Any]]) -> list[str]:
+    return [
+        str(alias.get('name', '')).strip() for alias in aliases
+        if alias.get('language') == 'eng' and str(alias.get('name', '')).strip()
+    ]
 
 
-def _pick_specific_eng_alias(
+def _pick_eng_alias(
     aliases: list[dict[str, Any]],
-    slug: Any = None,
     debug: bool = False,
 ) -> Optional[str]:
     if not aliases:
         return None
 
-    year_pattern = re.compile(r'\((\d{4})\)')
-    eng_aliases = [
-        str(alias.get('name', '')) for alias in aliases
-        if alias.get('language') == 'eng' and str(alias.get('name', '')).strip()
-    ]
+    eng_aliases = _english_alias_names(aliases)
     if not eng_aliases:
         return None
 
-    eng_aliases_with_year = [name for name in eng_aliases if year_pattern.search(name)]
-    if eng_aliases_with_year:
-        specific_alias = eng_aliases_with_year[-1]
-        if debug:
-            console.print(f"[blue]English alias with year: {specific_alias}[/blue]")
-        return specific_alias
+    eng_alias = eng_aliases[-1]
+    if debug:
+        console.print(f"[blue]English alias: {eng_alias}[/blue]")
+    return eng_alias
 
-    slug_year = _extract_year_from_slug(slug)
-    if slug_year:
-        specific_alias = f"{eng_aliases[-1]} ({slug_year})"
-        if debug:
-            console.print(f"[blue]English alias with slug year fallback: {specific_alias}[/blue]")
-        return specific_alias
 
-    return None
+def _extract_year_from_text(value: Any) -> Optional[str]:
+    if not isinstance(value, (str, int)):
+        return None
+
+    match = re.search(r'(19\d\d|20[0-3]\d)', str(value))
+    return match.group(1) if match else None
+
+
+def _best_effort_series_year(series_info: Optional[dict[str, Any]]) -> Optional[str]:
+    if not series_info:
+        return None
+
+    return _extract_year_from_text(series_info.get('year')) or _extract_year_from_text(series_info.get('slug'))
+
+
+def _series_translation_metadata(
+    client: Any,
+    series_id: int,
+    aliases: list[dict[str, Any]],
+    _series_info: Optional[dict[str, Any]] = None,
+    debug: bool = False,
+) -> dict[str, Optional[str]]:
+    translation_name: Optional[str] = None
+    translation_aliases: list[str] = []
+
+    try:
+        translation = cast(dict[str, Any], client.get_series_translation(series_id, 'eng'))
+        name = translation.get('name')
+        if isinstance(name, str) and name.strip():
+            translation_name = name.strip()
+        aliases_value = translation.get('aliases')
+        if isinstance(aliases_value, list):
+            translation_aliases = [str(alias).strip() for alias in aliases_value if str(alias).strip()]
+    except Exception as translation_error:
+        if debug:
+            console.print(f"[yellow]Could not retrieve TVDB English series translation: {translation_error}[/yellow]")
+
+    extended_eng_aliases = _english_alias_names(aliases)
+    english_aliases = translation_aliases + extended_eng_aliases
+    fallback_title = translation_aliases[-1] if translation_aliases else _pick_eng_alias(aliases, debug=debug)
+    title = translation_name or fallback_title
+    year = None
+    for alias in english_aliases:
+        year = _extract_year_from_text(alias)
+        if year:
+            break
+    if not english_aliases:
+        year = _best_effort_series_year(_series_info)
+
+    if debug and title:
+        console.print(f"[blue]TVDB English series title: {title}" + (f" ({year})" if year else "") + "[/blue]")
+
+    return {
+        'series_title': title,
+        'series_year': year,
+    }
 
 
 try:
@@ -284,14 +325,29 @@ class tvdb_data:
                                 'episodes': cached_episodes,
                                 'aliases': cached_dict.get('aliases', []) if isinstance(cached_dict.get('aliases', []), list) else [],
                                 'slug': cached_dict.get('slug') if isinstance(cached_dict.get('slug'), str) else None,
+                                'series_title': cached_dict.get('series_title') if isinstance(cached_dict.get('series_title'), str) else None,
+                                'series_year': cached_dict.get('series_year') if isinstance(cached_dict.get('series_year'), str) else None,
                             }
 
-                            aliases_list = _as_dict_list(episodes_data.get('aliases'))
-                            specific_alias = _pick_specific_eng_alias(
-                                aliases_list,
-                                slug=episodes_data.get('slug'),
-                                debug=debug,
-                            )
+                            if not episodes_data.get('series_title') and not episodes_data.get('series_year'):
+                                client = _get_tvdb_or_warn()
+                                if client is not None:
+                                    try:
+                                        series_info = cast(dict[str, Any], cast(Any, client).get_series_extended(series_id_int))
+                                        aliases_list = _as_dict_list(series_info.get('aliases', episodes_data.get('aliases')))
+                                        series_metadata = _series_translation_metadata(
+                                            client,
+                                            series_id_int,
+                                            aliases_list,
+                                            _series_info=series_info,
+                                            debug=debug,
+                                        )
+                                        episodes_data.update(series_metadata)
+                                    except Exception as series_error:
+                                        if debug:
+                                            console.print(f"[yellow]Could not refresh cached TVDB series metadata: {series_error}[/yellow]")
+
+                            specific_alias = episodes_data.get('series_title') if isinstance(episodes_data.get('series_title'), str) else None
                             if original_language and original_language == 'en':
                                 specific_alias = None
 
@@ -373,6 +429,8 @@ class tvdb_data:
                 'episodes': all_episodes,
                 'aliases': [],  # Will be populated if available from first response
                 'slug': series_slug,
+                'series_title': None,
+                'series_year': None,
             }
 
             # Try to get aliases from series info (may need separate call)
@@ -382,6 +440,14 @@ class tvdb_data:
                     series_info = cast(dict[str, Any], cast(Any, client).get_series_extended(series_id_int))
                     if 'aliases' in series_info:
                         episodes_data['aliases'] = series_info['aliases']
+                    aliases_list = _as_dict_list(episodes_data['aliases'])
+                    episodes_data.update(_series_translation_metadata(
+                        client,
+                        series_id_int,
+                        aliases_list,
+                        _series_info=series_info,
+                        debug=debug,
+                    ))
             except Exception as alias_error:
                 if debug:
                     console.print(f"[yellow]Could not retrieve series aliases: {alias_error}[/yellow]")
@@ -409,17 +475,9 @@ class tvdb_data:
                     if debug:
                         console.print(f"[yellow]Failed to write TVDB cache for {series_id}: {cache_write_error}[/yellow]")
 
-            # Extract specific English alias only if it contains a year (e.g., "Cats eye (2025)")
-            specific_alias = None
-            if 'aliases' in episodes_data and episodes_data['aliases']:
-                aliases_list = _as_dict_list(episodes_data['aliases'])
-                specific_alias = _pick_specific_eng_alias(
-                    aliases_list,
-                    slug=episodes_data.get('slug'),
-                    debug=debug,
-                )
-                if original_language and original_language == 'en':
-                    specific_alias = None
+            specific_alias = episodes_data.get('series_title') if isinstance(episodes_data.get('series_title'), str) else None
+            if original_language and original_language == 'en':
+                specific_alias = None
 
             return episodes_data, specific_alias
 
@@ -437,6 +495,27 @@ class tvdb_data:
         client = _get_tvdb_or_warn()
         if client is None:
             return None, None
+
+        def _translated_series_name(series_id_value: Any, fallback: Any) -> Optional[str]:
+            series_id_int = _coerce_int(series_id_value)
+            fallback_name = str(fallback).strip() if fallback else None
+            if series_id_int is None:
+                return fallback_name
+            try:
+                series_info = cast(dict[str, Any], cast(Any, client).get_series_extended(series_id_int))
+                aliases = _as_dict_list(series_info.get('aliases', []))
+                series_metadata = _series_translation_metadata(
+                    client,
+                    series_id_int,
+                    aliases,
+                    _series_info=series_info,
+                    debug=debug,
+                )
+                return series_metadata.get('series_title') or fallback_name
+            except Exception as series_error:
+                if debug:
+                    console.print(f"[yellow]Could not retrieve translated TVDB series name: {series_error}[/yellow]")
+                return fallback_name
 
         # Try IMDB first if available
         if imdb:
@@ -464,7 +543,7 @@ class tvdb_data:
                     for result in results:
                         if 'series' in result and isinstance(result.get('series'), dict):
                             series_id = result['series']['id']
-                            series_name = result['series'].get('name')
+                            series_name = _translated_series_name(series_id, result['series'].get('name'))
                             if debug:
                                 console.print(f"[blue]TVDB series ID from IMDB: {series_id}[/blue]")
                             return _coerce_int(series_id), series_name
@@ -475,7 +554,7 @@ class tvdb_data:
                         for result in results:
                             if 'episode' in result and isinstance(result.get('episode'), dict) and result['episode'].get('seriesId'):
                                 series_id = result['episode']['seriesId']
-                                series_name = result['episode'].get('seriesName')
+                                series_name = _translated_series_name(series_id, result['episode'].get('seriesName'))
                                 if debug:
                                     console.print(f"[blue]TVDB series ID from episode entry (tv_movie): {series_id}[/blue]")
                                 return _coerce_int(series_id), series_name
@@ -517,7 +596,7 @@ class tvdb_data:
                     for result in results:
                         if 'series' in result and isinstance(result.get('series'), dict):
                             series_id = result['series']['id']
-                            series_name = result['series'].get('name')
+                            series_name = _translated_series_name(series_id, result['series'].get('name'))
                             if debug:
                                 console.print(f"[blue]TVDB series ID from TMDB: {series_id}[/blue]")
                             return _coerce_int(series_id), series_name
@@ -528,7 +607,7 @@ class tvdb_data:
                         for result in results:
                             if 'episode' in result and isinstance(result.get('episode'), dict) and result['episode'].get('seriesId'):
                                 series_id = result['episode']['seriesId']
-                                series_name = result['episode'].get('seriesName')
+                                series_name = _translated_series_name(series_id, result['episode'].get('seriesName'))
                                 if debug:
                                     console.print(f"[blue]TVDB series ID from episode entry (tv_movie): {series_id}[/blue]")
                                 return _coerce_int(series_id), series_name

--- a/src/tvdb.py
+++ b/src/tvdb.py
@@ -15,7 +15,7 @@ from tvdb_v4_official import TVDB
 
 from src.console import console
 
-YEAR_PATTERN = re.compile(r'\((19\d\d|20[0-3]\d)\)')
+YEAR_PATTERN = re.compile(r"\((19\d\d|20[0-3]\d)\)")
 
 
 def _get_tvdb_k() -> str:
@@ -28,9 +28,7 @@ def _get_tvdb_k() -> str:
         b"AxMTAwMTAxMDEwMTExMDEwMTAwMTAwMTEwMTAxMDAxMDAxMTEwMDEwMTAxMTEwMTAxMTAxMDAxMTAxMDEw"
     )
     binary_bytes = base64.b64decode(k)
-    b64_bytes = bytes(
-        int(binary_bytes[i: i + 8], 2) for i in range(0, len(binary_bytes), 8)
-    )
+    b64_bytes = bytes(int(binary_bytes[i : i + 8], 2) for i in range(0, len(binary_bytes), 8))
     return base64.b64decode(b64_bytes).decode()
 
 
@@ -53,10 +51,7 @@ def _as_dict_list(value: Any) -> list[dict[str, Any]]:
 
 
 def _english_alias_names(aliases: list[dict[str, Any]]) -> list[str]:
-    return [
-        str(alias.get('name', '')).strip() for alias in aliases
-        if alias.get('language') == 'eng' and str(alias.get('name', '')).strip()
-    ]
+    return [str(alias.get("name", "")).strip() for alias in aliases if alias.get("language") == "eng" and str(alias.get("name", "")).strip()]
 
 
 def _pick_eng_alias(
@@ -80,7 +75,7 @@ def _extract_year_from_text(value: Any) -> Optional[str]:
     if not isinstance(value, (str, int)):
         return None
 
-    match = re.search(r'(19\d\d|20[0-3]\d)', str(value))
+    match = re.search(r"(19\d\d|20[0-3]\d)", str(value))
     return match.group(1) if match else None
 
 
@@ -88,7 +83,7 @@ def _best_effort_series_year(series_info: Optional[dict[str, Any]]) -> Optional[
     if not series_info:
         return None
 
-    return _extract_year_from_text(series_info.get('year')) or _extract_year_from_text(series_info.get('slug'))
+    return _extract_year_from_text(series_info.get("year")) or _extract_year_from_text(series_info.get("slug"))
 
 
 def _series_translation_metadata(
@@ -102,11 +97,11 @@ def _series_translation_metadata(
     translation_aliases: list[str] = []
 
     try:
-        translation = cast(dict[str, Any], client.get_series_translation(series_id, 'eng'))
-        name = translation.get('name')
+        translation = cast(dict[str, Any], client.get_series_translation(series_id, "eng"))
+        name = translation.get("name")
         if isinstance(name, str) and name.strip():
             translation_name = name.strip()
-        aliases_value = translation.get('aliases')
+        aliases_value = translation.get("aliases")
         if isinstance(aliases_value, list):
             translation_aliases = [str(alias).strip() for alias in aliases_value if str(alias).strip()]
     except Exception as translation_error:
@@ -129,8 +124,8 @@ def _series_translation_metadata(
         console.print(f"[blue]TVDB English series title: {title}" + (f" ({year})" if year else "") + "[/blue]")
 
     return {
-        'series_title': title,
-        'series_year': year,
+        "series_title": title,
+        "series_year": year,
     }
 
 
@@ -151,14 +146,11 @@ def _get_tvdb_or_warn() -> Optional[TVDB]:
     if not _tvdb_error_reported:
         _tvdb_error_reported = True
         if _tvdb_init_error:
-            console.print(
-                "[yellow]TVDB login failed; continuing without TVDB. "
-                f"Reason: {_tvdb_init_error}[/yellow]"
-            )
+            console.print(f"[yellow]TVDB login failed; continuing without TVDB. Reason: {_tvdb_init_error}[/yellow]")
             console.print(
                 "[yellow]This is usually a local Python CA/cert issue. "
                 "Fix options: install/update Windows roots, or set SSL_CERT_FILE to certifi's bundle "
-                "(e.g. `python -c \"import certifi; print(certifi.where())\"`).[/yellow]"
+                '(e.g. `python -c "import certifi; print(certifi.where())"`).[/yellow]'
             )
         else:
             console.print("[yellow]TVDB unavailable; continuing without TVDB.[/yellow]")
@@ -189,24 +181,24 @@ class tvdb_data:
             if results and len(results) > 0:
                 # Try to find the best match based on year
                 best_match: Optional[dict[str, Any]] = None
-                search_year = str(year) if year else ''
+                search_year = str(year) if year else ""
 
                 if search_year:
                     # First, try to find exact year match
                     for result in results:
-                        if result.get('year') == search_year:
+                        if result.get("year") == search_year:
                             best_match = result
                             break
 
                 # If no exact match, check aliases for year-based names
                 if not best_match and search_year:
                     for result in results:
-                        aliases_raw = result.get('aliases', [])
+                        aliases_raw = result.get("aliases", [])
                         aliases = cast(list[Any], aliases_raw) if isinstance(aliases_raw, list) else []
                         if aliases:
                             # Check if any alias contains the year in parentheses
                             for alias in aliases:
-                                alias_name = str(cast(dict[str, Any], alias).get('name', '')) if isinstance(alias, dict) else str(alias)
+                                alias_name = str(cast(dict[str, Any], alias).get("name", "")) if isinstance(alias, dict) else str(alias)
                                 if f"({search_year})" in alias_name:
                                     best_match = result
                                     break
@@ -217,7 +209,7 @@ class tvdb_data:
                 if not best_match:
                     best_match = results[0]
 
-                series_id = best_match['tvdb_id'] if best_match else None
+                series_id = best_match["tvdb_id"] if best_match else None
                 if debug:
                     console.print(f"[blue]TVDB series ID: {series_id}[/blue]")
                 return results, _coerce_int(series_id)
@@ -254,7 +246,7 @@ class tvdb_data:
 
             aired_norm = None
             if aired_date:
-                aired_norm = str(aired_date).strip().replace('.', '-')
+                aired_norm = str(aired_date).strip().replace(".", "-")
 
             # Normalize numeric inputs
             try:
@@ -275,7 +267,7 @@ class tvdb_data:
             # For daily-style episodes, match by aired date.
             if aired_norm:
                 for ep in episodes:
-                    if ep.get('aired') == aired_norm:
+                    if ep.get("aired") == aired_norm:
                         return True
 
             # Treat episode==0/None as "no specific episode" (season packs, etc.)
@@ -283,10 +275,10 @@ class tvdb_data:
                 return True
 
             for ep in episodes:
-                if absolute_int is not None and ep.get('absoluteNumber') == absolute_int:
+                if absolute_int is not None and ep.get("absoluteNumber") == absolute_int:
                     return True
 
-                if season_int is not None and episode_int not in (None, 0) and ep.get('seasonNumber') == season_int and ep.get('number') == episode_int:
+                if season_int is not None and episode_int not in (None, 0) and ep.get("seasonNumber") == season_int and ep.get("number") == episode_int:
                     return True
 
             return False
@@ -300,41 +292,39 @@ class tvdb_data:
         cache_path = None
         if isinstance(base_dir, str) and base_dir:
             try:
-                cache_dir = Path(base_dir) / 'data' / 'tvdb'
+                cache_dir = Path(base_dir) / "data" / "tvdb"
                 cache_path = cache_dir / f"{series_id_int}.json"
 
                 if cache_path.exists():
-                    with cache_path.open('r', encoding='utf-8') as f:
+                    with cache_path.open("r", encoding="utf-8") as f:
                         cached = json.load(f)
 
                     if isinstance(cached, dict):
                         cached_dict = cast(dict[str, Any], cached)
-                        cached_episodes = _as_dict_list(cached_dict.get('episodes', []))
-                        if not cached_episodes and not isinstance(cached_dict.get('episodes', []), list):
+                        cached_episodes = _as_dict_list(cached_dict.get("episodes", []))
+                        if not cached_episodes and not isinstance(cached_dict.get("episodes", []), list):
                             cached_episodes = []
                         if not _episode_is_present(cached_episodes):
                             if debug:
-                                console.print(
-                                    f"[yellow]Cached TVDB data for {series_id_int} does not include requested episode; refreshing from TVDB[/yellow]"
-                                )
+                                console.print(f"[yellow]Cached TVDB data for {series_id_int} does not include requested episode; refreshing from TVDB[/yellow]")
                         else:
                             if debug:
                                 console.print(f"[cyan]Using cached TVDB episodes for {series_id_int}[/cyan]")
 
                             episodes_data: dict[str, Any] = {
-                                'episodes': cached_episodes,
-                                'aliases': cached_dict.get('aliases', []) if isinstance(cached_dict.get('aliases', []), list) else [],
-                                'slug': cached_dict.get('slug') if isinstance(cached_dict.get('slug'), str) else None,
-                                'series_title': cached_dict.get('series_title') if isinstance(cached_dict.get('series_title'), str) else None,
-                                'series_year': cached_dict.get('series_year') if isinstance(cached_dict.get('series_year'), str) else None,
+                                "episodes": cached_episodes,
+                                "aliases": cached_dict.get("aliases", []) if isinstance(cached_dict.get("aliases", []), list) else [],
+                                "slug": cached_dict.get("slug") if isinstance(cached_dict.get("slug"), str) else None,
+                                "series_title": cached_dict.get("series_title") if isinstance(cached_dict.get("series_title"), str) else None,
+                                "series_year": cached_dict.get("series_year") if isinstance(cached_dict.get("series_year"), str) else None,
                             }
 
-                            if not episodes_data.get('series_title') and not episodes_data.get('series_year'):
+                            if not episodes_data.get("series_title") and not episodes_data.get("series_year"):
                                 client = _get_tvdb_or_warn()
                                 if client is not None:
                                     try:
                                         series_info = cast(dict[str, Any], cast(Any, client).get_series_extended(series_id_int))
-                                        aliases_list = _as_dict_list(series_info.get('aliases', episodes_data.get('aliases')))
+                                        aliases_list = _as_dict_list(series_info.get("aliases", episodes_data.get("aliases")))
                                         series_metadata = _series_translation_metadata(
                                             client,
                                             series_id_int,
@@ -347,8 +337,8 @@ class tvdb_data:
                                         if debug:
                                             console.print(f"[yellow]Could not refresh cached TVDB series metadata: {series_error}[/yellow]")
 
-                            specific_alias = episodes_data.get('series_title') if isinstance(episodes_data.get('series_title'), str) else None
-                            if original_language and original_language == 'en':
+                            specific_alias = episodes_data.get("series_title") if isinstance(episodes_data.get("series_title"), str) else None
+                            if original_language and original_language == "en":
                                 specific_alias = None
 
                             return episodes_data, specific_alias
@@ -373,21 +363,16 @@ class tvdb_data:
                     console.print(f"[cyan]Fetching TVDB episodes page {page + 1}[/cyan]")
 
                 try:
-                    episodes_response = cast(Any, client).get_series_episodes(
-                        series_id_int,
-                        season_type="default",
-                        page=page,
-                        lang="eng"
-                    )
+                    episodes_response = cast(Any, client).get_series_episodes(series_id_int, season_type="default", page=page, lang="eng")
 
                     # Handle both dict response and direct episodes list
                     if isinstance(episodes_response, dict):
                         episodes_response_dict = cast(dict[str, Any], episodes_response)
                         if page == 0:
-                            slug_value = episodes_response_dict.get('slug')
+                            slug_value = episodes_response_dict.get("slug")
                             if isinstance(slug_value, str):
                                 series_slug = slug_value
-                        current_episodes = _as_dict_list(episodes_response_dict.get('episodes', []))
+                        current_episodes = _as_dict_list(episodes_response_dict.get("episodes", []))
                     else:
                         # Fallback for direct list response
                         current_episodes = _as_dict_list(episodes_response)
@@ -426,11 +411,11 @@ class tvdb_data:
 
             # Create the response structure
             episodes_data: dict[str, Any] = {
-                'episodes': all_episodes,
-                'aliases': [],  # Will be populated if available from first response
-                'slug': series_slug,
-                'series_title': None,
-                'series_year': None,
+                "episodes": all_episodes,
+                "aliases": [],  # Will be populated if available from first response
+                "slug": series_slug,
+                "series_title": None,
+                "series_year": None,
             }
 
             # Try to get aliases from series info (may need separate call)
@@ -438,16 +423,18 @@ class tvdb_data:
                 if all_episodes:
                     # Get series details for aliases
                     series_info = cast(dict[str, Any], cast(Any, client).get_series_extended(series_id_int))
-                    if 'aliases' in series_info:
-                        episodes_data['aliases'] = series_info['aliases']
-                    aliases_list = _as_dict_list(episodes_data['aliases'])
-                    episodes_data.update(_series_translation_metadata(
-                        client,
-                        series_id_int,
-                        aliases_list,
-                        _series_info=series_info,
-                        debug=debug,
-                    ))
+                    if "aliases" in series_info:
+                        episodes_data["aliases"] = series_info["aliases"]
+                    aliases_list = _as_dict_list(episodes_data["aliases"])
+                    episodes_data.update(
+                        _series_translation_metadata(
+                            client,
+                            series_id_int,
+                            aliases_list,
+                            _series_info=series_info,
+                            debug=debug,
+                        )
+                    )
             except Exception as alias_error:
                 if debug:
                     console.print(f"[yellow]Could not retrieve series aliases: {alias_error}[/yellow]")
@@ -456,17 +443,17 @@ class tvdb_data:
             if cache_path and pages_fetched > 1:
                 try:
                     # Ensure cache dir exists; on POSIX explicitly apply typical dir perms.
-                    if os.name == 'posix':
+                    if os.name == "posix":
                         cache_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
                         with contextlib.suppress(Exception):
                             os.chmod(cache_path.parent, 0o700)
                     else:
                         cache_path.parent.mkdir(parents=True, exist_ok=True)
 
-                    with cache_path.open('w', encoding='utf-8') as f:
+                    with cache_path.open("w", encoding="utf-8") as f:
                         json.dump(episodes_data, f, ensure_ascii=False)
 
-                    if os.name == 'posix':
+                    if os.name == "posix":
                         with contextlib.suppress(Exception):
                             os.chmod(cache_path, 0o644)
                     if debug:
@@ -475,8 +462,8 @@ class tvdb_data:
                     if debug:
                         console.print(f"[yellow]Failed to write TVDB cache for {series_id}: {cache_write_error}[/yellow]")
 
-            specific_alias = episodes_data.get('series_title') if isinstance(episodes_data.get('series_title'), str) else None
-            if original_language and original_language == 'en':
+            specific_alias = episodes_data.get("series_title") if isinstance(episodes_data.get("series_title"), str) else None
+            if original_language and original_language == "en":
                 specific_alias = None
 
             return episodes_data, specific_alias
@@ -503,7 +490,7 @@ class tvdb_data:
                 return fallback_name
             try:
                 series_info = cast(dict[str, Any], cast(Any, client).get_series_extended(series_id_int))
-                aliases = _as_dict_list(series_info.get('aliases', []))
+                aliases = _as_dict_list(series_info.get("aliases", []))
                 series_metadata = _series_translation_metadata(
                     client,
                     series_id_int,
@@ -511,7 +498,7 @@ class tvdb_data:
                     _series_info=series_info,
                     debug=debug,
                 )
-                return series_metadata.get('series_title') or fallback_name
+                return series_metadata.get("series_title") or fallback_name
             except Exception as series_error:
                 if debug:
                     console.print(f"[yellow]Could not retrieve translated TVDB series name: {series_error}[/yellow]")
@@ -520,7 +507,7 @@ class tvdb_data:
         # Try IMDB first if available
         if imdb:
             try:
-                if isinstance(imdb, str) and imdb.startswith('tt'):
+                if isinstance(imdb, str) and imdb.startswith("tt"):
                     imdb_formatted = imdb
                 elif isinstance(imdb, str) and imdb.isdigit():
                     imdb_formatted = f"tt{int(imdb):07d}"
@@ -541,9 +528,9 @@ class tvdb_data:
 
                     # Look for series results first
                     for result in results:
-                        if 'series' in result and isinstance(result.get('series'), dict):
-                            series_id = result['series']['id']
-                            series_name = _translated_series_name(series_id, result['series'].get('name'))
+                        if "series" in result and isinstance(result.get("series"), dict):
+                            series_id = result["series"]["id"]
+                            series_name = _translated_series_name(series_id, result["series"].get("name"))
                             if debug:
                                 console.print(f"[blue]TVDB series ID from IMDB: {series_id}[/blue]")
                             return _coerce_int(series_id), series_name
@@ -552,18 +539,18 @@ class tvdb_data:
                     if tv_movie:
                         # Check if any result has an episode with a seriesId
                         for result in results:
-                            if 'episode' in result and isinstance(result.get('episode'), dict) and result['episode'].get('seriesId'):
-                                series_id = result['episode']['seriesId']
-                                series_name = _translated_series_name(series_id, result['episode'].get('seriesName'))
+                            if "episode" in result and isinstance(result.get("episode"), dict) and result["episode"].get("seriesId"):
+                                series_id = result["episode"]["seriesId"]
+                                series_name = _translated_series_name(series_id, result["episode"].get("seriesName"))
                                 if debug:
                                     console.print(f"[blue]TVDB series ID from episode entry (tv_movie): {series_id}[/blue]")
                                 return _coerce_int(series_id), series_name
 
                         # If no episode with seriesId, accept movie results
                         for result in results:
-                            if 'movie' in result and isinstance(result.get('movie'), dict):
-                                movie_id = result['movie']['id']
-                                movie_name = result['movie'].get('name')
+                            if "movie" in result and isinstance(result.get("movie"), dict):
+                                movie_id = result["movie"]["id"]
+                                movie_name = result["movie"].get("name")
                                 if debug:
                                     console.print(f"[blue]TVDB movie ID from IMDB (tv_movie): {movie_id}[/blue]")
                                 return _coerce_int(movie_id), movie_name
@@ -594,9 +581,9 @@ class tvdb_data:
 
                     # Look for series results first
                     for result in results:
-                        if 'series' in result and isinstance(result.get('series'), dict):
-                            series_id = result['series']['id']
-                            series_name = _translated_series_name(series_id, result['series'].get('name'))
+                        if "series" in result and isinstance(result.get("series"), dict):
+                            series_id = result["series"]["id"]
+                            series_name = _translated_series_name(series_id, result["series"].get("name"))
                             if debug:
                                 console.print(f"[blue]TVDB series ID from TMDB: {series_id}[/blue]")
                             return _coerce_int(series_id), series_name
@@ -605,18 +592,18 @@ class tvdb_data:
                     if tv_movie:
                         # Check if any result has an episode with a seriesId
                         for result in results:
-                            if 'episode' in result and isinstance(result.get('episode'), dict) and result['episode'].get('seriesId'):
-                                series_id = result['episode']['seriesId']
-                                series_name = _translated_series_name(series_id, result['episode'].get('seriesName'))
+                            if "episode" in result and isinstance(result.get("episode"), dict) and result["episode"].get("seriesId"):
+                                series_id = result["episode"]["seriesId"]
+                                series_name = _translated_series_name(series_id, result["episode"].get("seriesName"))
                                 if debug:
                                     console.print(f"[blue]TVDB series ID from episode entry (tv_movie): {series_id}[/blue]")
                                 return _coerce_int(series_id), series_name
 
                         # If no episode with seriesId, accept movie results
                         for result in results:
-                            if 'movie' in result and isinstance(result.get('movie'), dict):
-                                movie_id = result['movie']['id']
-                                movie_name = result['movie'].get('name')
+                            if "movie" in result and isinstance(result.get("movie"), dict):
+                                movie_id = result["movie"]["id"]
+                                movie_name = result["movie"].get("name")
                                 if debug:
                                     console.print(f"[blue]TVDB movie ID from TMDB (tv_movie): {movie_id}[/blue]")
                                 return _coerce_int(movie_id), movie_name
@@ -655,12 +642,12 @@ class tvdb_data:
             if debug:
                 console.print(f"[yellow]Episode data retrieved for episode ID {episode_id}[/yellow]")
 
-            remote_ids = _as_dict_list(episode_data.get('remoteIds', []))
+            remote_ids = _as_dict_list(episode_data.get("remoteIds", []))
             imdb_id = None
 
             for remote_id in remote_ids:
-                if remote_id.get('type') == 2 or remote_id.get('sourceName') == 'IMDB':
-                    imdb_id = remote_id.get('id')
+                if remote_id.get("type") == 2 or remote_id.get("sourceName") == "IMDB":
+                    imdb_id = remote_id.get("id")
                     break
 
             if imdb_id and debug:
@@ -695,7 +682,7 @@ class tvdb_data:
         # Handle both dict (full series data) and list (episodes only) formats
         if isinstance(data, dict):
             data_dict = cast(dict[str, Any], data)
-            episodes = _as_dict_list(data_dict.get('episodes', []))
+            episodes = _as_dict_list(data_dict.get("episodes", []))
         elif isinstance(data, list):
             episodes = _as_dict_list(data)
         else:
@@ -724,69 +711,37 @@ class tvdb_data:
 
         # For daily shows, match by air date if provided.
         if aired_date:
-            aired_norm = str(aired_date).strip().replace('.', '-')
+            aired_norm = str(aired_date).strip().replace(".", "-")
             for ep in episodes:
-                if ep.get('aired') == aired_norm:
+                if ep.get("aired") == aired_norm:
                     if debug:
                         console.print(f"[green]Matched daily episode by air date {aired_norm}: S{ep.get('seasonNumber'):02d}E{ep.get('number'):02d} - {ep.get('name')}[/green]")
-                    return (
-                        ep.get('seasonName'),
-                        ep.get('name'),
-                        ep.get('overview'),
-                        ep.get('seasonNumber'),
-                        ep.get('number'),
-                        ep.get('year'),
-                        ep.get('id')
-                    )
+                    return (ep.get("seasonName"), ep.get("name"), ep.get("overview"), ep.get("seasonNumber"), ep.get("number"), ep.get("year"), ep.get("id"))
 
         # If episode_int is None or 0, return first episode of the season
         if episode_int is None or episode_int == 0:
             for ep in episodes:
-                if ep.get('seasonNumber') == season_int:
+                if ep.get("seasonNumber") == season_int:
                     if debug:
                         console.print(f"[green]Found first episode of season {season_int}: S{season_int:02d}E{ep.get('number'):02d} - {ep.get('name')}[/green]")
-                    return (
-                        ep.get('seasonName'),
-                        ep.get('name'),
-                        ep.get('overview'),
-                        ep.get('seasonNumber'),
-                        ep.get('number'),
-                        ep.get('year'),
-                        ep.get('id')
-                    )
+                    return (ep.get("seasonName"), ep.get("name"), ep.get("overview"), ep.get("seasonNumber"), ep.get("number"), ep.get("year"), ep.get("id"))
 
         # Try to find exact season/episode match
         for ep in episodes:
-            if ep.get('seasonNumber') == season_int and ep.get('number') == episode_int:
+            if ep.get("seasonNumber") == season_int and ep.get("number") == episode_int:
                 if debug:
                     console.print(f"[green]Found exact match: S{season_int:02d}E{episode_int:02d} - {ep.get('name')}[/green]")
-                return (
-                    ep.get('seasonName'),
-                    ep.get('name'),
-                    ep.get('overview'),
-                    ep.get('seasonNumber'),
-                    ep.get('number'),
-                    ep.get('year'),
-                    ep.get('id')
-                )
+                return (ep.get("seasonName"), ep.get("name"), ep.get("overview"), ep.get("seasonNumber"), ep.get("number"), ep.get("year"), ep.get("id"))
 
         # Try to find an episode with this absolute number directly
         console.print("[yellow]No exact match found, trying absolute number mapping...[/yellow]")
         for ep in episodes:
-            if ep.get('absoluteNumber') == episode_int:
-                mapped_season = ep.get('seasonNumber')
-                mapped_episode = ep.get('number')
+            if ep.get("absoluteNumber") == episode_int:
+                mapped_season = ep.get("seasonNumber")
+                mapped_episode = ep.get("number")
                 if debug:
                     console.print(f"[green]Mapped absolute #{episode_int} -> S{mapped_season:02d}E{mapped_episode:02d} - {ep.get('name')}[/green]")
-                return (
-                    ep.get('seasonName'),
-                    ep.get('name'),
-                    ep.get('overview'),
-                    ep.get('seasonNumber'),
-                    ep.get('number'),
-                    ep.get('year'),
-                    ep.get('id')
-                )
+                return (ep.get("seasonName"), ep.get("name"), ep.get("overview"), ep.get("seasonNumber"), ep.get("number"), ep.get("year"), ep.get("id"))
 
         console.print(f"[red]Could not find episode for S{season_int:02d}E{episode_int:02d} or absolute #{episode_int}[/red]")
         return None, None, None, None, None, None, None

--- a/src/tvdb.py
+++ b/src/tvdb.py
@@ -112,12 +112,13 @@ def _series_translation_metadata(
     english_aliases = translation_aliases + extended_eng_aliases
     fallback_title = translation_aliases[-1] if translation_aliases else _pick_eng_alias(aliases, debug=debug)
     title = translation_name or fallback_title
-    year = None
-    for alias in english_aliases:
-        year = _extract_year_from_text(alias)
-        if year:
-            break
-    if not english_aliases:
+    year = _extract_year_from_text(title)
+    if not year:
+        for alias in english_aliases:
+            year = _extract_year_from_text(alias)
+            if year:
+                break
+    if not year and not english_aliases:
         year = _best_effort_series_year(_series_info)
 
     if debug and title:

--- a/tests/test_edition.py
+++ b/tests/test_edition.py
@@ -75,9 +75,14 @@ class TestSpecialEditionIMDB:
     the edition must resolve to 'SPECIAL EDITION'."""
 
     def test_imdb_special_edition_preserved(self) -> None:
-        """Simulate IMDB duration match returning 'Special Edition'."""
+        """Simulate IMDB duration match returning 'Special Edition'.
+
+        edition_count is set to 2 (theatrical + special) so the upstream
+        imdb_edition_count > 1 guard does not skip the IMDB path.
+        """
         meta = _meta_base(
             imdb_info={
+                'edition_count': 2,
                 'edition_details': {
                     'v1': {
                         'seconds': 7200,

--- a/tests/test_edition.py
+++ b/tests/test_edition.py
@@ -102,6 +102,31 @@ class TestSpecialEditionIMDB:
         edition, _repack, _hybrid = _run(get_edition(video, None, [video], '', meta))
         assert edition == 'SPECIAL EDITION'
 
+    def test_sole_imdb_edition_ignored(self) -> None:
+        """When edition_count == 1 the sole IMDB edition must be skipped
+        (upstream imdb_edition_count > 1 guard) and the guessit path used."""
+        meta = _meta_base(
+            imdb_info={
+                'edition_count': 1,
+                'edition_details': {
+                    '120_0': {
+                        'seconds': 7200,
+                        'attributes': ['special', 'edition'],
+                    },
+                },
+            },
+            mediainfo={
+                'media': {
+                    'track': [
+                        {'@type': 'General', 'Duration': '7200'},
+                    ],
+                },
+            },
+        )
+        video = 'Aliens.1986.2160p.UHD.BluRay.TrueHD.7.1.DoVi.HDR10.x265-W4NK3R.mkv'
+        edition, _repack, _hybrid = _run(get_edition(video, None, [video], '', meta))
+        assert edition != 'SPECIAL EDITION'
+
 
 # ─── Extended Edition — must still normalise to 'EXTENDED' ───
 


### PR DESCRIPTION
## Summary

- Merges 6 upstream commits from Audionut/Upload-Assistant into the fork's master
- All conflicts resolved: source files take upstream, README retains fork banner

## Upstream changes included

- `readme`: development freeze notice + upbrr link
- `fix(edition)`: ignore sole IMDb edition (`imdb_edition_count > 1` guard)
- `fix(tvdb)`: don't rely on slug — use `_series_translation_metadata` / `_translated_series_name`
- `PTP`: fix poster rehosting (`rehost_poster_to_selected_host`)
- `fix(trackers/IS)`: successful upload detection
- `NBL`: fix ignoredupes (`'1'` instead of `'on'`)

## Conflict resolution

| File | Decision |
|------|----------|
| `README.md` | Kept fork banner + added upstream content below |
| `src/edition.py` | Took upstream (bug fix) |
| `src/imdb.py` | Took upstream (adds `edition_count` field) |
| `src/metadata_searching.py` | Took upstream (refactor to `_apply_tvdb_series_metadata`) |
| `src/prep.py` | Took upstream (leading-article guard) |
| `src/trackers/NBL.py` | Took upstream (ignoredupes fix) |
| `src/trackers/PTP.py` | Took upstream (poster rehosting fix) |
| `src/tvdb.py` | Took upstream (slug-free series name resolution) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added flexible upload success validation supporting multiple success indicators for tracker uploads.
  * Introduced poster rehosting functionality for PTP with intelligent host selection and fallback support.
  * Enhanced TVDB metadata handling with improved series title and year extraction.

* **Bug Fixes**
  * Improved IMDb edition detection logic for more accurate media categorization.
  * Fixed NBL upload payload configuration.

* **Documentation**
  * Updated README with reference to related project repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->