### PR TITLE
fix(trackers): G3MINI WEB label and C411 unattended slot skip

### DIFF
--- a/src/trackers/C411.py
+++ b/src/trackers/C411.py
@@ -1390,6 +1390,11 @@ class C411(FrenchTrackerMixin):
         Optional fields: options, uploaderNote, tmdbData, rawgData
         """
 
+        if meta.get("unattended", False) and meta.get("_c411_slot_occupied", False):
+            console.print("[yellow]C411: slot already taken — skipping in unattended mode[/yellow]")
+            meta["tracker_status"][self.tracker]["status_message"] = "slot occupied — skipped in unattended mode"
+            return False
+
         common = COMMON(config=self.config)
 
         # If NFO file exist, include it in torrent file by recreate .torrent
@@ -1840,6 +1845,8 @@ class C411(FrenchTrackerMixin):
             meta["_corrective_slot_warning"] = True
         else:
             meta.pop("_corrective_slot_warning", None)
+
+        meta["_c411_slot_occupied"] = len(final_dupes) > 0
 
         return final_dupes
 

--- a/src/trackers/C411.py
+++ b/src/trackers/C411.py
@@ -1390,7 +1390,7 @@ class C411(FrenchTrackerMixin):
         Optional fields: options, uploaderNote, tmdbData, rawgData
         """
 
-        if meta.get("unattended", False) and meta.get("_c411_slot_occupied", False):
+        if meta.get("unattended", False) and meta.get("_c411_slot_occupied", False) and not self._is_corrective_version_meta(meta):
             console.print("[yellow]C411: slot already taken — skipping in unattended mode[/yellow]")
             meta["tracker_status"][self.tracker]["status_message"] = "slot occupied — skipped in unattended mode"
             return False
@@ -1846,7 +1846,7 @@ class C411(FrenchTrackerMixin):
         else:
             meta.pop("_corrective_slot_warning", None)
 
-        meta["_c411_slot_occupied"] = len(final_dupes) > 0
+        meta["_c411_slot_occupied"] = len(final_dupes) > 0 and not is_corrective
 
         return final_dupes
 

--- a/src/trackers/G3MINI.py
+++ b/src/trackers/G3MINI.py
@@ -26,7 +26,7 @@ class G3MINI(FrenchTrackerMixin, UNIT3D):
         self.source_flag = "G3MINI"
         pass
 
-    WEB_LABEL: str = "WEB-DL"
+    WEB_LABEL: str = "WEB"
 
     async def get_category_id(self, meta: dict[str, Any], category: str = "", reverse: bool = False, mapping_only: bool = False) -> dict[str, str]:
         category_id = {
@@ -273,7 +273,7 @@ class G3MINI(FrenchTrackerMixin, UNIT3D):
             elif type == "ENCODE":  # Encode
                 name = f"{title} {year} {edition} {repack} {language} {resolution} {uhd} {source} {hybrid} {hdr} {audio} {video_encode}"
             elif type == "WEBDL":  # WEB-DL
-                name = f"{title} {year} {edition} {repack} {language} {resolution} {uhd} {service} WEB-DL {hybrid} {hdr} {audio} {video_encode}"
+                name = f"{title} {year} {edition} {repack} {language} {resolution} {uhd} {service} {self.WEB_LABEL} {hybrid} {hdr} {audio} {video_encode}"
             elif type == "WEBRIP":  # WEBRip
                 name = f"{title} {year} {edition} {repack} {language} {resolution} {uhd} {service} WEBRip {hybrid} {hdr} {audio} {video_encode}"
             elif type == "HDTV":  # HDTV
@@ -296,7 +296,7 @@ class G3MINI(FrenchTrackerMixin, UNIT3D):
             elif type == "ENCODE":  # Encode
                 name = f"{title} {year} {season_ep} {part} {edition} {repack} {language} {resolution} {uhd} {source} {hybrid} {hdr} {audio} {video_encode}"  # SOURCE
             elif type == "WEBDL":  # WEB-DL
-                name = f"{title} {year} {season_ep} {part} {edition} {repack} {language} {resolution} {uhd} {service} WEB-DL {hybrid} {hdr} {audio} {video_encode}"
+                name = f"{title} {year} {season_ep} {part} {edition} {repack} {language} {resolution} {uhd} {service} {self.WEB_LABEL} {hybrid} {hdr} {audio} {video_encode}"
             elif type == "WEBRIP":  # WEBRip
                 name = f"{title} {year} {season_ep} {part} {edition} {repack} {language} {resolution} {uhd} {service} WEBRip {hybrid} {hdr} {audio} {video_encode}"
             elif type == "HDTV":  # HDTV


### PR DESCRIPTION
## Summary

- **G3MINI** (`src/trackers/G3MINI.py`): `WEB_LABEL` was `"WEB-DL"` but G3MINI convention is `"WEB"`. Both WEBDL format strings in `get_name()` hardcoded the literal `WEB-DL` instead of using `self.WEB_LABEL`, so fixing the constant alone had no effect. Both the constant and both f-strings are now corrected.
- **C411** (`src/trackers/C411.py`): In unattended mode with `--dupe`, the dupe gate in `uphelper.py` is bypassed, so a slot-occupied release could still reach `upload()` and land in C411's pending review queue. `upload()` now checks `_c411_slot_occupied` (set by `search_existing`) and bails early with a clear message.

## Test plan

- [ ] 1280 existing tests pass (`pytest tests/ -x -q`)
- [ ] G3MINI WEBDL name no longer contains `WEB-DL` — `WEB_LABEL = "WEB"` flows through both MOVIE and TV format strings
- [ ] C411 upload in unattended mode with a slot-occupied release returns `False` and logs "slot already taken — skipping in unattended mode"

Closes bd#5zc, bd#r4x

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * C411: Enhanced slot detection to prevent unnecessary upload attempts when content is already present.

* **Changes**
  * G3MINI: Updated web release label naming convention for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->