### PR TITLE
fix(G3MINI): merge codec abbreviation with channel layout (DDP5.1 not DDP.5.1)

### DIFF
--- a/src/trackers/G3MINI.py
+++ b/src/trackers/G3MINI.py
@@ -331,5 +331,10 @@ class G3MINI(FrenchTrackerMixin, UNIT3D):
         dot_name = re.sub(r"\.(-\.)+", ".", dot_name)
         # Collapse consecutive dots and strip boundary dots
         dot_name = re.sub(r"\.{2,}", ".", dot_name)
+        # G3MINI convention: codec abbreviation directly concatenated with channel
+        # layout — no dot separator.  "DDP.5.1" → "DDP5.1", "DTS.5.1" → "DTS5.1".
+        # DTS-HD MA is unaffected: "DTS" is followed by "-" not ".", so \bDTS\. never
+        # matches inside "DTS-HD.MA.5.1".
+        dot_name = re.sub(r"\b(DDP|EAC3|DD|DTS|FLAC|AAC|MP3|Opus)\.(\d+\.\d+)", r"\1\2", dot_name, flags=re.IGNORECASE)
         dot_name = dot_name.strip(".")
         return {"name": dot_name}


### PR DESCRIPTION
## Summary

- **Root cause**: `codec_info_from_track` returns `DDP 5.1` (space between codec and channels). G3MINI's `get_name` calls `replace_spaces_with_dots` on the whole assembled name, turning that space into a dot → `DDP.5.1`. G3MINI scene convention is `DDP5.1` (no separator).
- **Fix**: post-process the final dot-name with a regex that merges simple codec abbreviations (`DDP`, `DD`, `DTS`, `EAC3`, `FLAC`, `AAC`, `MP3`, `Opus`) directly with their channel layout (`\d+\.\d+`). `DTS-HD.MA.5.1` is unaffected — `DTS` is followed by `-` in the name so `\bDTS\.` never matches.

## Examples

| Before | After |
|--------|-------|
| `Hamnet.2025.MULTi.VF2.1080p.WEB.DDP.5.1.H264-SUPPLY` | `Hamnet.2025.MULTi.VF2.1080p.WEB.DDP5.1.H264-SUPPLY` |
| `Movie.2025.MULTi.VF2.1080p.WEB.DDP.5.1.Atmos.H265-GROUP` | `Movie.2025.MULTi.VF2.1080p.WEB.DDP5.1.Atmos.H265-GROUP` |
| `Movie.2025.MULTi.VF2.1080p.WEB.DTS-HD.MA.5.1.H265-GROUP` | unchanged ✓ |

## Test plan

- [ ] 1280 existing tests pass (`pytest tests/ -x -q`)
- [ ] G3MINI WEBDL name with DDP 5.1 audio generates `DDP5.1` not `DDP.5.1`
- [ ] DTS-HD MA 5.1 names are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refined audio codec naming format to remove unnecessary separators between codec abbreviations and channel layout information, resulting in cleaner and more consistent content names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->