### PR TITLE
feat(IHD): add non-English audio language tag before resolution in release name

### DIFF
--- a/src/trackers/IHD.py
+++ b/src/trackers/IHD.py
@@ -268,6 +268,12 @@ class IHD(UNIT3D):
         if not meta.get("language_checked", False):
             await languages_manager.process_desc_language(meta, tracker=self.tracker)
 
+        audio_languages: list[str] = meta.get("audio_languages") or []
+        if audio_languages and not await languages_manager.has_english_language(audio_languages):
+            foreign_lang = audio_languages[0].upper()
+            if meta.get("is_disc") != "BDMV":
+                ihd_name = ihd_name.replace(meta["resolution"], f"{foreign_lang} {meta['resolution']}", 1)
+
         return {"name": ihd_name}
 
     async def get_additional_files(self, meta: Meta) -> dict[str, tuple[str, bytes, str]]:


### PR DESCRIPTION
## Summary

- IHD now prepends the primary non-English audio language (uppercased) before the resolution token in the generated release name
- Example: `Movie.Title.2025.1080p.WEB-DL...` → `Movie.Title.2025.FRENCH.1080p.WEB-DL...`
- BDMV discs are excluded (consistent with existing disc exemptions in IHD)
- Mirrors the exact same pattern already used by A4K and AITHER trackers

## Test plan

- [ ] Upload a release with French-only audio → name should contain `FRENCH 1080p` (or relevant resolution)
- [ ] Upload a release with English audio → name unchanged
- [ ] Upload a BDMV disc with non-English audio → name unchanged (BDMV guard)

Closes bd/Upload-Assistant-8gq

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Refined release name formatting to remove separators between audio codec abbreviations and channel information (e.g., `DDP.5.1` now displays as `DDP5.1`)
  * Enhanced release naming to include foreign language indicators when English audio is unavailable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->