### PR TITLE
chore: ignore bin/MI/* (runtime-downloaded mediainfo binaries)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ docker-compose.yml
 Dockerfile
 bin/mkbrr/*
 bin/bdinfo/*
+bin/MI/*
 *.mkv
 .vscode/
 __pycache__/


### PR DESCRIPTION
## Summary

- Adds `bin/MI/*` to `.gitignore`, consistent with the existing `bin/mkbrr/*` and `bin/bdinfo/*` entries
- `bin/MI/linux/` contains `mediainfo` and `libmediainfo.so.0` (~28 MB total), downloaded automatically at runtime — they should not be tracked in git

🤖 Generated with [Claude Code](https://claude.com/claude-code)