### PR TITLE
fix(NXM): align search_existing with NXM naming pattern + screenshots order

### DIFF
--- a/src/trackers/NXM.py
+++ b/src/trackers/NXM.py
@@ -892,28 +892,31 @@ class NXM(FrenchTrackerMixin):
         if not fr_title:
             fr_title = await self._get_french_title(meta)
         year = meta.get("year", "")
-        tag = meta.get("tag", "")
+        resolution = meta.get("resolution", "")
 
         # Normalize for relevance filtering
         def _normalize(s: str) -> str:
             return re.sub(r"[^a-z0-9]", "", unidecode(s).lower())
 
-        # Build the list of search queries — original-language title first
+        # Build search queries using NXM's naming pattern (Titre Année Résolution)
+        # so the API returns results that match the specific quality being uploaded.
+        suffix = " ".join(p for p in [str(year), resolution] if p)
+
         search_queries: list[str] = []
         is_original_french = str(meta.get("original_language", "")).lower() == "fr"
 
         if is_original_french:
             # Original is French → search FR first, then EN as complement
             if fr_title:
-                search_queries.append(f"{fr_title} {tag}".strip())
+                search_queries.append(f"{fr_title} {suffix}".strip())
             if title and _normalize(title) != _normalize(fr_title or ""):
-                search_queries.append(f"{title} {tag}".strip())
+                search_queries.append(f"{title} {suffix}".strip())
         else:
             # Original is not French → search EN first, then FR as complement
             if title:
-                search_queries.append(f"{title} {tag}".strip())
+                search_queries.append(f"{title} {suffix}".strip())
             if fr_title and _normalize(fr_title) != _normalize(title or ""):
-                search_queries.append(f"{fr_title} {tag}".strip())
+                search_queries.append(f"{fr_title} {suffix}".strip())
 
         if not search_queries:
             return []
@@ -921,6 +924,7 @@ class NXM(FrenchTrackerMixin):
         title_norm = _normalize(title)
         fr_title_norm = _normalize(fr_title) if fr_title else ""
         year_str = str(year).strip()
+        resolution_norm = _normalize(resolution)
         seen_names: set[str] = set()
 
         try:
@@ -969,7 +973,7 @@ class NXM(FrenchTrackerMixin):
                         if name_norm in seen_names:
                             continue
 
-                        # Filter: the result must contain the title (EN or FR) AND year to be relevant
+                        # Filter: result must contain title (EN or FR), year, and resolution
                         title_match = title_norm and title_norm in name_norm
                         fr_title_match = fr_title_norm and fr_title_norm in name_norm
                         if not title_match and not fr_title_match:
@@ -980,6 +984,11 @@ class NXM(FrenchTrackerMixin):
                         if year_str and year_str not in name and meta.get("category") != "TV":
                             if meta.get("debug"):
                                 console.print(f"[dim]NXM dupe skip (year mismatch): {name}[/dim]")
+                            continue
+                        # Resolution must match — 1080p and 2160p are distinct uploads on NXM
+                        if resolution_norm and resolution_norm not in name_norm:
+                            if meta.get("debug"):
+                                console.print(f"[dim]NXM dupe skip (resolution mismatch): {name}[/dim]")
                             continue
 
                         seen_names.add(name_norm)

--- a/src/trackers/NXM.py
+++ b/src/trackers/NXM.py
@@ -573,6 +573,16 @@ class NXM(FrenchTrackerMixin):
                 chap_body = "\n".join(f"{tc[:8]} — {name}" for tc, name in chapters)
                 out.append(f"[spoiler=Liste des chapitres]{chap_body}[/spoiler]")
 
+        # ── Notes ─────────────────────────────────────────────────────────
+        out.append("")
+        out.append(f"[img]{_B}/notes.svg[/img]")
+        out.append("")
+        note = self.config["TRACKERS"].get(self.tracker, {}).get("note", "Bon visionnage à tous, et vive Nexum !")
+        personal_note = await DescriptionBuilder(self.tracker, self.config).get_personal_note(meta)
+        if personal_note:
+            note = f"{note}\n{personal_note}"
+        out.append(note)
+
         # ── Captures d'écran ──────────────────────────────────────────────
         include_screens = self.config["TRACKERS"].get(self.tracker, {}).get("include_screenshots", False)
         image_list: list[dict[str, Any]] = meta.get("image_list", []) if include_screens else []
@@ -585,17 +595,8 @@ class NXM(FrenchTrackerMixin):
                     img_lines.append(f"[url={web_url}][img]{raw_url}[/img][/url]" if web_url else f"[img]{raw_url}[/img]")
             if img_lines:
                 out.append("")
+                out.append("")
                 out.append(f"[spoiler=Captures d'écran]\n{chr(10).join(img_lines)}\n[/spoiler]")
-
-        # ── Notes ─────────────────────────────────────────────────────────
-        out.append("")
-        out.append(f"[img]{_B}/notes.svg[/img]")
-        out.append("")
-        note = self.config["TRACKERS"].get(self.tracker, {}).get("note", "Bon visionnage à tous, et vive Nexum !")
-        personal_note = await DescriptionBuilder(self.tracker, self.config).get_personal_note(meta)
-        if personal_note:
-            note = f"{note}\n{personal_note}"
-        out.append(note)
 
         # ── Signature UA ──────────────────────────────────────────────────
         ua_sig = meta.get("ua_signature", "Created by Upload Assistant")


### PR DESCRIPTION
## Summary

**Screenshots order** (from #259, now rebased here after merge):
- Screenshots section moved below Notes
- Two blank lines before `[spoiler=Captures d'écran]`

**search_existing alignment with NXM naming pattern:**
- Search queries now use `Titre Année Résolution` instead of `Titre -GROUP`, matching NXM's own release format (`Titre.Année.Langue.Résolution.Source.Codec-TEAM`)
- Post-search filter gains a **resolution check**: a 1080p and a 4K release of the same title no longer flag each other as duplicates

## Test plan

- [ ] Dry-run a 1080p upload — confirm it finds an existing 1080p dupe but not a 4K version of the same title
- [ ] Dry-run a French-original title — confirm both FR and EN search queries fire, with the right one first
- [ ] Dry-run a TV episode — confirm year-skip logic still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate content detection to better distinguish between different video resolutions when searching

* **Refactor**
  * Adjusted description formatting to reorganize content sections for better presentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->