### PR TITLE
fix(TORR9): align search_existing with tracker rules

### DIFF
--- a/src/trackers/TORR9.py
+++ b/src/trackers/TORR9.py
@@ -80,6 +80,45 @@ class TORR9(FrenchTrackerMixin):
     # TORR9 accepts NOTAG
     notag_label: str = "NoTag"
 
+    # TORR9 internal production groups — existing releases from these groups
+    # always block the upload, even if _check_french_lang_dupes would clear them.
+    # These are NOT in banned_groups: we block reposts *of* their releases, not
+    # uploads *by* these groups.
+    _TORR9_INTERNAL_GROUPS: frozenset[str] = frozenset(
+        {
+            "Blade56",
+            "Blap",
+            "Floppy",
+            "KAF",
+            "S7KO",
+            "SUB",
+            "Tsundere-Raws",
+            "ZiGZaG",
+        }
+    )
+
+    def _check_torr9_specific_dupes(
+        self,
+        all_dupes: list[dict[str, Any]],
+        filtered: list[dict[str, Any]],
+        meta: dict[str, Any],
+    ) -> list[dict[str, Any]]:
+        """Re-inject dupes from TORR9 internal groups that block all reposts."""
+        result = list(filtered)
+        for dupe in all_dupes:
+            if not isinstance(dupe, dict):
+                continue
+            name = dupe.get("name", "")
+            m = re.search(r"-([A-Za-z0-9][A-Za-z0-9\-]*)\s*$", name.replace(".", " "))
+            group = m.group(1) if m else ""
+            if group in self._TORR9_INTERNAL_GROUPS:
+                if dupe not in result:
+                    result.append(dupe)
+                flags: list[str] = dupe.setdefault("flags", [])
+                if "torr9_internal" not in flags:
+                    flags.append("torr9_internal")
+        return result
+
     # ──────────────────────────────────────────────────────────
     #  Authentication — login to obtain Bearer JWT
     # ──────────────────────────────────────────────────────────
@@ -959,27 +998,41 @@ class TORR9(FrenchTrackerMixin):
         if not fr_title:
             fr_title = await self._get_french_title(meta)
         year = meta.get("year", "")
+        resolution = meta.get("resolution", "")
+        group = self._get_release_group(meta)
 
-        # Normalize for relevance filtering
+        # Normalize for relevance filtering (strip all non-alphanumeric)
         def _normalize(s: str) -> str:
             return re.sub(r"[^a-z0-9]", "", unidecode(s).lower())
 
-        # Build the list of search queries — original-language title first
+        # Clean a title for use in the API query: strip accents, parentheses,
+        # and extra punctuation so the TORR9 search API can match stored names.
+        def _clean_query(s: str) -> str:
+            return re.sub(r"[^a-zA-Z0-9 ]", " ", unidecode(s)).split()
+
+        def _q(s: str) -> str:
+            return " ".join(_clean_query(s))
+
+        # Build queries using TORR9's naming pattern (Titre Année Résolution Groupe)
+        # TORR9 allows the same release from different groups, so the group must be
+        # included to avoid false-positive dupe blocks.
+        suffix = " ".join(p for p in [str(year), resolution, group] if p)
+
         search_queries: list[str] = []
         is_original_french = str(meta.get("original_language", "")).lower() == "fr"
 
         if is_original_french:
             # Original is French → search FR first, then EN as complement
             if fr_title:
-                search_queries.append(f"{fr_title} {year}".strip())
+                search_queries.append(f"{_q(fr_title)} {suffix}".strip())
             if title and _normalize(title) != _normalize(fr_title or ""):
-                search_queries.append(f"{title} {year}".strip())
+                search_queries.append(f"{_q(title)} {suffix}".strip())
         else:
             # Original is not French → search EN first, then FR as complement
             if title:
-                search_queries.append(f"{title} {year}".strip())
+                search_queries.append(f"{_q(title)} {suffix}".strip())
             if fr_title and _normalize(fr_title) != _normalize(title or ""):
-                search_queries.append(f"{fr_title} {year}".strip())
+                search_queries.append(f"{_q(fr_title)} {suffix}".strip())
 
         if not search_queries:
             return []
@@ -987,6 +1040,8 @@ class TORR9(FrenchTrackerMixin):
         title_norm = _normalize(title)
         fr_title_norm = _normalize(fr_title) if fr_title else ""
         year_str = str(year).strip()
+        resolution_norm = _normalize(resolution)
+        group_norm = _normalize(group)
         seen_names: set[str] = set()
 
         try:
@@ -1032,7 +1087,7 @@ class TORR9(FrenchTrackerMixin):
                         if name_norm in seen_names:
                             continue
 
-                        # Filter: the result must contain the title (EN or FR) AND year to be relevant
+                        # Filter: result must contain title (EN or FR), year, resolution, group
                         title_match = title_norm and title_norm in name_norm
                         fr_title_match = fr_title_norm and fr_title_norm in name_norm
                         if not title_match and not fr_title_match:
@@ -1043,6 +1098,16 @@ class TORR9(FrenchTrackerMixin):
                         if year_str and year_str not in name and meta.get("category") != "TV":
                             if meta.get("debug"):
                                 console.print(f"[dim]TORR9 dupe skip (year mismatch): {name}[/dim]")
+                            continue
+                        # Resolution must match — TORR9 allows different qualities per title
+                        if resolution_norm and resolution_norm not in name_norm:
+                            if meta.get("debug"):
+                                console.print(f"[dim]TORR9 dupe skip (resolution mismatch): {name}[/dim]")
+                            continue
+                        # Group must match — TORR9 allows same quality from different groups
+                        if group_norm and group_norm not in name_norm:
+                            if meta.get("debug"):
+                                console.print(f"[dim]TORR9 dupe skip (group mismatch): {name}[/dim]")
                             continue
 
                         seen_names.add(name_norm)
@@ -1070,7 +1135,8 @@ class TORR9(FrenchTrackerMixin):
         if dupes and token:
             await self._enrich_with_files(dupes, token, debug=bool(meta.get("debug")))
 
-        return await self._check_french_lang_dupes(dupes, meta)
+        filtered = await self._check_french_lang_dupes(dupes, meta)
+        return self._check_torr9_specific_dupes(dupes, filtered, meta)
 
     async def _enrich_with_files(self, dupes: list[dict[str, Any]], token: str, *, debug: bool = False) -> None:
         """Fetch file lists for each dupe entry via GET /api/v1/torrents/{id}/files.

--- a/tests/test_torr9.py
+++ b/tests/test_torr9.py
@@ -831,10 +831,12 @@ class TestSearchExisting:
         t._bearer_token = 'test-token'  # skip login
         mock_response = MagicMock()
         mock_response.status_code = 200
+        # Names must include the group tag (-Troxy) and the resolution (1080p)
+        # to pass the post-search resolution+group filters added in the dupe check.
         mock_response.json.return_value = {
             'torrents': [
-                {'title': 'Le.Prenom.2012.MULTi.1080p', 'id': 42, 'file_size_bytes': 5000000000},
-                {'title': 'Le.Prenom.2012.FRENCH.720p', 'id': 43, 'file_size_bytes': 3000000000},
+                {'title': 'Le.Prenom.2012.MULTi.1080p.WEB.x264-Troxy', 'id': 42, 'file_size_bytes': 5000000000},
+                {'title': 'Le.Prenom.2012.FRENCH.1080p.WEB.x264-Troxy', 'id': 43, 'file_size_bytes': 3000000000},
             ],
             'total_count': 2,
         }
@@ -849,7 +851,7 @@ class TestSearchExisting:
             dupes = _run(t.search_existing(_meta_base(), ''))
 
         assert len(dupes) == 2
-        assert dupes[0]['name'] == 'Le.Prenom.2012.MULTi.1080p'
+        assert dupes[0]['name'] == 'Le.Prenom.2012.MULTi.1080p.WEB.x264-Troxy'
         assert dupes[0]['id'] == 42
         assert dupes[0]['size'] == 5000000000
 
@@ -1030,7 +1032,7 @@ class TestDupeRelevanceFilter:
         assert dupes == []
 
     def test_keeps_matching_titles(self):
-        """Results matching the title+year should be kept."""
+        """Results matching the title+year+resolution+group should be kept."""
         t = TORR9(_config())
         t._bearer_token = 'test-token'
         meta = _meta_base(title='Inception', year='2010')
@@ -1038,9 +1040,9 @@ class TestDupeRelevanceFilter:
         mock_response.status_code = 200
         mock_response.json.return_value = {
             'data': [
-                {'title': 'Inception.2010.MULTi.2160p.REMUX', 'id': 10},
-                {'title': 'A.Fistful.of.Dollars.1964.MULTi.2160p', 'id': 1},
-                {'title': 'Inception.2010.FRENCH.1080p.WEB-DL', 'id': 11},
+                {'title': 'Inception.2010.MULTi.1080p.BluRay.x264-Troxy', 'id': 10},
+                {'title': 'A.Fistful.of.Dollars.1964.MULTi.1080p.x264-Troxy', 'id': 1},
+                {'title': 'Inception.2010.FRENCH.1080p.WEB.x264-Troxy', 'id': 11},
             ]
         }
 
@@ -1054,8 +1056,8 @@ class TestDupeRelevanceFilter:
             dupes = _run(t.search_existing(meta, ''))
 
         assert len(dupes) == 2
-        assert dupes[0]['name'] == 'Inception.2010.MULTi.2160p.REMUX'
-        assert dupes[1]['name'] == 'Inception.2010.FRENCH.1080p.WEB-DL'
+        assert dupes[0]['name'] == 'Inception.2010.MULTi.1080p.BluRay.x264-Troxy'
+        assert dupes[1]['name'] == 'Inception.2010.FRENCH.1080p.WEB.x264-Troxy'
 
     def test_accent_insensitive_match(self):
         """French titles with accents should match their dot-separated versions."""
@@ -1066,7 +1068,7 @@ class TestDupeRelevanceFilter:
         mock_response.status_code = 200
         mock_response.json.return_value = {
             'data': [
-                {'title': 'Le.Prenom.2012.FRENCH.1080p', 'id': 50},
+                {'title': 'Le.Prenom.2012.FRENCH.1080p.WEB.x264-Troxy', 'id': 50},
             ]
         }
 
@@ -1098,7 +1100,7 @@ class TestDupeRelevanceFilter:
         resp_en.status_code = 200
         resp_en.json.return_value = {
             'data': [
-                {'title': 'The.Sixth.Sense.1999.MULTi.2160p.REMUX', 'id': 100},
+                {'title': 'The.Sixth.Sense.1999.MULTi.1080p.BluRay.x264-Troxy', 'id': 100},
             ]
         }
         # Second call (FR title) → returns 1 result under French name
@@ -1106,7 +1108,7 @@ class TestDupeRelevanceFilter:
         resp_fr.status_code = 200
         resp_fr.json.return_value = {
             'data': [
-                {'title': 'Sixieme.Sens.1999.FRENCH.1080p', 'id': 101},
+                {'title': 'Sixieme.Sens.1999.FRENCH.1080p.WEB.x264-Troxy', 'id': 101},
             ]
         }
 
@@ -1122,8 +1124,8 @@ class TestDupeRelevanceFilter:
         # Both results should be present
         assert len(dupes) == 2
         names = [d['name'] for d in dupes]
-        assert 'The.Sixth.Sense.1999.MULTi.2160p.REMUX' in names
-        assert 'Sixieme.Sens.1999.FRENCH.1080p' in names
+        assert 'The.Sixth.Sense.1999.MULTi.1080p.BluRay.x264-Troxy' in names
+        assert 'Sixieme.Sens.1999.FRENCH.1080p.WEB.x264-Troxy' in names
 
     def test_bilingual_search_deduplicates(self):
         """If both queries return the same torrent, it should appear only once."""
@@ -1140,7 +1142,7 @@ class TestDupeRelevanceFilter:
         resp.status_code = 200
         resp.json.return_value = {
             'data': [
-                {'title': 'Inception.2010.MULTi.2160p', 'id': 200},
+                {'title': 'Inception.2010.MULTi.1080p.BluRay.x264-Troxy', 'id': 200},
             ]
         }
 
@@ -1174,7 +1176,7 @@ class TestDupeRelevanceFilter:
         resp_fr.status_code = 200
         resp_fr.json.return_value = {
             'data': [
-                {'title': 'Intouchables.2011.FRENCH.1080p', 'id': 300},
+                {'title': 'Intouchables.2011.FRENCH.1080p.WEB.x264-Troxy', 'id': 300},
             ]
         }
         resp_en = MagicMock()
@@ -1205,6 +1207,7 @@ class TestDupeRelevanceFilter:
             frtitle='Fais pas ci fais pas ça',
             year='2007',
             original_language='fr',
+            tag='-FW',
         )
 
         resp = MagicMock()


### PR DESCRIPTION
## Summary

- **Resolution + group filtering**: search queries now use `Titre Année Résolution Groupe` and the post-filter rejects results with a different resolution or group — TORR9 allows the same release from different groups, so the group filter is essential to avoid false-positive dupe blocks
- **Clean query titles**: strip accents, parentheses, and punctuation from titles before sending to the TORR9 search API (`"Éducation"` → `"Education"`) so stored names are reliably matched
- **Internal group block** (`_TORR9_INTERNAL_GROUPS`): releases from `Blade56`, `Blap`, `Floppy`, `KAF`, `S7KO`, `SUB`, `Tsundere-Raws`, `ZiGZaG` always block uploads, even if `_check_french_lang_dupes` would otherwise clear them — same pattern as `TOS._check_tos_specific_dupes`

## Test plan

- [ ] Dry-run upload from group `SUPPLY` when TORR9 has the same title/resolution from `KAF` → upload should be blocked (`torr9_internal` flag)
- [ ] Dry-run upload from group `SUPPLY` when TORR9 has same title/resolution from `OTHER-GROUP` → should pass (different group, not internal)
- [ ] Dry-run with accented French title (e.g. "Les Misérables") → confirm API query strips accent correctly
- [ ] Dry-run TV episode → confirm year-skip logic still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)