### PR TITLE
Fix/c411 webdl slot a4k unattended

### DIFF
--- a/src/trackers/A4K.py
+++ b/src/trackers/A4K.py
@@ -150,5 +150,6 @@ class A4K(UNIT3D):
             foreign_lang = audio_languages[0].upper()
             if meta.get("is_disc") != "BDMV":
                 a4k_name = a4k_name.replace(meta["resolution"], f"{foreign_lang} {meta['resolution']}", 1)
-        console.print(f"[yellow]Generated name for {self.tracker}: [bold]{a4k_name}[/bold][/yellow]")
+        if not meta.get("unattended", False):
+            console.print(f"[yellow]Generated name for {self.tracker}: [bold]{a4k_name}[/bold][/yellow]")
         return {"name": a4k_name}

--- a/src/trackers/C411.py
+++ b/src/trackers/C411.py
@@ -529,7 +529,7 @@ class C411(FrenchTrackerMixin):
         # Restrict the ambiguous ".WEB." token to the technical portion (post-year) to
         # avoid matching it in movie titles such as "The.Girl.in.the.Spider.s.WEB.2018...".
         # WEBRIP / WEB.RIP / WEB.DL / WEBDL are unambiguous and stay on the full string.
-        _year_m = re.search(r'\.(19|20)\d{2}\.', n)
+        _year_m = re.search(r"\.(19|20)\d{2}\.", n)
         _tech = n[_year_m.start() :] if _year_m else n
         is_web = "WEBRIP" in n or "WEB.RIP" in n or "WEB.DL" in n or "WEBDL" in n or ".WEB." in _tech
         is_4klight = "4KLIGHT" in n

--- a/src/trackers/C411.py
+++ b/src/trackers/C411.py
@@ -526,7 +526,12 @@ class C411(FrenchTrackerMixin):
         is_remux = "REMUX" in n
         is_bdmv = "BDMV" in n or "BD.FULL" in n or "COMPLETE.BLURAY" in n
         is_iso = "ISO" in n.split(".")
-        is_web = "WEBRIP" in n or "WEB.RIP" in n or "WEB.DL" in n or "WEBDL" in n or ".WEB." in n
+        # Restrict the ambiguous ".WEB." token to the technical portion (post-year) to
+        # avoid matching it in movie titles such as "The.Girl.in.the.Spider.s.WEB.2018...".
+        # WEBRIP / WEB.RIP / WEB.DL / WEBDL are unambiguous and stay on the full string.
+        _year_m = re.search(r'\.(19|20)\d{2}\.', n)
+        _tech = n[_year_m.start() :] if _year_m else n
+        is_web = "WEBRIP" in n or "WEB.RIP" in n or "WEB.DL" in n or "WEBDL" in n or ".WEB." in _tech
         is_4klight = "4KLIGHT" in n
 
         # Codec

--- a/src/trackers/C411.py
+++ b/src/trackers/C411.py
@@ -1820,11 +1820,29 @@ class C411(FrenchTrackerMixin):
 
         # ── Lossy / Lossless coexistence (permanent) ──
         # A lossy version and a lossless version can always coexist in the same slot.
+        # Exception: for VOSTFR uploads, always keep FR-audio releases regardless of
+        # lossless/lossy — they must reach _check_french_lang_dupes to be flagged as
+        # french_lang_supersede. Without this, a MULTI EAC3 release would be silently
+        # removed before the language-hierarchy check can see it.
         if dupes:
-            upload_audio = str(meta.get("audio", ""))
-            upload_lossless = self._is_lossless_audio(upload_audio)
+            upload_audio_str = str(meta.get("audio", ""))
+            upload_lossless = self._is_lossless_audio(upload_audio_str)
+            upload_audio_tag = await self._build_audio_string(meta)
+            _, upload_lang_level = self._extract_french_lang_tag(upload_audio_tag)
+            # Level 1=VO, 2=VOSTFR, >=3=FR audio, 0=no French tag (e.g. English release).
+            # Only treat the upload as VOSTFR when it carries an explicit VO/VOSTFR tag.
+            is_vostfr_upload = 1 <= upload_lang_level < 3
             before = len(dupes)
-            dupes = [d for d in dupes if self._is_lossless_from_name(d.get("name", "")) == upload_lossless]
+
+            def _keep_dupe(d: dict) -> bool:
+                name = d.get("name", "")
+                if is_vostfr_upload:
+                    _, name_level = self._extract_french_lang_tag(name)
+                    if name_level >= 3:
+                        return True  # FR-audio: let _check_french_lang_dupes handle it
+                return self._is_lossless_from_name(name) == upload_lossless
+
+            dupes = [d for d in dupes if _keep_dupe(d)]
             if meta.get("debug") and len(dupes) < before:
                 kind = "lossless" if upload_lossless else "lossy"
                 opposite = "lossy" if upload_lossless else "lossless"

--- a/src/trackers/C411.py
+++ b/src/trackers/C411.py
@@ -445,8 +445,8 @@ class C411(FrenchTrackerMixin):
         uuid = str(meta.get("uuid", "")).lower()
         is_disc = str(meta.get("is_disc", ""))
         is_4klight = "4klight" in uuid
-        # Source-based distinction: BluRay (encode from disc) vs WEB
-        is_webrip = release_type == "WEBRIP"
+        # Source-based distinction: BluRay (encode from disc) vs WEB (WEBDL and WEBRIP both map to WR slots)
+        is_web = release_type in ("WEBRIP", "WEBDL")
 
         lossless = self._is_lossless_audio(audio)
         h264 = self._is_h264_codec(codec)
@@ -468,7 +468,7 @@ class C411(FrenchTrackerMixin):
 
         # ── COMPAT: H.264, 1080p, SDR, Lossy ──
         if h264 and not is_4k and not has_hdr:
-            if is_webrip:
+            if is_web:
                 return f"{prefix}COMPAT-WR"
             return f"{prefix}COMPAT-01"
 
@@ -478,13 +478,13 @@ class C411(FrenchTrackerMixin):
             if is_4k:
                 if is_4klight:
                     return f"{prefix}HCOPT-2160-4KL-{codec_suffix}"
-                if is_webrip:
+                if is_web:
                     if has_hdr:
                         return f"{prefix}HCOPT-2160-WR-{codec_suffix}-HDR"
                     return f"{prefix}HCOPT-2160-WR-{codec_suffix}"
                 return f"{prefix}HCOPT-2160-BD-{codec_suffix}"
             else:
-                if is_webrip:
+                if is_web:
                     return f"{prefix}HCOPT-1080-WR-{codec_suffix}"
                 return f"{prefix}HCOPT-1080-BD-{codec_suffix}"
 
@@ -495,14 +495,14 @@ class C411(FrenchTrackerMixin):
             if has_hdr:
                 return f"{prefix}OPTI-2160-HDR"
             else:
-                if is_webrip:
+                if is_web:
                     return f"{prefix}OPTI-2160-SDR-WR"
                 return f"{prefix}OPTI-2160-SDR-BD"
         else:
             # 1080p
             if has_hdr:
                 return f"{prefix}OPTI-1080-HDR"
-            if is_webrip:
+            if is_web:
                 return f"{prefix}OPTI-1080-SDR-WR"
             return f"{prefix}OPTI-1080-SDR-BD"
 
@@ -526,7 +526,7 @@ class C411(FrenchTrackerMixin):
         is_remux = "REMUX" in n
         is_bdmv = "BDMV" in n or "BD.FULL" in n or "COMPLETE.BLURAY" in n
         is_iso = "ISO" in n.split(".")
-        is_webrip = "WEBRIP" in n or "WEB.RIP" in n
+        is_web = "WEBRIP" in n or "WEB.RIP" in n or "WEB.DL" in n or "WEBDL" in n or ".WEB." in n
         is_4klight = "4KLIGHT" in n
 
         # Codec
@@ -557,7 +557,7 @@ class C411(FrenchTrackerMixin):
 
         # ── COMPAT: H.264, 1080p, SDR ──
         if h264 and not is_4k and not has_hdr:
-            return f"{prefix}COMPAT-WR" if is_webrip else f"{prefix}COMPAT-01"
+            return f"{prefix}COMPAT-WR" if is_web else f"{prefix}COMPAT-01"
 
         # ── HCOPT or OPTI ──
         if lossless or has_dv or av1:
@@ -566,13 +566,13 @@ class C411(FrenchTrackerMixin):
             if is_4k:
                 if is_4klight:
                     return f"{prefix}HCOPT-2160-4KL-{codec_suffix}"
-                if is_webrip:
+                if is_web:
                     if has_hdr:
                         return f"{prefix}HCOPT-2160-WR-{codec_suffix}-HDR"
                     return f"{prefix}HCOPT-2160-WR-{codec_suffix}"
                 return f"{prefix}HCOPT-2160-BD-{codec_suffix}"
             else:
-                if is_webrip:
+                if is_web:
                     return f"{prefix}HCOPT-1080-WR-{codec_suffix}"
                 return f"{prefix}HCOPT-1080-BD-{codec_suffix}"
 
@@ -583,13 +583,13 @@ class C411(FrenchTrackerMixin):
             if has_hdr:
                 return f"{prefix}OPTI-2160-HDR"
             else:
-                if is_webrip:
+                if is_web:
                     return f"{prefix}OPTI-2160-SDR-WR"
                 return f"{prefix}OPTI-2160-SDR-BD"
         else:
             if has_hdr:
                 return f"{prefix}OPTI-1080-HDR"
-            if is_webrip:
+            if is_web:
                 return f"{prefix}OPTI-1080-SDR-WR"
             return f"{prefix}OPTI-1080-SDR-BD"
 

--- a/src/trackers/NXM.py
+++ b/src/trackers/NXM.py
@@ -1050,7 +1050,7 @@ class NXM(FrenchTrackerMixin):
                             params={"q": search_term},
                         )
                     except Exception:  # noqa: BLE001
-                        continue
+                        continue  # nosec B112 — skip failed search queries gracefully
 
                     if response.status_code != 200:
                         continue

--- a/src/trackers/NXM.py
+++ b/src/trackers/NXM.py
@@ -929,6 +929,13 @@ class NXM(FrenchTrackerMixin):
         group_norm = _normalize(group)
         seen_names: set[str] = set()
 
+        # Detect VOSTFR upload early: for VOSTFR, we must also surface FR-audio
+        # releases from other groups (they supersede VOSTFR regardless of group).
+        # Level >= 3 means FR audio (VFF/VFI/VFQ/MULTI…); VOSTFR = level 2.
+        upload_audio = await self._build_audio_string(meta)
+        _, upload_lang_level = self._extract_french_lang_tag(upload_audio)
+        is_vostfr_upload = upload_lang_level < 3
+
         try:
             headers = {
                 "X-API-Key": self.api_key,
@@ -992,11 +999,19 @@ class NXM(FrenchTrackerMixin):
                             if meta.get("debug"):
                                 console.print(f"[dim]NXM dupe skip (resolution mismatch): {name}[/dim]")
                             continue
-                        # Group must match — NXM allows the same release from different groups
+                        # Group must match — NXM allows the same release from different groups.
+                        # Exception: for VOSTFR uploads, also keep non-same-group releases
+                        # that have FR audio (level >= 3), so _check_french_lang_dupes can
+                        # flag them as superseding dupes.
                         if group_norm and group_norm not in name_norm:
-                            if meta.get("debug"):
-                                console.print(f"[dim]NXM dupe skip (group mismatch): {name}[/dim]")
-                            continue
+                            keep = False
+                            if is_vostfr_upload:
+                                _, name_level = self._extract_french_lang_tag(name)
+                                keep = name_level >= 3
+                            if not keep:
+                                if meta.get("debug"):
+                                    console.print(f"[dim]NXM dupe skip (group mismatch): {name}[/dim]")
+                                continue
 
                         seen_names.add(name_norm)
                         dupes.append(

--- a/src/trackers/NXM.py
+++ b/src/trackers/NXM.py
@@ -899,25 +899,44 @@ class NXM(FrenchTrackerMixin):
         def _normalize(s: str) -> str:
             return re.sub(r"[^a-z0-9]", "", unidecode(s).lower())
 
+        # Detect VOSTFR upload early: for VOSTFR, we must surface FR-audio releases
+        # from other groups (they supersede VOSTFR regardless of group).
+        # Level >= 3 means FR audio (VFF/VFI/VFQ/MULTI…); VOSTFR = level 2.
+        upload_audio = await self._build_audio_string(meta)
+        _, upload_lang_level = self._extract_french_lang_tag(upload_audio)
+        is_vostfr_upload = upload_lang_level < 3
+
         # Build search queries using NXM's naming pattern (Titre Année Résolution Groupe)
         # NXM allows dupes from different groups, so the group must be part of the query.
         suffix = " ".join(p for p in [str(year), resolution, group] if p)
+        # For VOSTFR: also build broader queries (no group) to find FR-audio releases
+        # from any group that would supersede this upload.
+        broad_suffix = " ".join(p for p in [str(year), resolution] if p)
 
         search_queries: list[str] = []
+        broad_queries: list[str] = []  # VOSTFR only — no group filter applied
         is_original_french = str(meta.get("original_language", "")).lower() == "fr"
 
         if is_original_french:
             # Original is French → search FR first, then EN as complement
             if fr_title:
                 search_queries.append(f"{fr_title} {suffix}".strip())
+                if is_vostfr_upload:
+                    broad_queries.append(f"{fr_title} {broad_suffix}".strip())
             if title and _normalize(title) != _normalize(fr_title or ""):
                 search_queries.append(f"{title} {suffix}".strip())
+                if is_vostfr_upload:
+                    broad_queries.append(f"{title} {broad_suffix}".strip())
         else:
             # Original is not French → search EN first, then FR as complement
             if title:
                 search_queries.append(f"{title} {suffix}".strip())
+                if is_vostfr_upload:
+                    broad_queries.append(f"{title} {broad_suffix}".strip())
             if fr_title and _normalize(fr_title) != _normalize(title or ""):
                 search_queries.append(f"{fr_title} {suffix}".strip())
+                if is_vostfr_upload:
+                    broad_queries.append(f"{fr_title} {broad_suffix}".strip())
 
         if not search_queries:
             return []
@@ -928,13 +947,6 @@ class NXM(FrenchTrackerMixin):
         resolution_norm = _normalize(resolution)
         group_norm = _normalize(group)
         seen_names: set[str] = set()
-
-        # Detect VOSTFR upload early: for VOSTFR, we must also surface FR-audio
-        # releases from other groups (they supersede VOSTFR regardless of group).
-        # Level >= 3 means FR audio (VFF/VFI/VFQ/MULTI…); VOSTFR = level 2.
-        upload_audio = await self._build_audio_string(meta)
-        _, upload_lang_level = self._extract_french_lang_tag(upload_audio)
-        is_vostfr_upload = upload_lang_level < 3
 
         try:
             headers = {
@@ -1012,6 +1024,76 @@ class NXM(FrenchTrackerMixin):
                                 if meta.get("debug"):
                                     console.print(f"[dim]NXM dupe skip (group mismatch): {name}[/dim]")
                                 continue
+
+                        seen_names.add(name_norm)
+                        dupes.append(
+                            {
+                                "name": name,
+                                "size": item.get("size", item.get("file_size_bytes")),
+                                "link": (
+                                    item.get("url")
+                                    or item.get("link")
+                                    or (f"{self.torrent_url}{item['slug']}" if item.get("slug") else None)
+                                    or (f"{self.torrent_url}{item['id']}" if item.get("id") else None)
+                                ),
+                                "id": item.get("id", item.get("torrent_id")),
+                            }
+                        )
+
+                # Broad queries (VOSTFR only): find FR-audio releases from any group.
+                # Only keep results with FR audio (level >= 3); group filter is skipped.
+                for search_term in broad_queries:
+                    try:
+                        response = await client.get(
+                            self.search_url,
+                            headers=headers,
+                            params={"q": search_term},
+                        )
+                    except Exception:  # noqa: BLE001
+                        continue
+
+                    if response.status_code != 200:
+                        continue
+
+                    try:
+                        data = response.json()
+                    except json.JSONDecodeError:
+                        continue
+
+                    if not isinstance(data, dict):
+                        continue
+
+                    items = data.get("torrents", data.get("data", []))
+                    if not items:
+                        continue
+
+                    for item in items:
+                        if not isinstance(item, dict):
+                            continue
+                        name = item.get("title", item.get("name", ""))
+                        if not name:
+                            continue
+
+                        name_norm = _normalize(name)
+                        if name_norm in seen_names:
+                            continue
+
+                        title_match = title_norm and title_norm in name_norm
+                        fr_title_match = fr_title_norm and fr_title_norm in name_norm
+                        if not title_match and not fr_title_match:
+                            continue
+                        if year_str and year_str not in name and meta.get("category") != "TV":
+                            continue
+                        if resolution_norm and resolution_norm not in name_norm:
+                            continue
+
+                        # Only keep FR-audio results (the whole point of this broader search)
+                        _, name_level = self._extract_french_lang_tag(name)
+                        if name_level < 3:
+                            continue
+
+                        if meta.get("debug"):
+                            console.print(f"[dim]NXM broad search: FR-audio dupe from other group: {name}[/dim]")
 
                         seen_names.add(name_norm)
                         dupes.append(

--- a/tests/test_c411.py
+++ b/tests/test_c411.py
@@ -2065,6 +2065,17 @@ class TestSlotISO:
         slot = C411._determine_c411_slot_from_name('Movie.Isolated.2024.2160p.UHD.WEB-DL.AAC.2.0.H.264-GRP')
         assert slot != 'PURE-UHD-ISO'
 
+    def test_web_in_title_not_treated_as_web_source(self):
+        """'WEB' appearing only in the movie title must not be confused with WEB source.
+        Regression: '.WEB.' in 'Spider.s.Web.2018' was triggering is_web=True and
+        producing a WR slot for what is actually a BluRay release.
+        """
+        slot = C411._determine_c411_slot_from_name(
+            "The.Girl.in.the.Spider.s.Web.2018.1080p.BluRay.REMUX.AC3.5.1-GRP"
+        )
+        assert "WR" not in slot, f"WEB in title should not produce a WR slot, got: {slot}"
+        assert slot == "PURE-BD-REMUX"
+
 
 # ─── Slot: AD special edition ────────────────────────────────
 

--- a/tests/test_c411.py
+++ b/tests/test_c411.py
@@ -1580,7 +1580,7 @@ class TestSearchExisting:
             )
 
         assert len(dupes) >= 1
-        assert dupes[0]['name'] == '[COMPAT-01] Le.Prenom.2012.FRENCH.1080p.WEB.x264-Troxy'
+        assert dupes[0]['name'] == '[COMPAT-WR] Le.Prenom.2012.FRENCH.1080p.WEB.x264-Troxy'
 
         # Verify API was called with correct params
         call_args = mock_client.get.call_args_list
@@ -2058,7 +2058,7 @@ class TestSlotISO:
     def test_iso_not_matched_in_word(self):
         """'ISO' embedded in another word (e.g. ISOLATION) should NOT match as ISO disc."""
         slot = C411._determine_c411_slot_from_name('Isolation.2024.1080p.WEB-DL.AAC.2.0.H.264-GRP')
-        assert slot == 'COMPAT-01'
+        assert slot == 'COMPAT-WR'
 
     def test_iso_not_matched_mid_name(self):
         """'ISO' as a prefix inside a mid-name token (e.g. .Isolated.) must NOT match."""
@@ -2076,18 +2076,18 @@ class TestSlotADEdition:
         c = C411(_config())
         meta = _meta_base(edition='AD', resolution='1080p')
         slot = c._determine_c411_slot(meta)
-        assert slot == 'AD|COMPAT-01'
+        assert slot == 'AD|COMPAT-WR'
 
     def test_ad_from_name(self):
         # "AD" is intentionally skipped in name-based detection (too ambiguous as a token).
         # Only meta-based detection sets the AD edition prefix.
         slot = C411._determine_c411_slot_from_name('Movie.2024.AD.FRENCH.1080p.WEB.x264-GRP')
-        assert slot == 'COMPAT-01'
+        assert slot == 'COMPAT-WR'
 
     def test_ad_not_in_word(self):
         """AD embedded in another word should NOT trigger special edition."""
         slot = C411._determine_c411_slot_from_name('Adrenaline.2024.FRENCH.1080p.WEB.x264-GRP')
-        assert slot == 'COMPAT-01'
+        assert slot == 'COMPAT-WR'
 
     def test_ad_4k_remux(self):
         c = C411(_config())
@@ -2357,7 +2357,7 @@ class TestADFalsePositiveRegression:
         c = C411(_config())
         meta = _meta_base(edition='AD', resolution='1080p')
         slot = c._determine_c411_slot(meta)
-        assert slot == 'AD|COMPAT-01'
+        assert slot == 'AD|COMPAT-WR'
 
 
 # ═══════════════════════════════════════════════════════════════

--- a/tests/test_c411.py
+++ b/tests/test_c411.py
@@ -2333,6 +2333,49 @@ class TestLossyLosslessCoexistence:
 
         assert len(dupes) == 1, "PURE-BD-BDMV dupe must not be silently dropped by lossless filter"
 
+    def test_vostfr_lossless_upload_sees_multi_lossy_dupe(self):
+        """A lossless VOSTFR upload must NOT silently drop a lossy MULTI dupe.
+        Regression: the lossless/lossy coexistence filter removed EAC3 releases before
+        _check_french_lang_dupes could flag them as french_lang_supersede.
+        """
+        c = C411(_config())
+        meta = _meta_base(
+            type='WEBDL', resolution='2160p', audio='TrueHD Atmos 7.1',
+            video_encode='H.265', hdr='DV HDR10+',
+            mediainfo=_mi([_audio_track('en')], [_sub_track('fr')]),
+            original_language='en',
+        )
+        meta['is_disc'] = None
+        meta['uhd'] = ''
+
+        # Existing release: MULTI (FR audio, level 3+), lossy EAC3, same WR+DV slot
+        xml = """<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:torznab="http://torznab.com/schemas/2015/feed">
+  <channel>
+    <item>
+      <title>Le.Prenom.2012.MULTI.VFF.2160p.WEB.ATMOS.DV.HDR10Plus.EAC3.5.1.H265-GRP</title>
+      <guid>https://c411.org/torrents/999</guid>
+      <link>https://c411.org/torrents/999/download</link>
+      <size>15000000000</size>
+    </item>
+  </channel>
+</rss>"""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = xml
+
+        with patch('httpx.AsyncClient') as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_cls.return_value = mock_client
+
+            dupes = asyncio.run(c.search_existing(meta, 'nodisc'))
+
+        assert len(dupes) == 1, "MULTI EAC3 dupe must survive lossless filter when upload is VOSTFR"
+        assert 'french_lang_supersede' in (dupes[0].get('flags') or []), "Dupe must be flagged as french_lang_supersede"
+
 
 # ─── AD false positive: Ad.Astra regression ──────────────────
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Suppressed console output messages during unattended operations

* **Improvements**
  * Refined source classification for web-sourced releases (WEBRIP/WEBDL variants) across multiple categories
  * Enhanced duplicate detection logic for French-language releases with expanded cross-group search capabilities
  * Improved dupe filtering for multilingual content

* **Tests**
  * Updated test suite to reflect new source selection behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->