### PR TITLE
fix(NXM): remove FLOP from banned_groups (not in TRaSH FR list)

### DIFF
--- a/src/trackers/NXM.py
+++ b/src/trackers/NXM.py
@@ -93,7 +93,6 @@ class NXM(FrenchTrackerMixin):
             "EZTVRE",
             "FGT",
             "FIRETOWN",
-            "FLOP",
             "FLY3R",
             "FREEZER",
             "FUN",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated tracker filtering so one previously blocked group is no longer excluded, improving search and upload availability for affected content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->