### PR TITLE
feat(FR): only run predb.fr group-reputation check on French-audio re…

### DIFF
--- a/src/predb_fr.py
+++ b/src/predb_fr.py
@@ -71,17 +71,12 @@ def _our_tmdb(tmdb_id: Any) -> int:
 # Exact French language codes/names. Mirrors FRENCH.FRENCH_LANG_VALUES but kept
 # local so this module stays importable without pymediainfo. A prefix test would
 # wrongly match Frisian/Friulian ("fry", "fur", "frisian"), so we match exactly.
-_FR_AUDIO_VALUES = frozenset(
-    {"fr", "fre", "fra", "french", "français", "francais", "fr-fr", "fr-ca", "fr-be", "fr-ch"}
-)
+_FR_AUDIO_VALUES = frozenset({"fr", "fre", "fra", "french", "français", "francais", "fr-fr", "fr-ca", "fr-be", "fr-ch"})
 
 
 def _has_fr_audio(meta: dict[str, Any]) -> bool:
     """True when the upload has at least one French audio track."""
-    return any(
-        str(lang).strip().lower().replace("_", "-") in _FR_AUDIO_VALUES
-        for lang in (meta.get("audio_languages") or [])
-    )
+    return any(str(lang).strip().lower().replace("_", "-") in _FR_AUDIO_VALUES for lang in (meta.get("audio_languages") or []))
 
 
 def tmdb_debug_line(releases: list[dict[str, Any]], *, tmdb_id: Any, category: Any, tracker: str) -> str:

--- a/src/predb_fr.py
+++ b/src/predb_fr.py
@@ -68,6 +68,15 @@ def _our_tmdb(tmdb_id: Any) -> int:
         return 0
 
 
+def _has_fr_audio(meta: dict[str, Any]) -> bool:
+    """True when the upload has at least one French audio track.
+
+    All French language codes/names start with ``fr`` (french, fra, fre,
+    fr-fr, français…), so a prefix test is enough.
+    """
+    return any(str(lang).strip().lower().startswith("fr") for lang in (meta.get("audio_languages") or []))
+
+
 def tmdb_debug_line(releases: list[dict[str, Any]], *, tmdb_id: Any, category: Any, tracker: str) -> str:
     """One ``--debug`` line spelling out what predb.fr can say about our TMDB id.
 
@@ -94,6 +103,7 @@ def analyze(
     tmdb_id: Any,
     group: Any,
     category: Any,
+    has_fr_audio: bool = True,
 ) -> tuple[list[str], list[str]]:
     """Compare predb candidates to our submission.
 
@@ -123,8 +133,10 @@ def analyze(
     # Nuke only reported for same-group candidates to avoid noise.
     blocking.extend(f"Nuked release on the FR scene: {r.get('name')} — {r['nuke_reason']}" for r in ours if r.get("nuke_reason"))
 
-    # Group reputation is advisory only.
-    if ours and not any(r.get("team_profilarr_validated") for r in ours):
+    # Group reputation is advisory only, and only meaningful for French-audio
+    # releases: FR trackers also take VOSTFR (English audio + FR subs) whose
+    # groups are English teams that predb.fr legitimately won't have validated.
+    if has_fr_audio and ours and not any(r.get("team_profilarr_validated") for r in ours):
         info.append(f"Group {group} is not profilarr-validated on predb.fr.")
 
     return blocking, info
@@ -249,6 +261,7 @@ async def crosscheck(meta: dict[str, Any], config: dict[str, Any], tracker: str)
         tmdb_id=our_tmdb_id,
         group=meta.get("tag"),
         category=meta.get("category"),
+        has_fr_audio=_has_fr_audio(meta),
     )
     for w in info:
         console.print(f"[yellow]⚠️  predb.fr [{tracker}]: {w}[/yellow]")

--- a/src/predb_fr.py
+++ b/src/predb_fr.py
@@ -68,13 +68,20 @@ def _our_tmdb(tmdb_id: Any) -> int:
         return 0
 
 
-def _has_fr_audio(meta: dict[str, Any]) -> bool:
-    """True when the upload has at least one French audio track.
+# Exact French language codes/names. Mirrors FRENCH.FRENCH_LANG_VALUES but kept
+# local so this module stays importable without pymediainfo. A prefix test would
+# wrongly match Frisian/Friulian ("fry", "fur", "frisian"), so we match exactly.
+_FR_AUDIO_VALUES = frozenset(
+    {"fr", "fre", "fra", "french", "français", "francais", "fr-fr", "fr-ca", "fr-be", "fr-ch"}
+)
 
-    All French language codes/names start with ``fr`` (french, fra, fre,
-    fr-fr, français…), so a prefix test is enough.
-    """
-    return any(str(lang).strip().lower().startswith("fr") for lang in (meta.get("audio_languages") or []))
+
+def _has_fr_audio(meta: dict[str, Any]) -> bool:
+    """True when the upload has at least one French audio track."""
+    return any(
+        str(lang).strip().lower().replace("_", "-") in _FR_AUDIO_VALUES
+        for lang in (meta.get("audio_languages") or [])
+    )
 
 
 def tmdb_debug_line(releases: list[dict[str, Any]], *, tmdb_id: Any, category: Any, tracker: str) -> str:

--- a/tests/test_predb_fr.py
+++ b/tests/test_predb_fr.py
@@ -85,6 +85,25 @@ def test_unvalidated_group_is_advisory_not_blocking():
     assert any("not profilarr-validated" in w for w in info)
 
 
+def test_unvalidated_group_silent_without_fr_audio():
+    # VOSTFR upload (English audio): the ENG group is legitimately unvalidated,
+    # so the advisory must be suppressed.
+    blocking, info = analyze(
+        [_rel(team_profilarr_validated=False)], tmdb_id=207, group="-T4KT", category="MOVIE", has_fr_audio=False
+    )
+    assert blocking == []
+    assert info == []
+
+
+def test_has_fr_audio_detection():
+    from src.predb_fr import _has_fr_audio
+
+    assert _has_fr_audio({"audio_languages": ["English", "French"]})
+    assert _has_fr_audio({"audio_languages": ["fr-FR"]})
+    assert not _has_fr_audio({"audio_languages": ["English", "Japanese"]})
+    assert not _has_fr_audio({})
+
+
 def test_tv_category_matches_series():
     rels = [_rel(categ="Series", media_id="tv:999")]
     blocking, _ = analyze(rels, tmdb_id=72879, group="-T4KT", category="TV")

--- a/tests/test_predb_fr.py
+++ b/tests/test_predb_fr.py
@@ -98,8 +98,15 @@ def test_unvalidated_group_silent_without_fr_audio():
 def test_has_fr_audio_detection():
     from src.predb_fr import _has_fr_audio
 
+    # Accepted French variants (codes and names, any case/separator).
     assert _has_fr_audio({"audio_languages": ["English", "French"]})
     assert _has_fr_audio({"audio_languages": ["fr-FR"]})
+    assert _has_fr_audio({"audio_languages": ["fra"]})
+    assert _has_fr_audio({"audio_languages": ["français"]})
+    assert _has_fr_audio({"audio_languages": ["FR_CA"]})
+    # Non-French values that merely start with "fr" must be rejected.
+    assert not _has_fr_audio({"audio_languages": ["Frisian"]})
+    assert not _has_fr_audio({"audio_languages": ["Friulian", "fry"]})
     assert not _has_fr_audio({"audio_languages": ["English", "Japanese"]})
     assert not _has_fr_audio({})
 


### PR DESCRIPTION
…leases

French trackers also accept VOSTFR uploads (English audio + French subs) whose release groups are English teams that predb.fr legitimately never profilarr-validates. Gating the advisory on French audio avoids a useless "group not validated" warning on every VOSTFR upload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary “unvalidated” advisory warnings when uploads do not include French audio.
  * Advisory messages about unvalidated group reputation now appear only for uploads with French-audio content.

* **Tests**
  * Added coverage for the French-audio “silent” behavior when French audio is absent.
  * Added tests to validate French-audio detection across common language representations and missing/empty metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->