### PR TITLE
feat: refuse renamed files before upload (cross-seed integrity)

### DIFF
--- a/src/trackers/COMMON.py
+++ b/src/trackers/COMMON.py
@@ -3177,13 +3177,13 @@ class COMMON:
         counts as a rename, because cross-seeding needs byte-identical filenames,
         so any change to the name is rejected.
         """
-        known_ext = (".mkv", ".mp4", ".avi", ".ts", ".m2ts", ".wmv", ".mpg", ".mpeg", ".vob", ".iso")
+        known_ext = {".mkv", ".mp4", ".avi", ".ts", ".m2ts", ".wmv", ".mpg", ".mpeg", ".vob", ".iso"}
 
         def strip_ext(s: str) -> str:
-            for ext in known_ext:
-                if s.lower().endswith(ext):
-                    return s[: -len(ext)]
-            return s
+            # splitext only peels the final component, so ".m2ts" is dropped
+            # whole instead of being truncated by a shorter ".ts" match.
+            root, ext = os.path.splitext(s)
+            return root if ext.lower() in known_ext else s
 
         disk = strip_ext(disk_name).strip()
         embedded = strip_ext(embedded_name).strip()

--- a/src/trackers/COMMON.py
+++ b/src/trackers/COMMON.py
@@ -3078,7 +3078,7 @@ class COMMON:
         torrent_tag = meta.get("tag", "")
         torrent_group = torrent_tag.lstrip("-").strip() if torrent_tag else ""
 
-        mi_filename = await self._get_mediainfo_filename(meta)
+        mi_filename, disk_filename = await self._get_mediainfo_filename(meta)
         mi_group = self._extract_group_from_filename(mi_filename) if mi_filename else ""
 
         if not torrent_group:
@@ -3098,18 +3098,39 @@ class COMMON:
             }
             return True
 
+        # Rename: the embedded name is a real release name (it carries a group
+        # tag, so we trust its format) but the on-disk filename no longer matches
+        # it. Renamed files are always refused — they usually hide a faked
+        # quality/source and need manual verification.
+        if mi_filename and mi_group and disk_filename and self._is_renamed(disk_filename, mi_filename):
+            meta["detag_info"] = {
+                "type": "rename",
+                "torrent_group": torrent_group,
+                "mi_group": mi_group,
+                "mi_filename": mi_filename,
+                "disk_filename": disk_filename,
+            }
+            return True
+
         return False
 
-    async def _get_mediainfo_filename(self, meta: dict[str, Any]) -> str:
-        """Read the original release name from MEDIAINFO_CLEANPATH.txt."""
+    async def _get_mediainfo_filename(self, meta: dict[str, Any]) -> tuple[str, str]:
+        """Read the embedded release name and the on-disk filename from
+        MEDIAINFO_CLEANPATH.txt.
+
+        Returns ``(embedded_name, disk_name)`` where *embedded_name* is the
+        ``Movie name``/``Title`` the release group muxed into the container and
+        *disk_name* is ``Complete name`` (rewritten to the current basename by
+        exportmi). A mismatch between the two means the file was renamed.
+        """
         base_dir = meta.get("base_dir", ".")
         uuid = meta.get("uuid", "")
         if not uuid:
-            return ""
+            return "", ""
 
         cleanpath = os.path.join(base_dir, "tmp", uuid, "MEDIAINFO_CLEANPATH.txt")
         if not os.path.isfile(cleanpath):
-            return ""
+            return "", ""
 
         try:
             async with aiofiles.open(cleanpath, encoding="utf-8", errors="ignore") as f:
@@ -3117,6 +3138,7 @@ class COMMON:
 
             movie_name = ""
             title = ""
+            complete_name = ""
             in_general = False
             for line in content.splitlines():
                 stripped = line.strip()
@@ -3126,7 +3148,11 @@ class COMMON:
                 if in_general and stripped == "":
                     break
                 if in_general:
-                    if stripped.startswith("Movie name"):
+                    if stripped.startswith("Complete name"):
+                        parts = line.split(":", 1)
+                        if len(parts) == 2:
+                            complete_name = parts[1].strip()
+                    elif stripped.startswith("Movie name"):
                         parts = line.split(":", 1)
                         if len(parts) == 2:
                             movie_name = parts[1].strip()
@@ -3135,11 +3161,33 @@ class COMMON:
                         if len(parts) == 2:
                             title = parts[1].strip()
 
-            return movie_name or title
+            return movie_name or title, complete_name
         except OSError:
             pass
 
-        return ""
+        return "", ""
+
+    @staticmethod
+    def _is_renamed(disk_name: str, embedded_name: str) -> bool:
+        """True when the on-disk filename differs from the name the release group
+        muxed into the container.
+
+        The comparison is exact — only a trailing media extension is dropped
+        (the embedded name usually carries none). Even a dot-vs-space difference
+        counts as a rename, because cross-seeding needs byte-identical filenames,
+        so any change to the name is rejected.
+        """
+        known_ext = (".mkv", ".mp4", ".avi", ".ts", ".m2ts", ".wmv", ".mpg", ".mpeg", ".vob", ".iso")
+
+        def strip_ext(s: str) -> str:
+            for ext in known_ext:
+                if s.lower().endswith(ext):
+                    return s[: -len(ext)]
+            return s
+
+        disk = strip_ext(disk_name).strip()
+        embedded = strip_ext(embedded_name).strip()
+        return bool(disk) and bool(embedded) and disk != embedded
 
     @staticmethod
     def _extract_group_from_filename(filename: str) -> str:

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -155,3 +155,60 @@ class TestCheckLanguageRequirementsEdgeCases:
                 meta, "TEST", languages_to_check=["french"], check_audio=True
             ))
         assert result is True
+
+
+# ═══════════════════════════════════════════════════════════════
+#  _is_renamed() and check_detag() rename detection
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestRenameDetection:
+    """The on-disk filename must match the name muxed in by the release group."""
+
+    @pytest.fixture
+    def common(self):
+        return COMMON(config=_config())
+
+    def test_not_renamed_extension_only(self, common):
+        # On-disk name == embedded name apart from the extension → not renamed.
+        assert common._is_renamed("Movie.2026.1080p.BluRay.x264-GRP.mkv", "Movie.2026.1080p.BluRay.x264-GRP") is False
+
+    def test_renamed_dots_vs_spaces(self, common):
+        # Even a separator change breaks cross-seeding → treated as a rename.
+        assert common._is_renamed("Movie 2026 1080p BluRay x264-GRP.mkv", "Movie.2026.1080p.BluRay.x264-GRP") is True
+
+    def test_not_renamed_exact_match(self, common):
+        # Identical apart from the extension → not renamed.
+        assert common._is_renamed("Movie.2026.1080p.BluRay.x264-GRP.mkv", "Movie.2026.1080p.BluRay.x264-GRP") is False
+
+    def test_renamed_to_junk(self, common):
+        assert common._is_renamed("movie.mkv", "Movie.2026.1080p.BluRay.x264-GRP") is True
+
+    def test_renamed_faked_resolution(self, common):
+        assert common._is_renamed("Movie.2026.2160p.BluRay.x264-GRP.mkv", "Movie.2026.1080p.BluRay.x264-GRP") is True
+
+    def test_empty_names_never_renamed(self, common):
+        assert common._is_renamed("", "Movie-GRP") is False
+        assert common._is_renamed("Movie-GRP.mkv", "") is False
+
+    def test_check_detag_flags_rename(self, common):
+        # Group matches (not detag/notag) but the on-disk name was changed.
+        meta = {"tag": "-GRP"}
+        with patch.object(
+            common, "_get_mediainfo_filename",
+            AsyncMock(return_value=("Movie.2026.1080p.BluRay.x264-GRP", "Movie.2026.2160p.BluRay.x264-GRP.mkv")),
+        ):
+            result = _run(common.check_detag(meta, "TEST"))
+        assert result is True
+        assert meta["detag_info"]["type"] == "rename"
+        assert meta["detag_info"]["disk_filename"] == "Movie.2026.2160p.BluRay.x264-GRP.mkv"
+
+    def test_check_detag_no_rename_when_names_match(self, common):
+        meta = {"tag": "-GRP"}
+        with patch.object(
+            common, "_get_mediainfo_filename",
+            AsyncMock(return_value=("Movie.2026.1080p.BluRay.x264-GRP", "Movie.2026.1080p.BluRay.x264-GRP.mkv")),
+        ):
+            result = _run(common.check_detag(meta, "TEST"))
+        assert result is False
+        assert "detag_info" not in meta

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -212,3 +212,19 @@ class TestRenameDetection:
             result = _run(common.check_detag(meta, "TEST"))
         assert result is False
         assert "detag_info" not in meta
+
+    def test_not_renamed_m2ts_extension(self, common):
+        # ".m2ts" must be dropped whole, not truncated to ".m2" by a ".ts" match.
+        assert common._is_renamed("Movie.2026.1080p.BluRay.x264-GRP.m2ts", "Movie.2026.1080p.BluRay.x264-GRP") is False
+
+    def test_check_detag_no_rename_without_group_tag(self, common):
+        # Embedded name is a plain human title (no -GROUP suffix): we don't trust
+        # its format, so a mismatch must NOT be flagged as a rename.
+        meta = {"tag": "-GRP"}
+        with patch.object(
+            common, "_get_mediainfo_filename",
+            AsyncMock(return_value=("The Movie 2026", "Movie.2026.1080p.BluRay.x264-GRP.mkv")),
+        ):
+            result = _run(common.check_detag(meta, "TEST"))
+        assert result is False
+        assert "detag_info" not in meta

--- a/upload.py
+++ b/upload.py
@@ -657,6 +657,33 @@ async def process_meta(meta: Meta, base_dir: str, bot: Any = None) -> Optional[b
                     return
                 # User overrides — clear so trackers won't skip
                 meta.pop("detag_info", None)
+        elif detection_type == "rename":
+            # --- RENAME: always block, ask confirmation ---
+            disk_file = detag_info.get("disk_filename", "")
+            console.print("[bold yellow]⚠️  RENAME DETECTED[/bold yellow]")
+            console.print("[bold red]━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━[/bold red]")
+            console.print(f"[cyan]On-disk filename:[/cyan] [yellow]{disk_file}[/yellow]")
+            console.print(f"[cyan]Original filename:[/cyan] [yellow]{mi_file}[/yellow]")
+            console.print()
+            console.print("[bold white]The file was renamed: its on-disk name differs from the name the release group muxed in.[/bold white]")
+            console.print("[bold white]This release will be skipped on all trackers unless you override below.[/bold white]")
+            console.print("[bold red]━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━[/bold red]")
+            console.print()
+
+            # Attended only; unattended already cancelled above.
+            try:
+                detag_confirm = cli_ui.ask_yes_no("Do you want to proceed anyway?", default=False)
+            except EOFError:
+                console.print("\n[red]Exiting on user request (Ctrl+C)[/red]")
+                await cleanup_manager.cleanup()
+                cleanup_manager.reset_terminal()
+                sys.exit(1)
+            if not detag_confirm:
+                console.print("[red]Upload cancelled due to rename detection.[/red]")
+                meta["we_are_uploading"] = False
+                return
+            # User chose to proceed — clear flag so trackers won't skip
+            meta.pop("detag_info", None)
         else:
             # --- DETAG: always block, ask confirmation ---
             torrent_grp = detag_info.get("torrent_group", "?")


### PR DESCRIPTION
A file whose on-disk name no longer matches the name the release group muxed into the container (MediaInfo General "Movie name"/"Title" vs "Complete name") is now detected at the same early stage as notag/detag and always refused: cancelled in unattended mode, prompted in attended, skipped per-tracker.

The comparison is exact (only a trailing media extension is dropped) so even a dot-vs-space change counts as a rename — cross-seeding needs byte-identical filenames. Detection is gated on the embedded name carrying a real group tag, to avoid false positives on groups that mux a plain human title instead of the release name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated detection for renamed uploads when the embedded release name and on-disk filename differ.
  * Displays a specific “rename detected” warning and asks for confirmation before proceeding.

* **Bug Fixes**
  * Ensures rename cases are handled separately from standard detag flows.
  * Clears rename-related flags when you choose to continue, preventing unintended auto-skips.

* **Tests**
  * Added unit test coverage for rename detection and the upload confirmation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->