### PR TITLE
fix(NXM): send documentary sub-category id, not the parent (422)

### DIFF
--- a/src/trackers/NXM.py
+++ b/src/trackers/NXM.py
@@ -274,7 +274,9 @@ class NXM(FrenchTrackerMixin):
 
         { "id": 1, "name": "Films", "slug": "films" },
         { "id": 2, "name": "Séries TV", "slug": "series" },
-        { "id": 3, "name": "Documentaires", "slug": "documentaires" },
+        { "id": 3, "name": "Documentaires", "slug": "documentaires" },  # parent — needs a sub-cat:
+            { "id": 23, "name": "Film documentaire", "slug": "documentaires-films" },
+            { "id": 24, "name": "Série documentaire", "slug": "documentaires-series" },
         { "id": 4, "name": "Animés", "slug": "animes" },
         { "id": 5, "name": "Concerts / Spectacles", "slug": "concerts-spectacles" },
         { "id": 7, "name": "Sports", "slug": "sports" }
@@ -287,7 +289,8 @@ class NXM(FrenchTrackerMixin):
         if "concert" in genres.lower() or "concert" in keywords.lower():
             return 5
         elif "documentary" in genres.lower() or "documentary" in keywords.lower():
-            return 3
+            # Documentaires (3) has sub-cats; sending the parent id is a 422.
+            return 24 if meta.get("category") == "TV" else 23
         elif meta.get("category") == "TV":
             return 4 if is_anime else 2
         return 4 if is_anime else 1

--- a/tests/test_nxm.py
+++ b/tests/test_nxm.py
@@ -100,10 +100,10 @@ class TestGetCategoryId:
             ("MOVIE", "", "", False, 1),
             # Standard TV → numeric 2 (serie-tv)
             ("TV", "", "", False, 2),
-            # Documentary movie → numeric 3 (documentaire)
-            ("MOVIE", "Documentary", "", False, 3),
-            # Documentary TV → numeric 3 (documentaire)
-            ("TV", "Documentary", "", False, 3),
+            # Documentary movie → 23 (Film documentaire sub-cat; parent 3 is a 422)
+            ("MOVIE", "Documentary", "", False, 23),
+            # Documentary TV → 24 (Série documentaire sub-cat)
+            ("TV", "Documentary", "", False, 24),
             # Anime movie → numeric 4 (animation)
             ("MOVIE", "", "", True, 4),
             # Anime TV → numeric 4 (animation-serie)


### PR DESCRIPTION
NXM's "Documentaires" category (id 3) is a parent with sub-categories; POST /api/v1/upload rejects the parent id with 422. Map to the right sub-cat: 24 (Série documentaire) for TV, 23 (Film documentaire) otherwise.