### PR TITLE
4KLight/HDLight handling across FR trackers

### DIFF
--- a/src/dupe_checking.py
+++ b/src/dupe_checking.py
@@ -789,7 +789,9 @@ class DupeChecker:
             return set()
         hdr_upper = str(hdr).upper()
         terms: set[str] = set()
-        if "DV" in hdr_upper or "DOVI" in hdr_upper:
+        # "DOLBY VISION" spelled out (e.g. in a release name) is Dolby Vision too —
+        # the bare "DV" substring doesn't occur in it, so match it explicitly.
+        if "DV" in hdr_upper or "DOVI" in hdr_upper or "DOLBY VISION" in hdr_upper or "DOLBYVISION" in hdr_upper:
             terms.add("DV")
         if "HDR" in hdr_upper:  # Any HDR-related term is normalized to 'HDR'
             terms.add("HDR")

--- a/src/trackers/C411.py
+++ b/src/trackers/C411.py
@@ -329,6 +329,13 @@ class C411(FrenchTrackerMixin):
     def _detect_special_edition_from_meta(cls, meta: Meta) -> str:
         """Return normalised edition key from meta, or '' if standard release."""
         edition = str(meta.get("edition", "")).upper()
+        # "Hybrid" lives in webdv (get_name keeps it out of edition), but the
+        # name parser sees it as a HYBRID edition token. Fold it in so the
+        # meta-based slot matches the name-based one — otherwise a Hybrid
+        # release fails to match its own dupe.
+        webdv = str(meta.get("webdv", "")).strip().upper()
+        if webdv:
+            edition = f"{edition} {webdv}".strip()
         if not edition:
             return ""
         tokens = set(edition.replace(".", " ").replace("-", " ").replace("_", " ").split())

--- a/src/trackers/FRENCH.py
+++ b/src/trackers/FRENCH.py
@@ -986,6 +986,7 @@ class FrenchTrackerMixin:
         three_d = meta.get("3D", "")
         tag = meta.get("tag", "")
         source = meta.get("source", "")
+        light = self._light_encode_tag(meta)
         uhd = meta.get("uhd", "")
         hdr = meta.get("hdr", "").replace("HDR10+", "HDR10PLUS")
         hybrid = str(meta.get("webdv", "")) if meta.get("webdv", "") else ""
@@ -1053,7 +1054,7 @@ class FrenchTrackerMixin:
             elif type_val == "REMUX":
                 name = f"{title} {year} {edition} {repack} {language} {resolution} {hybrid} {uhd} {source} REMUX {hdr} {_av(video_codec, audio)}"
             elif type_val == "ENCODE":
-                name = f"{title} {year} {edition} {repack} {language} {resolution} {hybrid} {uhd} {source} {hdr} {_av(video_encode, audio)}"
+                name = f"{title} {year} {edition} {repack} {language} {resolution} {hybrid} {uhd} {source} {light} {hdr} {_av(video_encode, audio)}"
             elif type_val == "WEBDL":
                 name = f"{title} {year} {edition} {repack} {language} {resolution} {hybrid} {uhd} {service} {web_lbl} {hdr} {_av(video_encode, audio)}"
             elif type_val == "WEBRIP":
@@ -1081,7 +1082,7 @@ class FrenchTrackerMixin:
             elif type_val == "REMUX":
                 name = f"{title} {year} {se} {part} {edition} {repack} {language} {resolution} {hybrid} {uhd} {source} REMUX {hdr} {_av(video_codec, audio)}"
             elif type_val == "ENCODE":
-                name = f"{title} {year} {se} {part} {edition} {repack} {language} {resolution} {hybrid} {uhd} {source} {hdr} {_av(video_encode, audio)}"
+                name = f"{title} {year} {se} {part} {edition} {repack} {language} {resolution} {hybrid} {uhd} {source} {light} {hdr} {_av(video_encode, audio)}"
             elif type_val == "WEBDL":
                 name = f"{title} {year} {se} {part} {edition} {repack} {language} {resolution} {hybrid} {uhd} {service} {web_lbl} {hdr} {_av(video_encode, audio)}"
             elif type_val == "WEBRIP":
@@ -1322,6 +1323,22 @@ class FrenchTrackerMixin:
         """Return a human-readable release type label."""
         raw = (meta.get("type") or "").upper()
         return FrenchTrackerMixin.TYPE_LABELS.get(raw, raw)
+
+    @staticmethod
+    def _light_encode_tag(meta: dict) -> str:
+        """French-scene light re-encode label, or '' when not one.
+
+        4KLight (2160p) and HDLight (1080p) are BluRay re-encodes; the source
+        release name declares which, but it isn't a meta field, so we read it
+        from ``uuid`` exactly like the C411 slot/quality detection does. Surfaced
+        in the generated name (after the source) so the tag isn't dropped.
+        """
+        uuid = str(meta.get("uuid", "")).lower()
+        if "4klight" in uuid:
+            return "4KLight"
+        if "hdlight" in uuid:
+            return "HDLight"
+        return ""
 
     # Container name → common file extension
     CONTAINER_EXT: dict[str, str] = {

--- a/src/trackers/TOS.py
+++ b/src/trackers/TOS.py
@@ -413,6 +413,16 @@ class TOS(FrenchTrackerMixin, UNIT3D):
         import os
         import re as _re
 
+        # TOS forbids light re-encodes (4KLight / HDLight). The minimum-bitrate
+        # check below catches most of them indirectly, but this rejects the label
+        # itself — regardless of bitrate — with a clear reason. Detected from the
+        # source filename (uuid), like the rest of the 4klight/hdlight handling.
+        uuid = str(meta.get("uuid", "")).lower()
+        if "4klight" in uuid or "hdlight" in uuid:
+            if not meta.get("unattended", False):
+                console.print(f"[bold red]{self.tracker}: 4KLight/HDLight re-encodes are not allowed on TOS.[/bold red]")
+            return False
+
         # TOS rejects filenames with special characters (e.g. parentheses).
         # Check both the release folder name and all individual files.
         _SAFE_FILENAME = _re.compile(r"^[a-zA-Z0-9 .\-_+\[\]]*$")

--- a/tests/test_c411.py
+++ b/tests/test_c411.py
@@ -1083,6 +1083,52 @@ class TestCodecCleanup:
         assert '.x264' not in name
 
 
+# ─── 4KLight / HDLight token in name ─────────────────────────
+
+class TestLightEncodeTag:
+    """4KLight/HDLight (BluRay light re-encodes) must survive into the name,
+    placed right after the source — they aren't a meta field, so they're read
+    from the original filename (uuid)."""
+
+    def _run(self, meta: dict[str, Any]) -> str:
+        c = C411(_config())
+        c._get_french_title = AsyncMock(return_value=meta.get('title', ''))
+        c._build_audio_string = AsyncMock(return_value='')
+        return asyncio.run(c.get_name(meta)).get('name', '')
+
+    def test_4klight_after_source(self):
+        meta = _meta_base(
+            title='Solo', year='2018', type='ENCODE', source='BluRay',
+            resolution='2160p', video_encode='x265', hdr='DV HDR',
+            uuid='Solo.2018.2160p.4KLight.DV.HDR.BluRay.x265-QTZ.mkv',
+            mediainfo=_mi([_audio_track('fr')]), original_language='en',
+        )
+        name = self._run(meta)
+        assert '4KLight' in name, name
+        # placed immediately after the source token
+        assert 'BluRay.4KLight' in name, name
+
+    def test_hdlight_token(self):
+        meta = _meta_base(
+            title='Film', year='2020', type='ENCODE', source='BluRay',
+            resolution='1080p', video_encode='x265',
+            uuid='Film.2020.1080p.HDLight.BluRay.x265-GRP.mkv',
+            mediainfo=_mi([_audio_track('fr')]), original_language='en',
+        )
+        name = self._run(meta)
+        assert 'HDLight' in name, name
+
+    def test_no_light_tag_when_absent(self):
+        meta = _meta_base(
+            title='Film', year='2020', type='ENCODE', source='BluRay',
+            resolution='2160p', video_encode='x265',
+            uuid='Film.2020.2160p.BluRay.x265-GRP.mkv',
+            mediainfo=_mi([_audio_track('fr')]), original_language='en',
+        )
+        name = self._run(meta)
+        assert 'Light' not in name, name
+
+
 # ─── Category / Subcategory mapping ──────────────────────────
 
 class TestCategoryMapping:

--- a/tests/test_c411.py
+++ b/tests/test_c411.py
@@ -2154,6 +2154,42 @@ class TestSlotADEdition:
         assert slot == 'AD|PURE-UHD-REMUX'
 
 
+class TestSlotHybridEdition:
+    """Hybrid lives in meta['webdv'], but the name parser sees a HYBRID token —
+    both slot paths must agree, else a Hybrid release fails to match its dupe."""
+
+    def test_hybrid_from_webdv_meta(self):
+        c = C411(_config())
+        meta = _meta_base(
+            type='ENCODE', resolution='2160p', source='BluRay', video_encode='x265',
+            hdr='DV HDR', audio='TrueHD Atmos 7.1',
+            uuid='Solo.2018.2160p.4KLight.BluRay.x265-QTZ.mkv',
+        )
+        meta['webdv'] = 'Hybrid'
+        assert c._detect_special_edition_from_meta(meta) == 'HYBRID'
+        assert c._determine_c411_slot(meta).startswith('HYBRID|')
+
+    def test_hybrid_meta_slot_matches_name_slot(self):
+        c = C411(_config())
+        meta = _meta_base(
+            type='ENCODE', resolution='2160p', source='BluRay', video_encode='x265',
+            hdr='DV HDR', audio='TrueHD Atmos 7.1',
+            uuid='Solo.2018.2160p.4KLight.BluRay.x265-QTZ.mkv',
+        )
+        meta['webdv'] = 'Hybrid'
+        dupe = 'Solo.A.Star.Wars.Story.2018.Hybrid.MULTI.VFF.2160p.BluRay.4KLight.DV.HDR10.TrueHD.Atmos.7.1.x265-QTZ'
+        assert c._determine_c411_slot(meta) == c._determine_c411_slot_from_name(dupe)
+
+    def test_no_webdv_no_hybrid_prefix(self):
+        c = C411(_config())
+        meta = _meta_base(
+            type='ENCODE', resolution='2160p', source='BluRay', video_encode='x265',
+            hdr='DV HDR', audio='TrueHD Atmos 7.1',
+            uuid='Solo.2018.2160p.4KLight.BluRay.x265-QTZ.mkv',
+        )
+        assert not c._determine_c411_slot(meta).startswith('HYBRID|')
+
+
 # ─── Lossy / Lossless coexistence ────────────────────────────
 
 

--- a/tests/test_dupe_checking.py
+++ b/tests/test_dupe_checking.py
@@ -492,3 +492,29 @@ class TestSeasonPackVsEpisodeGuard:
             "filename_match must be set when season-pack upload matches an "
             "existing season-pack entry on the tracker"
         )
+
+
+class TestRefineHdrTerms:
+    """refine_hdr_terms must recognise 'Dolby Vision' spelled out, not just 'DV'."""
+
+    def test_dolby_vision_spelled_out_is_dv(self):
+        # A release name carrying "DOLBY.VISION" (normalised to "dolby vision")
+        # must yield DV — the bare "DV" substring never appears in it.
+        terms = _run(DupeChecker.refine_hdr_terms("solo 2018 2160p 4klight dolby vision ddp 7 1 x265-qtz"))
+        assert terms == {"DV"}
+
+    def test_dv_token_still_works(self):
+        assert _run(DupeChecker.refine_hdr_terms("movie 2160p dv hdr10 x265")) == {"DV", "HDR"}
+
+    def test_plain_hdr(self):
+        assert _run(DupeChecker.refine_hdr_terms("movie 2160p hdr10 x265")) == {"HDR"}
+
+    def test_no_hdr(self):
+        assert _run(DupeChecker.refine_hdr_terms("movie 1080p bluray x264")) == set()
+
+    def test_dolby_vision_matches_dv_hdr_target(self):
+        # The reported bug: a DV upload (hdr="DV HDR") vs a "Dolby Vision" dupe
+        # must be considered the same HDR flavour, not excluded.
+        file_hdr = _run(DupeChecker.refine_hdr_terms("solo 2018 2160p 4klight dolby vision ddp 7 1 x265-qtz"))
+        target_hdr = _run(DupeChecker.refine_hdr_terms("DV HDR"))
+        assert _run(DupeChecker.has_matching_hdr(file_hdr, target_hdr, {"type": "ENCODE"}, tracker="C411"))

--- a/tests/test_tos.py
+++ b/tests/test_tos.py
@@ -135,6 +135,35 @@ class TestTosSpecialCharRejection:
         assert result is True
 
 
+class TestTosLightReencodeRejection:
+    """get_additional_checks must reject 4KLight / HDLight re-encodes (forbidden on TOS)."""
+
+    def _patch_lang_ok(self, t: TOS) -> None:
+        t.common.check_language_requirements = AsyncMock(return_value=True)  # type: ignore[assignment]
+
+    def test_4klight_rejected(self):
+        t = TOS(_config())
+        self._patch_lang_ok(t)
+        meta = _additional_checks_meta("/tmp/Solo.2018.2160p.4KLight.BluRay.x265-GRP")
+        meta["uuid"] = "Solo.2018.2160p.4KLight.BluRay.x265-GRP.mkv"
+        assert _run(t.get_additional_checks(meta)) is False
+
+    def test_hdlight_rejected(self):
+        t = TOS(_config())
+        self._patch_lang_ok(t)
+        meta = _additional_checks_meta("/tmp/Film.2020.1080p.HDLight.BluRay.x265-GRP")
+        meta["uuid"] = "Film.2020.1080p.HDLight.BluRay.x265-GRP.mkv"
+        assert _run(t.get_additional_checks(meta)) is False
+
+    def test_normal_encode_not_rejected_by_light_gate(self):
+        t = TOS(_config())
+        self._patch_lang_ok(t)
+        meta = _additional_checks_meta("/tmp/Film.2020.1080p.BluRay.x265-GRP")
+        meta["uuid"] = "Film.2020.1080p.BluRay.x265-GRP.mkv"
+        # No light tag → gate passes; clean filename + stubbed language → True
+        assert _run(t.get_additional_checks(meta)) is True
+
+
 # ---------------------------------------------------------------------------
 # Tests – _check_tos_specific_dupes
 # ---------------------------------------------------------------------------


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release names now preserve light re-encode tags such as `4KLight` and `HDLight` when present.
  * Dolby Vision wording like “Dolby Vision” is now normalized to the same HDR compatibility label as shorter variants.

* **Bug Fixes**
  * Improved edition matching when special-edition details are supplied through alternate metadata.
  * Upload checks now consistently reject light re-encode releases when they are not allowed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->