### PR TITLE
fix(TORR9): widen dupe search to title+year only

### DIFF
--- a/src/trackers/TORR9.py
+++ b/src/trackers/TORR9.py
@@ -1013,10 +1013,13 @@ class TORR9(FrenchTrackerMixin):
         def _q(s: str) -> str:
             return " ".join(_clean_query(s))
 
-        # Build queries using TORR9's naming pattern (Titre Année Résolution Groupe)
-        # TORR9 allows the same release from different groups, so the group must be
-        # included to avoid false-positive dupe blocks.
-        suffix = " ".join(p for p in [str(year), resolution, group] if p)
+        # Query by title + year only. Resolution and group are deliberately left
+        # out: the search API ranks by relevance over the whole stored name, where
+        # real releases interleave type/codec/audio tokens (…2160p.BluRay.x265…-QTZ),
+        # so a trailing "<res> <group>" tanks the match and the dupe is never
+        # returned. Resolution and group are already enforced by the filters below,
+        # so keeping them out of the query widens recall without losing precision.
+        suffix = str(year).strip()
 
         search_queries: list[str] = []
         is_original_french = str(meta.get("original_language", "")).lower() == "fr"

--- a/tests/test_torr9.py
+++ b/tests/test_torr9.py
@@ -1197,6 +1197,51 @@ class TestDupeRelevanceFilter:
         assert 'Intouchables' in first_call.kwargs.get('params', {}).get('q', '')
         assert len(dupes) == 1
 
+    def test_search_query_excludes_resolution_and_group(self):
+        """Query is title+year only — resolution/group would break relevance matching.
+
+        Regression: existing releases that interleave codec/type tokens between the
+        resolution and the group (e.g. ...2160p.BluRay.x265.AC3.5.1-QTZ) were never
+        returned by the API when the query ended in "<res> <group>", so obvious
+        dupes slipped through. Resolution/group stay as post-filters, not in the query.
+        """
+        t = TORR9(_config())
+        t._bearer_token = 'test-token'
+        meta = _meta_base(
+            title='Jurassic Park III',
+            frtitle='Jurassic Park III',
+            year='2001',
+            resolution='2160p',
+            original_language='en',
+            tag='-QTZ',
+        )
+
+        # Existing release: differently formatted, but same title/year/res/group.
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {
+            'data': [
+                {'title': 'Jurassic.Park.III.2001.MULTI.2160p.BluRay.x265.AC3.5.1-QTZ', 'id': 600},
+            ]
+        }
+
+        with patch('httpx.AsyncClient') as MockClient:
+            client_instance = AsyncMock()
+            client_instance.get = AsyncMock(return_value=resp)
+            client_instance.__aenter__ = AsyncMock(return_value=client_instance)
+            client_instance.__aexit__ = AsyncMock(return_value=False)
+            MockClient.return_value = client_instance
+
+            dupes = _run(t.search_existing(meta, ''))
+
+        q = client_instance.get.call_args_list[0].kwargs.get('params', {}).get('q', '')
+        assert 'Jurassic Park III' in q
+        assert '2001' in q
+        assert '2160p' not in q
+        assert 'QTZ' not in q.upper()
+        # The differently-formatted existing release is still detected as a dupe.
+        assert len(dupes) == 1
+
     def test_tv_dupes_without_year_in_name(self):
         """TV torrents whose names lack the year should still be detected as duplicates."""
         t = TORR9(_config())


### PR DESCRIPTION
The dupe search query was built as "<title> <year> <resolution> <group>". Real release names interleave type/codec/audio tokens between the resolution and the group, so a relevance/proximity search API never returned the candidate when the query ended in "<res> <group>" — obvious dupes (different formatting, same title/year/res/group) slipped through.

Resolution and group are already enforced by the local post-filters, so including them in the query was redundant and only hurt recall. Query by title+year; filters keep precision.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate detection for TORR9 searches so releases with mixed title tokens are less likely to be missed.
  * Search queries now use a simpler suffix, helping results surface correctly while keeping existing duplicate filtering behavior intact.
* **Tests**
  * Added regression coverage to confirm the search query excludes resolution and group tags while still matching relevant duplicates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->