### PR TITLE
fix(TORR9): walk all dupe search result pages

### DIFF
--- a/src/trackers/TORR9.py
+++ b/src/trackers/TORR9.py
@@ -1055,26 +1055,41 @@ class TORR9(FrenchTrackerMixin):
 
             async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
                 for search_term in search_queries:
-                    try:
-                        response = await client.get(
-                            "https://api.torr9.net/api/v1/torrents/search",
-                            headers=headers,
-                            params={"q": search_term},
-                        )
-                    except Exception:  # noqa: BLE001
-                        continue  # nosec B112 — skip failed search queries gracefully
+                    # The API paginates (default 25/page). A popular title can span
+                    # several pages (e.g. ~230 results for Game of Thrones), and a
+                    # matching edition on a later page would be missed if we only
+                    # read the first. Walk every page so all editions are checked.
+                    items: list[Any] = []
+                    page = 1
+                    while page <= 50:  # hard cap so a misreported total can't loop forever
+                        try:
+                            response = await client.get(
+                                "https://api.torr9.net/api/v1/torrents/search",
+                                headers=headers,
+                                params={"q": search_term, "limit": 100, "page": page},
+                            )
+                        except Exception:  # noqa: BLE001
+                            break  # nosec B112 — skip failed search queries gracefully
 
-                    if response.status_code != 200:
-                        if meta.get("debug"):
-                            console.print(f"[yellow]TORR9 search returned HTTP {response.status_code} for '{search_term}'[/yellow]")
-                        continue
+                        if response.status_code != 200:
+                            if meta.get("debug"):
+                                console.print(f"[yellow]TORR9 search returned HTTP {response.status_code} for '{search_term}'[/yellow]")
+                            break
 
-                    try:
-                        data = response.json()
-                    except json.JSONDecodeError:
-                        continue
+                        try:
+                            data = response.json()
+                        except json.JSONDecodeError:
+                            break
 
-                    items = data.get("torrents", data.get("data", []))
+                        page_items = data.get("torrents", data.get("data", []))
+                        if not page_items:
+                            break
+                        items.extend(page_items)
+
+                        if page >= (data.get("total_pages", 1) or 1):
+                            break
+                        page += 1
+
                     if not items:
                         continue
 

--- a/src/trackers/TORR9.py
+++ b/src/trackers/TORR9.py
@@ -1061,6 +1061,7 @@ class TORR9(FrenchTrackerMixin):
                     # read the first. Walk every page so all editions are checked.
                     items: list[Any] = []
                     page = 1
+                    incomplete = False
                     while page <= 50:  # hard cap so a misreported total can't loop forever
                         try:
                             response = await client.get(
@@ -1069,16 +1070,19 @@ class TORR9(FrenchTrackerMixin):
                                 params={"q": search_term, "limit": 100, "page": page},
                             )
                         except Exception:  # noqa: BLE001
-                            break  # nosec B112 — skip failed search queries gracefully
+                            incomplete = True
+                            break
 
                         if response.status_code != 200:
                             if meta.get("debug"):
                                 console.print(f"[yellow]TORR9 search returned HTTP {response.status_code} for '{search_term}'[/yellow]")
+                            incomplete = True
                             break
 
                         try:
                             data = response.json()
                         except json.JSONDecodeError:
+                            incomplete = True
                             break
 
                         page_items = data.get("torrents", data.get("data", []))
@@ -1089,6 +1093,14 @@ class TORR9(FrenchTrackerMixin):
                         if page >= (data.get("total_pages", 1) or 1):
                             break
                         page += 1
+
+                    # A failed/unparseable page leaves us with only part of the
+                    # result set — a dupe could sit on a page we never read. Fail
+                    # closed: skip the tracker rather than upload over a possible dupe.
+                    if incomplete:
+                        console.print(f"[yellow]TORR9: incomplete dupe search for '{search_term}', skipping tracker to avoid a false negative.[/yellow]")
+                        meta["skipping"] = self.tracker
+                        return []
 
                     if not items:
                         continue

--- a/tests/test_torr9.py
+++ b/tests/test_torr9.py
@@ -1242,6 +1242,48 @@ class TestDupeRelevanceFilter:
         # The differently-formatted existing release is still detected as a dupe.
         assert len(dupes) == 1
 
+    def test_search_walks_all_pages(self):
+        """Dupes on later pages must still be found.
+
+        Regression: the API paginates (default 25/page, total_pages can be >1). A
+        popular title (e.g. ~230 results) spreads matching editions across pages;
+        an exact-name dupe on page 2 slipped through when only page 1 was read.
+        The search must walk every page until total_pages.
+        """
+        t = TORR9(_config())
+        t._bearer_token = 'test-token'
+        meta = _meta_base(title='Les enfants vont bien', frtitle='Les enfants vont bien',
+                          year='2025', resolution='1080p', original_language='fr', tag='-FW')
+
+        # Page 1: no match. Page 2: the -FW dupe. Single (fr) search term → 2 pages.
+        page1 = MagicMock()
+        page1.status_code = 200
+        page1.json.return_value = {
+            'torrents': [{'title': 'Les.enfants.vont.bien.2025.FRENCH.1080p.WEB.H265-OTHER', 'id': 1}],
+            'total_pages': 2,
+        }
+        page2 = MagicMock()
+        page2.status_code = 200
+        page2.json.return_value = {
+            'torrents': [{'title': 'Les.enfants.vont.bien.2025.FRENCH.1080p.WEB.H264-FW', 'id': 2}],
+            'total_pages': 2,
+        }
+
+        with patch('httpx.AsyncClient') as MockClient:
+            client_instance = AsyncMock()
+            client_instance.get = AsyncMock(side_effect=[page1, page2])
+            client_instance.__aenter__ = AsyncMock(return_value=client_instance)
+            client_instance.__aexit__ = AsyncMock(return_value=False)
+            MockClient.return_value = client_instance
+
+            dupes = _run(t.search_existing(meta, ''))
+
+        # Both pages were requested, with ascending page numbers.
+        pages = [c.kwargs.get('params', {}).get('page') for c in client_instance.get.call_args_list]
+        assert pages[:2] == [1, 2]
+        # The dupe from page 2 was detected.
+        assert any(d['name'].endswith('-FW') for d in dupes)
+
     def test_tv_dupes_without_year_in_name(self):
         """TV torrents whose names lack the year should still be detected as duplicates."""
         t = TORR9(_config())

--- a/tests/test_torr9.py
+++ b/tests/test_torr9.py
@@ -1278,11 +1278,45 @@ class TestDupeRelevanceFilter:
 
             dupes = _run(t.search_existing(meta, ''))
 
-        # Both pages were requested, with ascending page numbers.
-        pages = [c.kwargs.get('params', {}).get('page') for c in client_instance.get.call_args_list]
-        assert pages[:2] == [1, 2]
+        # Both pages were requested, with ascending page numbers and the
+        # widened page size (limit=100, not the API's default 25).
+        params = [c.kwargs.get('params', {}) for c in client_instance.get.call_args_list]
+        assert [p.get('page') for p in params[:2]] == [1, 2]
+        assert all(int(p.get('limit', 25)) == 100 for p in params[:2])
         # The dupe from page 2 was detected.
         assert any(d['name'].endswith('-FW') for d in dupes)
+
+    def test_partial_page_walk_fails_closed(self):
+        """If a later page can't be read, skip the tracker instead of risking a miss.
+
+        A dupe could sit on the page we failed to fetch, so proceeding on partial
+        results would be a false negative. Fail closed: mark the tracker skipped.
+        """
+        t = TORR9(_config())
+        t._bearer_token = 'test-token'
+        meta = _meta_base(title='Game of Thrones', frtitle='Game of Thrones',
+                          year='2011', resolution='1080p', original_language='en', tag='-FW')
+
+        page1 = MagicMock()
+        page1.status_code = 200
+        page1.json.return_value = {
+            'torrents': [{'title': 'Game.of.Thrones.S01.1080p.WEB-OTHER', 'id': 1}],
+            'total_pages': 3,
+        }
+        page2_err = MagicMock()
+        page2_err.status_code = 503  # transient failure mid-walk
+
+        with patch('httpx.AsyncClient') as MockClient:
+            client_instance = AsyncMock()
+            client_instance.get = AsyncMock(side_effect=[page1, page2_err])
+            client_instance.__aenter__ = AsyncMock(return_value=client_instance)
+            client_instance.__aexit__ = AsyncMock(return_value=False)
+            MockClient.return_value = client_instance
+
+            dupes = _run(t.search_existing(meta, ''))
+
+        assert dupes == []
+        assert meta.get('skipping') == t.tracker
 
     def test_tv_dupes_without_year_in_name(self):
         """TV torrents whose names lack the year should still be detected as duplicates."""


### PR DESCRIPTION
The search API paginates (default 25/page; total_pages can be >1). For a popular title the matching edition lands on a later page and is never checked, so a dupe slips through (observed: an upload went ahead while Les.enfants.vont.bien.2025.FRENCH.1080p.WEB.H264-FW already existed — 33 results, the -FW one on page 2; Game of Thrones returns ~230).

Request limit=100 and loop over total_pages so every edition is checked. A hard cap of 50 pages guards against a misreported total.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate search to check through all available result pages, making it more reliable at finding matches that may not appear on the first page.
  * Added safer handling for failed search responses so processing can continue for other items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->