### PR TITLE
fix(FR): tag original Québécois audio as VOQ, not VOF

### DIFF
--- a/src/trackers/C411.py
+++ b/src/trackers/C411.py
@@ -722,6 +722,7 @@ class C411(FrenchTrackerMixin):
             "MULTI.VFF": 4,
             "MULTI.VFI": 4,
             "MULTI.VFQ": 5,
+            "MULTI.VOQ": 5,
             "MULTI.VOF": 4,
             "MULTI.TRUEFRENCH": 4,
             "MULTI": 4,
@@ -730,6 +731,7 @@ class C411(FrenchTrackerMixin):
             "VFF": 2,
             "VFI": 2,
             "VFQ": 6,
+            "VOQ": 6,
             "VOSTFR": 8,
         }
         return tag_map.get(language_tag, 1)  # default: 1 (Anglais)

--- a/src/trackers/FRENCH.py
+++ b/src/trackers/FRENCH.py
@@ -880,8 +880,10 @@ class FrenchTrackerMixin:
                 return "VF2"
             if is_original_french:
                 # Original French production. Distinguish Québec (fr-CA audio) from
-                # France: a Québécois original is VOQ, a French one VOF.
-                if fr_suffix == "VFQ" or is_vfq_filename:
+                # France: a Québécois original is VOQ, a French one VOF. Filename VFQ
+                # only counts as a fallback when MediaInfo carries no explicit region,
+                # so an explicit fr-FR (VFF) is never overridden to VOQ.
+                if fr_suffix == "VFQ" or (not fr_suffix and is_vfq_filename):
                     return "VOQ"
                 return "VOF"
             if is_vfi:
@@ -912,7 +914,7 @@ class FrenchTrackerMixin:
         # ── Single French track ──
         else:
             # Includes the original-French case: _fr_precision() returns VOF, or
-            # VFQ when the original audio is Québécois (fr-CA).
+            # VOQ when the original audio is Québécois (fr-CA).
             language = _fr_precision()
 
         # ── Audio Description prefix ──

--- a/src/trackers/FRENCH.py
+++ b/src/trackers/FRENCH.py
@@ -353,6 +353,7 @@ FRENCH_LANG_HIERARCHY: dict[str, int] = {
     "VFB": 6,
     "VF2": 6,
     "VOF": 5,
+    "VOQ": 5,  # original Québécois audio — Québec counterpart of VOF
     "TRUEFRENCH": 4,
     "FRENCH": 3,
     "VOSTFR": 2,
@@ -878,6 +879,10 @@ class FrenchTrackerMixin:
             if is_vf2_filename:
                 return "VF2"
             if is_original_french:
+                # Original French production. Distinguish Québec (fr-CA audio) from
+                # France: a Québécois original is VOQ, a French one VOF.
+                if fr_suffix == "VFQ" or is_vfq_filename:
+                    return "VOQ"
                 return "VOF"
             if is_vfi:
                 return "VFI"
@@ -905,9 +910,9 @@ class FrenchTrackerMixin:
         elif [la for la in audio_langs if la != "FRA"] or num_audio_tracks > 1 or has_non_french_ad:
             language = f"MULTI.{_fr_precision()}"
         # ── Single French track ──
-        elif is_original_french:
-            language = "VOF"
         else:
+            # Includes the original-French case: _fr_precision() returns VOF, or
+            # VFQ when the original audio is Québécois (fr-CA).
             language = _fr_precision()
 
         # ── Audio Description prefix ──

--- a/tests/test_french_dupe.py
+++ b/tests/test_french_dupe.py
@@ -1547,3 +1547,37 @@ class TestFormatHdrDvBbcode:
     def test_wcg(self):
         c = C411(_config())
         assert c._format_hdr_dv_bbcode({'hdr': 'WCG'}) == 'WCG'
+
+
+# ═══════════════════════════════════════════════════════════════
+#   _build_audio_string — original Québécois (VOQ vs VOF)
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestOriginalQuebecois:
+    """An original French production with Québec audio is VOQ, not VOF."""
+
+    def test_single_quebec_original_track_is_voq(self):
+        """fr-CA single track + original_language fr → VOQ (regression: was VOF)."""
+        host = _mixin()
+        meta = _meta_base(
+            category='TV',
+            season='S01',
+            original_language='fr',
+            mediainfo=_mi([_audio_track('fr-CA')]),
+        )
+        assert asyncio.run(host._build_audio_string(meta)) == 'VOQ'
+
+    def test_single_france_original_track_is_vof(self):
+        """fr-FR single track + original_language fr → VOF (unchanged)."""
+        host = _mixin()
+        meta = _meta_base(original_language='fr', mediainfo=_mi([_audio_track('fr-FR')]))
+        assert asyncio.run(host._build_audio_string(meta)) == 'VOF'
+
+    def test_voq_recognised_in_hierarchy(self):
+        """VOQ is a known FR audio tag at original-audio level (same as VOF)."""
+        tag, level = FrenchTrackerMixin._extract_french_lang_tag(
+            'Le.dernier.des.monstres.2025.S01.VOQ.1080p.WEB.H264-TFA'
+        )
+        assert tag == 'VOQ'
+        assert level == 5

--- a/tests/test_french_dupe.py
+++ b/tests/test_french_dupe.py
@@ -1581,3 +1581,13 @@ class TestOriginalQuebecois:
         )
         assert tag == 'VOQ'
         assert level == 5
+
+    def test_explicit_france_not_overridden_by_vfq_filename(self):
+        """Explicit fr-FR audio wins over a stray VFQ filename token → VOF, not VOQ."""
+        host = _mixin()
+        meta = _meta_base(
+            original_language='fr',
+            name='Film.2025.VFQ.1080p.WEB.H264-GRP',
+            mediainfo=_mi([_audio_track('fr-FR')]),
+        )
+        assert asyncio.run(host._build_audio_string(meta)) == 'VOF'


### PR DESCRIPTION
_build_audio_string returned VOF for any original-French production (is_original_french → "VOF") without checking the audio region, so a Québécois original (fr-CA audio, MediaInfo shows VFQ) was mislabelled VOF.

Distinguish France (VOF) from Québec (VOQ) in _fr_precision, and drop the redundant single-track is_original_french shortcut so the region-aware path is used. Register VOQ in the FR language hierarchy (level 5, same as VOF) and map it on C411 (VOQ→6 Québécois, MULTI.VOQ→5). HDF already handled VOQ; NST folds it into VOF.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for additional French/Québécois language tags, including multi-variant VOQ handling.

* **Bug Fixes**
  * Improved audio language labeling to correctly distinguish Québec French vs France French when marking original-language audio.
  * Fixed cases where a Quebec-focused token could incorrectly override an explicitly detected France French audio choice.

* **Tests**
  * Added/expanded coverage to verify Québec vs France French behavior and correct language-tag recognition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->