### PR TITLE
fix(G3MINI): never emit the UHD token in release names

### DIFF
--- a/src/trackers/G3MINI.py
+++ b/src/trackers/G3MINI.py
@@ -211,11 +211,9 @@ class G3MINI(FrenchTrackerMixin, UNIT3D):
         three_d = meta.get("3D", "")
         tag = meta.get("tag", "")
         source = meta.get("source", "")
-        uhd = meta.get("uhd", "")
-        # G3MINI: "1080p UHD BluRay" is not a valid token combination — UHD
-        # denotes a 2160p source; strip it when resolution is not 2160p.
-        if resolution and resolution != "2160p":
-            uhd = ""
+        # G3MINI never carries the UHD token: it's redundant with 2160p (which
+        # already denotes UHD) and invalid on any lower resolution.
+        uhd = ""
         hdr = meta.get("hdr", "")
         hybrid = str(meta.get("webdv", "")) if meta.get("webdv", "") else ""
         # Ensure the following variables are always defined

--- a/tests/test_g3mini.py
+++ b/tests/test_g3mini.py
@@ -721,10 +721,11 @@ class TestNogroupWebDL:
 
 
 class TestG3MINIUhdStripping:
-    """G3MINI rejects '1080p.UHD.BluRay' — UHD is only valid at 2160p.
+    """G3MINI never carries the UHD token.
 
-    When the release is 1080p (or any non-4K resolution), the UHD token
-    must be stripped from the name even if meta['uhd'] is set.
+    At 2160p it's redundant (2160p already denotes UHD); at any lower
+    resolution it's invalid. Either way it must be stripped from the name
+    even when meta['uhd'] is set.
     """
 
     def _get_name(self, meta: dict) -> str:
@@ -754,8 +755,8 @@ class TestG3MINIUhdStripping:
         name = self._get_name(meta)
         assert 'UHD' not in name, f"'UHD' must be stripped for 1080p ENCODE, got: {name!r}"
 
-    def test_2160p_remux_uhd_preserved(self):
-        """2160p BluRay REMUX must keep 'UHD' in the name."""
+    def test_2160p_remux_uhd_stripped(self):
+        """2160p BluRay REMUX must not repeat 'UHD' — it's redundant with 2160p."""
         meta = _meta_base(
             resolution='2160p',
             uhd='UHD',
@@ -763,7 +764,7 @@ class TestG3MINIUhdStripping:
             source='BluRay',
         )
         name = self._get_name(meta)
-        assert 'UHD' in name, f"'UHD' must be preserved for 2160p, got: {name!r}"
+        assert 'UHD' not in name, f"'UHD' must be stripped for 2160p, got: {name!r}"
 
     def test_1080p_without_uhd_unaffected(self):
         """1080p release with uhd='' must not have 'UHD' introduced."""


### PR DESCRIPTION
2160p already denotes UHD, so "2160p UHD BluRay" repeats the same info; at lower resolutions the token is invalid. Strip it unconditionally instead of only when resolution != 2160p.