### PR TITLE
fix(G3MINI): render HDR10+ as HDR10P

### DIFF
--- a/src/trackers/G3MINI.py
+++ b/src/trackers/G3MINI.py
@@ -214,7 +214,8 @@ class G3MINI(FrenchTrackerMixin, UNIT3D):
         # G3MINI never carries the UHD token: it's redundant with 2160p (which
         # already denotes UHD) and invalid on any lower resolution.
         uhd = ""
-        hdr = meta.get("hdr", "")
+        # G3MINI spells HDR10+ as HDR10P (no '+' in the tag).
+        hdr = meta.get("hdr", "").replace("HDR10+", "HDR10P")
         hybrid = str(meta.get("webdv", "")) if meta.get("webdv", "") else ""
         # Ensure the following variables are always defined
         name = ""

--- a/tests/test_g3mini.py
+++ b/tests/test_g3mini.py
@@ -776,3 +776,21 @@ class TestG3MINIUhdStripping:
         )
         name = self._get_name(meta)
         assert 'UHD' not in name, f"'UHD' must not appear, got: {name!r}"
+
+
+class TestG3MINIHdr10Plus:
+    """G3MINI spells HDR10+ as HDR10P (no '+')."""
+
+    def _get_name(self, meta: dict) -> str:
+        return asyncio.run(G3MINI(_config()).get_name(meta))['name']
+
+    def test_hdr10_plus_becomes_hdr10p(self):
+        meta = _meta_base(
+            resolution='2160p',
+            type='REMUX',
+            source='BluRay',
+            hdr='HDR10+',
+        )
+        name = self._get_name(meta)
+        assert 'HDR10P' in name, f"HDR10+ must render as HDR10P, got: {name!r}"
+        assert 'HDR10+' not in name, f"'+' must be gone, got: {name!r}"


### PR DESCRIPTION
G3MINI's tag convention drops the '+': HDR10+ is spelled HDR10P.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed G3MINI release naming so HDR10+ is now shown in the expected HDR10P format.
  * Improved consistency in generated names to match the device’s tag style.
* **Tests**
  * Added coverage to confirm HDR10+ names are formatted correctly and no longer include the literal `HDR10+`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->