### PR TITLE
NST (fix): Fix NST with new rules :

### DIFF
--- a/src/trackers/NST.py
+++ b/src/trackers/NST.py
@@ -56,7 +56,7 @@ class NST(FrenchTrackerMixin, UNIT3D):
     # NST uses original (English) titles
     PREFER_ORIGINAL_TITLE: bool = True
 
-    # NST wants streaming service in name
+    # NST doesn't want streaming service in name
     INCLUDE_SERVICE_IN_NAME: bool = False
 
     UHD_ONLY_FOR_REMUX_DISC: bool = True
@@ -172,7 +172,7 @@ class NST(FrenchTrackerMixin, UNIT3D):
             check_subtitle=False,
         ):
             console.print(f"[bold red]{self.tracker} requires French language unless there has never been a dubbed version.[/bold red]")
-            french_missing_confirm = cli_ui.ask_yes_no("Do you want to proceed anyway?", default=False)
+            french_missing_confirm = cli_ui.ask_yes_no("Do you want to proceed anyway?", default=True)
             return french_missing_confirm
         return True
 
@@ -460,7 +460,7 @@ class NST(FrenchTrackerMixin, UNIT3D):
             if sub in (qc_aliases | fr_aliases | be_aliases) and not has_vf:
                 detected_langs.add("VOSTFR")
 
-        if "Autre" in detected_langs and "VOSTFR" not in detected_langs and not langs:
+        if "Autre" in detected_langs and "VOSTFR" not in detected_langs and not langs and not has_vf:
             return ""
 
         final_tags = [tag for tag in ("VOF", "VFF", "VFQ", "VFB", "VFI", "VOSTFR", "AD", "MUET", "VO") if tag in langs or tag in detected_langs]

--- a/src/trackers/NST.py
+++ b/src/trackers/NST.py
@@ -463,9 +463,6 @@ class NST(FrenchTrackerMixin, UNIT3D):
         if "Autre" in detected_langs and "VOSTFR" not in detected_langs and not langs:
             return ""
 
-        final_tags = []
-        for tag in ("VOF", "VFF", "VFQ", "VFB", "VFI", "VOSTFR", "AD", "MUET", "VO"):
-            if tag in langs or tag in detected_langs:
-                final_tags.append(tag)
+        final_tags = [tag for tag in ("VOF", "VFF", "VFQ", "VFB", "VFI", "VOSTFR", "AD", "MUET", "VO") if tag in langs or tag in detected_langs]
 
         return ", ".join(final_tags)

--- a/src/trackers/NST.py
+++ b/src/trackers/NST.py
@@ -4,6 +4,7 @@ import re
 from typing import Any
 
 import aiofiles
+import cli_ui
 
 from src.console import console
 from src.get_desc import DescriptionBuilder
@@ -56,7 +57,7 @@ class NST(FrenchTrackerMixin, UNIT3D):
     PREFER_ORIGINAL_TITLE: bool = True
 
     # NST wants streaming service in name
-    INCLUDE_SERVICE_IN_NAME: bool = True
+    INCLUDE_SERVICE_IN_NAME: bool = False
 
     UHD_ONLY_FOR_REMUX_DISC: bool = True
 
@@ -170,9 +171,10 @@ class NST(FrenchTrackerMixin, UNIT3D):
             check_audio=True,
             check_subtitle=False,
         ):
-            console.print(f"[bold red]{self.tracker} requiert au moins une piste audio VF.[/bold red]")
-            return False
-        return await self.predb_fr_check(meta)
+            console.print(f"[bold red]{self.tracker} requires French language unless there has never been a dubbed version.[/bold red]")
+            french_missing_confirm = cli_ui.ask_yes_no("Do you want to proceed anyway?", default=False)
+            return french_missing_confirm
+        return True
 
     # ── Image host gating ─────────────────────────────────────────────
 
@@ -387,43 +389,50 @@ class NST(FrenchTrackerMixin, UNIT3D):
         data["langue"] = self._detect_nst_langue(meta)
         return data
 
+    async def get_name(self, meta: dict[str, Any]) -> dict[str, str]:
+        result = await super().get_name(meta)
+        # Atmos before channel
+        name = re.sub(
+            r"\.(DDP|AC3|EAC3|DTS|TRUEHD|FLAC|AAC|LPCM|DTS\.HD\.MA|DTS\.HD\.HRA|DTS\.X)\.(\d\.\d)\.ATMOS([.-])", r".\1.Atmos.\2\3", result["name"], flags=re.IGNORECASE
+        )
+        # When DV.HDR needs to precise HDR10
+        name = name.replace("DV.HDR.", "DV.HDR10.")
+        return {"name": name}
+
     @staticmethod
     def _detect_nst_langue(meta: dict[str, Any]) -> str:
         """Derive the NST langue tag from the release name / audio metadata.
 
-        NST accepts: VOF, VFF, VFI, VFQ, VO.
+        NST accepts: VOF, VFF, VFI, VFQ, VFB, VOSTFR, AD, MUET, VO.
         """
         name = meta.get("uuid") or meta.get("name", "")  # More precise on UUID, UA remove Multi etc when forging name
         upper = name.upper().replace(" ", ".")
         langs = []
 
-        # New regex
-        if re.search(r"(?:^|\.)(TRUEFRENCH|FRENCH|VOF|VOB|VOQ)(?:\.|$)", upper):
-            langs.append("VOF")
+        patterns = [
+            (r"(?:^|\.)(TRUEFRENCH|FRENCH|VOF|VOB|VOQ)(?:\.|$)", ["VOF"]),
+            (r"(?:^|\.)(VF2)(?:\.|$)", ["VFF", "VFQ"]),
+            (r"(?:^|\.)(VF[3-9])(?:\.|$)", ["VFF"]),
+            (r"(?:^|\.)(VFQ)(?:\.|$)", ["VFQ"]),
+            (r"(?:^|\.)(VFB)(?:\.|$)", ["VFB"]),
+            (r"(?:^|\.)(VFF)(?:\.|$)", ["VFF"]),
+            (r"(?:^|\.)(VF)(?:\.|$)", ["VFF"]),
+            (r"(?:^|\.)(VFI)(?:\.|$)", ["VFI"]),
+            (r"(?:^|\.)(VOSTFR)(?:\.|$)", ["VOSTFR"]),
+            (r"(?:^|\.)(AD)(?:\.|$)", ["AD"]),
+            (r"(?:^|\.)(MUET)(?:\.|$)", ["MUET"]),
+            (r"(?:^|\.)(MULTI)(?:\.|$)", ["VO"]),
+        ]
 
-        if re.search(r"(?:^|\.)(VF2)(?:\.|$)", upper):
-            langs.append("VFQ")
-
-        if re.search(r"(?:^|\.)(VF\d*)(?:\.|$)", upper):
-            langs.append("VFF")
-
-        if re.search(r"(?:^|\.)(VFF)(?:\.|$)", upper):
-            langs.append("VFF")
-
-        if re.search(r"(?:^|\.)(VFI)(?:\.|$)", upper):
-            langs.append("VFI")
-
-        if re.search(r"(?:^|\.)(VFQ)(?:\.|$)", upper):
-            langs.append("VFQ")
-
-        if re.search(r"(?:^|\.)(MULTI)(?:\.|$)", upper):
-            langs.append("VO")
+        for pattern, tags in patterns:
+            if re.search(pattern, upper):
+                langs.extend(tags)
 
         # Fallback: inspect Mediainfo
-
         tracks = meta.get("mediainfo", {}).get("media", {}).get("track", [])
         langs_mi = [t for t in tracks if t.get("@type") == "Audio" and not FrenchTrackerMixin._is_audio_desc_track(t)]
         langs_all = langs_mi if langs_mi else (meta.get("audio_languages") or [])  # Ultimate fallback
+        sub_mi = [t for t in tracks if t.get("@type") == "Text"]
 
         fr_aliases = {"french", "français", "francais", "fra", "fre", "fr", "fr-fr"}
         qc_aliases = {"fr-ca", "qc", "fr-qc"}
@@ -436,23 +445,27 @@ class NST(FrenchTrackerMixin, UNIT3D):
             if lang in qc_aliases:
                 detected_langs.add("VFQ")
             elif lang in be_aliases:
-                detected_langs.add("VFF")  # franco-belge -> VFF
+                detected_langs.add("VFB")
             elif lang in fr_aliases:
                 detected_langs.add("VFF")
             else:
                 detected_langs.add("Autre")
 
-        # VO if more than one audiotrack (MULTi implies the original language)
-        if len(langs_all) > 1 and "VO" not in langs and "Autre" in detected_langs:
-            langs.append("VO")
+        # If there's no French dub, we can upload VOSTFR.
+        # We'll check if it's VO and that there is French subtitles.
+        has_vf = any(lang in {"VFF", "VFQ", "VFB"} for lang in detected_langs)
 
-        # Add tag if not already inside
-        for tag in ("VFF", "VFQ"):
-            if tag in detected_langs and tag not in langs:
-                langs.append(tag)
+        for t in sub_mi:
+            sub = (t.get("Language") or "").lower().strip()
+            if sub in (qc_aliases | fr_aliases | be_aliases) and not has_vf:
+                detected_langs.add("VOSTFR")
 
-        # If not French without VO, return empty
-        if "Autre" in detected_langs and "VO" not in langs:
+        if "Autre" in detected_langs and "VOSTFR" not in detected_langs and not langs:
             return ""
 
-        return ", ".join(langs)
+        final_tags = []
+        for tag in ("VOF", "VFF", "VFQ", "VFB", "VFI", "VOSTFR", "AD", "MUET", "VO"):
+            if tag in langs or tag in detected_langs:
+                final_tags.append(tag)
+
+        return ", ".join(final_tags)

--- a/tests/test_nst.py
+++ b/tests/test_nst.py
@@ -70,6 +70,11 @@ def _audio_track(lang: str = 'fr', **kw: Any) -> dict[str, Any]:
     t.update(kw)
     return t
 
+def _text_track(lang: str = "fr", **kw: Any) -> dict[str, Any]:
+    t: dict[str, Any] = {"@type": "Text", "Language": lang}
+    t.update(kw)
+    return t
+
 def _mi(audio: list[dict[str, Any]], subs: list[dict[str, Any]] | None = None) -> dict[str, Any]:
     tracks = list(audio)
     if subs:
@@ -228,7 +233,7 @@ class TestTrackerIdentity:
         assert NST.PREFER_ORIGINAL_TITLE is True
 
     def test_include_service_in_name(self):
-        assert NST.INCLUDE_SERVICE_IN_NAME is True
+        assert NST.INCLUDE_SERVICE_IN_NAME is False
 
 
 # ═══════════════════════════════════════════════════════════════
@@ -330,7 +335,7 @@ class TestDetectNstLangue:
         assert NST._detect_nst_langue({"name": "Movie.2026.VFI.1080p.WEB.H264-GRP"}) == "VFI"
 
     def test_vf2_maps_to_vf(self):
-        assert NST._detect_nst_langue({"name": "Movie.2026.VF2.1080p.WEB.H264-GRP"}) == "VFQ, VFF"
+        assert NST._detect_nst_langue({"name": "Movie.2026.VF2.1080p.WEB.H264-GRP"}) == "VFF, VFQ"
 
     def test_plain_vf_maps_to_vf(self):
         assert NST._detect_nst_langue({"name": "Movie.2026.VF.1080p.WEB.H264-GRP"}) == "VFF"
@@ -359,6 +364,18 @@ class TestDetectNstLangue:
     def test_multi_plain_returns_vf(self):
         assert NST._detect_nst_langue({"name": "Movie.2026.MULTi.HDR.2160p.WEB.H265-GRP"}) == "VO"
 
+    def test_vfb_returns_vfb(self):
+        assert NST._detect_nst_langue({"name": "Movie.2026.VFB.2160p.WEB.H265-GRP"}) == "VFB"
+
+    def test_muet_returns_muet(self):
+        assert NST._detect_nst_langue({"name": "Movie.2026.MUET.2160p.WEB.H265-GRP"}) == "MUET"
+
+    def test_ad_returns_ad(self):
+        assert NST._detect_nst_langue({"name": "Movie.2026.AD.VFF.2160p.WEB.H265-GRP"}) == "VFF, AD"
+
+    def test_vostfr_returns_vostfr(self):
+        assert NST._detect_nst_langue({"name": "Movie.2026.VOSTFR.2160p.WEB.H265-GRP"}) == "VOSTFR"
+
     def test_francais_from_audio_languages(self):
         meta = {"name": "Movie.2026.1080p.WEB-GRP", "audio_languages": ["French"]}
         assert NST._detect_nst_langue(meta) == "VFF"
@@ -369,6 +386,13 @@ class TestDetectNstLangue:
             "mediainfo":_mi([_audio_track('fr-fr', Title="French (AD)")],
                             [_audio_track('fr-fr', Title="French")]) }
         assert NST._detect_nst_langue(meta) == "VFF"
+
+    def test_vostfr_from_mediainfo(self):
+        meta = {
+            "name": "Movie.2026.1080p.WEB-GRP",
+            "mediainfo": _mi([_audio_track("en-en", Title="English")],
+                             [_text_track("fr")])}
+        assert NST._detect_nst_langue(meta) == "VOSTFR"
 
     def test_empty_when_no_data(self):
         assert NST._detect_nst_langue({}) == ""
@@ -511,3 +535,35 @@ class TestNogroupWebDL:
         )
         name = self._get_name(meta)
         assert name.endswith('-FRiENDS'), f"Expected -FRiENDS suffix, got: {name!r}"
+
+class TestName:
+
+    def _get_name(self, meta: dict) -> str:
+        return asyncio.run(NST(_config()).get_name(meta))['name']
+
+    def test_atmos_before_channels(self):
+        """Atmos must be before channels number"""
+        meta = _meta_base(
+            title='Movie',
+            year='2026',
+            audio='TrueHD 7.1 Atmos',
+            video_encode='H.264',
+            video_codec='H.264',
+            tag='-GRP',
+        )
+        name = self._get_name(meta)
+        assert '.TrueHD.Atmos.7.1.' in name, f"Atmos must be before channels number: {name}"
+
+    def test_dv_hdr10(self):
+        """When DV HDR, HDR10 must be written in title"""
+        meta = _meta_base(
+            title='Movie',
+            year='2026',
+            audio='TrueHD 7.1',
+            hdr='DV HDR',
+            video_encode='H.264',
+            video_codec='H.264',
+            tag='-GRP',
+        )
+        name = self._get_name(meta)
+        assert '.DV.HDR10.' in name, f"When DV HDR, HDR10 must be written in title: {name}"


### PR DESCRIPTION
           - Don't include streaming services in title
           - Allow VOSTFR if there is no dubbed version
           - ATMOS must be before channel number
           - DV.HDR becomes DV.HDR10
           - Add "VFB, VOSTFR, AD, MUET" in "langue"
           - Rework _detect_nst_langue with new rules and simplify things
Also predbfr is now down/dead

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added interactive handling for French-language requirements during uploads.
  - Improved recognition of French release and subtitle language tags, including VFB, MUET, AD, and VOSTFR.
  - Updated release naming to place Atmos correctly and display `DV.HDR10.` where applicable.

- **Bug Fixes**
  - Improved language tag ordering and detection when combining release metadata with media information.
  - Corrected VOSTFR identification for releases with French subtitles and non-French audio.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->