### PR TITLE
feat: notify a webhook URL after successful uploads

### DIFF
--- a/data/example-config.py
+++ b/data/example-config.py
@@ -10,7 +10,9 @@ config = {
         "verbose_notification": False,
 
         # Webhook URL notified after each processed upload (Discord-compatible
-        # JSON payload: {"content": "..."}). Leave empty to disable.
+        # JSON payload: an embed with Title/Category/Size/Trackers/Path fields).
+        # Only fires when not in debug mode and at least one tracker upload
+        # succeeded. Leave empty to disable.
         "webhook_url": "",
 
         # tmdb api key **REQUIRED**

--- a/data/example-config.py
+++ b/data/example-config.py
@@ -9,6 +9,10 @@ config = {
         # will print the changelog if an update is available
         "verbose_notification": False,
 
+        # Webhook URL notified after each processed upload (Discord-compatible
+        # JSON payload: {"content": "..."}). Leave empty to disable.
+        "webhook_url": "",
+
         # tmdb api key **REQUIRED**
         # visit "https://www.themoviedb.org/settings/api" copy api key and insert below
         "tmdb_api": "",

--- a/src/configvalidator.py
+++ b/src/configvalidator.py
@@ -21,6 +21,7 @@ REQUIRED_DEFAULT_KEYS: dict[str, type] = {
 DEFAULT_KEY_TYPES: dict[str, tuple[type, ...]] = {
     "update_notification": (bool,),
     "verbose_notification": (bool,),
+    "webhook_url": (str,),
     "tmdb_api": (str,),
     "btn_api": (str,),
     "img_host_1": (str,),

--- a/src/webhook.py
+++ b/src/webhook.py
@@ -1,0 +1,33 @@
+# Upload Assistant © 2025 Audionut & wastaken7 — Licensed under UAPL v1.0
+from datetime import datetime, timezone
+
+import httpx
+
+from src.console import console
+
+EMBED_COLOR = 10613286
+# Discord rejects embed field values over 1024 characters
+MAX_FIELD_LENGTH = 1024
+
+
+async def send_webhook_notification(url: str, title: str, fields: dict[str, str], debug: bool = False) -> None:
+    """POST a Discord-compatible embed payload to a webhook URL. Never raises."""
+    payload = {
+        "embeds": [
+            {
+                "title": title,
+                "color": EMBED_COLOR,
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "fields": [{"name": name, "value": value[:MAX_FIELD_LENGTH]} for name, value in fields.items() if value],
+            }
+        ]
+    }
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            response = await client.post(url, json=payload)
+            if debug:
+                console.print(f"[cyan]Webhook notification response: {response.status_code}")
+    except Exception as e:
+        # Log only the exception type: the webhook URL embeds a secret token
+        # and must never leak into logs via the exception message.
+        console.print(f"[red]Failed to send webhook notification: {type(e).__name__}")

--- a/src/webhook.py
+++ b/src/webhook.py
@@ -25,6 +25,7 @@ async def send_webhook_notification(url: str, title: str, fields: dict[str, str]
     try:
         async with httpx.AsyncClient(timeout=10) as client:
             response = await client.post(url, json=payload)
+            response.raise_for_status()
             if debug:
                 console.print(f"[cyan]Webhook notification response: {response.status_code}")
     except Exception as e:

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -1,0 +1,54 @@
+# Tests for src/webhook.py — Discord-compatible webhook embed notifications
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from src.webhook import EMBED_COLOR, MAX_FIELD_LENGTH, send_webhook_notification
+
+
+def _run(coro: Any) -> Any:
+    return asyncio.run(coro)
+
+
+def _mock_client(post_mock: AsyncMock) -> MagicMock:
+    """Async-context-manager httpx.AsyncClient whose .post is post_mock."""
+    client = MagicMock()
+    client.post = post_mock
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=client)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    return ctx
+
+
+class TestSendWebhookNotification:
+    def test_posts_embed_payload(self):
+        post = AsyncMock(return_value=MagicMock(status_code=204))
+        with patch("src.webhook.httpx.AsyncClient", return_value=_mock_client(post)):
+            _run(send_webhook_notification("https://discord.test/webhook", "Uploadé", {"Title": "X", "Path": "/media/X"}))
+        url_arg = post.await_args.args[0]
+        payload = post.await_args.kwargs["json"]
+        assert url_arg == "https://discord.test/webhook"
+        embed = payload["embeds"][0]
+        assert embed["title"] == "Uploadé"
+        assert embed["color"] == EMBED_COLOR
+        assert "timestamp" in embed
+        assert embed["fields"] == [{"name": "Title", "value": "X"}, {"name": "Path", "value": "/media/X"}]
+
+    def test_empty_fields_are_omitted(self):
+        post = AsyncMock(return_value=MagicMock(status_code=204))
+        with patch("src.webhook.httpx.AsyncClient", return_value=_mock_client(post)):
+            _run(send_webhook_notification("https://discord.test/webhook", "Uploadé", {"Title": "X", "Size": ""}))
+        fields = post.await_args.kwargs["json"]["embeds"][0]["fields"]
+        assert fields == [{"name": "Title", "value": "X"}]
+
+    def test_truncates_field_values_to_discord_limit(self):
+        post = AsyncMock(return_value=MagicMock(status_code=204))
+        with patch("src.webhook.httpx.AsyncClient", return_value=_mock_client(post)):
+            _run(send_webhook_notification("https://discord.test/webhook", "Uploadé", {"Trackers": "x" * 5000}))
+        sent = post.await_args.kwargs["json"]["embeds"][0]["fields"][0]["value"]
+        assert len(sent) == MAX_FIELD_LENGTH
+
+    def test_network_error_does_not_raise(self):
+        post = AsyncMock(side_effect=ConnectionError("boom"))
+        with patch("src.webhook.httpx.AsyncClient", return_value=_mock_client(post)):
+            _run(send_webhook_notification("https://discord.test/webhook", "Uploadé", {"Title": "X"}))

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -52,3 +52,23 @@ class TestSendWebhookNotification:
         post = AsyncMock(side_effect=ConnectionError("boom"))
         with patch("src.webhook.httpx.AsyncClient", return_value=_mock_client(post)):
             _run(send_webhook_notification("https://discord.test/webhook", "Uploadé", {"Title": "X"}))
+
+    def test_non_2xx_response_is_logged_as_failure(self):
+        response = MagicMock(status_code=404)
+        response.raise_for_status.side_effect = RuntimeError("404 for url https://discord.test/webhook/SECRET")
+        post = AsyncMock(return_value=response)
+        with patch("src.webhook.httpx.AsyncClient", return_value=_mock_client(post)), patch("src.webhook.console.print") as console_print:
+            _run(send_webhook_notification("https://discord.test/webhook/SECRET", "Uploadé", {"Title": "X"}))
+        logged = " ".join(str(c.args[0]) for c in console_print.call_args_list)
+        assert "Failed to send webhook notification" in logged
+
+    def test_error_log_never_leaks_webhook_url(self):
+        """The webhook URL embeds a secret token: it must not reach the logs."""
+        sentinel = "tok3n-s3cr3t"
+        url = f"https://discord.test/webhook/{sentinel}"
+        post = AsyncMock(side_effect=ConnectionError(f"cannot reach {url}"))
+        with patch("src.webhook.httpx.AsyncClient", return_value=_mock_client(post)), patch("src.webhook.console.print") as console_print:
+            _run(send_webhook_notification(url, "Uploadé", {"Title": "X"}))
+        logged = " ".join(str(c.args[0]) for c in console_print.call_args_list)
+        assert "ConnectionError" in logged
+        assert sentinel not in logged

--- a/upload.py
+++ b/upload.py
@@ -2091,8 +2091,8 @@ async def do_the_thing(base_dir: str) -> None:
                 else:
                     await DiscordNotifier.send_discord_notification(config, bot, f"Finished uploading: {meta['path']}\n", debug=meta.get("debug", False), meta=meta)
 
-            webhook_url = str(config["DEFAULT"].get("webhook_url", "") or "")
-            if webhook_url and not meta["debug"]:
+            webhook_url = config["DEFAULT"].get("webhook_url", "")
+            if isinstance(webhook_url, str) and webhook_url and not meta["debug"]:
                 tracker_status_all = cast(dict[str, Any], meta.get("tracker_status", {}))
                 uploaded_trackers = [t for t, s in tracker_status_all.items() if isinstance(s, dict) and cast(dict[str, Any], s).get("upload") is True]
                 if uploaded_trackers:

--- a/upload.py
+++ b/upload.py
@@ -63,6 +63,7 @@ from src.trackersetup import (
 from src.trackerstatus import TrackerStatusManager
 from src.uphelper import UploadHelper
 from src.uploadscreens import UploadScreensManager
+from src.webhook import send_webhook_notification
 
 cli_ui.setup(color="always", title="Upload Assistant")
 base_dir = os.path.abspath(os.path.dirname(__file__))
@@ -2089,6 +2090,26 @@ async def do_the_thing(base_dir: str) -> None:
                         console.print(f"[red]Error in tracker print loop: {e}[/red]")
                 else:
                     await DiscordNotifier.send_discord_notification(config, bot, f"Finished uploading: {meta['path']}\n", debug=meta.get("debug", False), meta=meta)
+
+            webhook_url = str(config["DEFAULT"].get("webhook_url", "") or "")
+            if webhook_url and not meta["debug"]:
+                tracker_status_all = cast(dict[str, Any], meta.get("tracker_status", {}))
+                uploaded_trackers = [t for t, s in tracker_status_all.items() if isinstance(s, dict) and cast(dict[str, Any], s).get("upload") is True]
+                if uploaded_trackers:
+                    tracker_links = "".join(build_tracker_status_line(t, tracker_status_all[t]) for t in uploaded_trackers)
+                    try:
+                        size_bytes = sum(os.path.getsize(f) for f in cast(list[str], meta.get("filelist") or []))
+                        size_str = f"{size_bytes / (1024**3):.2f} GB" if size_bytes else ""
+                    except OSError:
+                        size_str = ""
+                    webhook_fields = {
+                        "Title": str(meta.get("name") or os.path.basename(meta["path"])),
+                        "Category": str(meta.get("category") or ""),
+                        "Size": size_str,
+                        "Trackers": tracker_links,
+                        "Path": str(meta["path"]),
+                    }
+                    await send_webhook_notification(webhook_url, "Uploadé", webhook_fields, debug=meta.get("debug", False))
 
             for tracker in meta.get("trumping_trackers", []):
                 console.print(f"[yellow]Submitting trumpable report to {tracker}.....")


### PR DESCRIPTION
New DEFAULT config key "webhook_url": when set, POST a Discord-compatible JSON payload ({"content": ...}) after upload processing, listing the release name and per-tracker torrent links. Errors are swallowed (type name only — the URL embeds a secret token).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Discord-compatible webhook notifications after successful uploads.
  * Notifications include upload status, completed items, metadata, and total file size when available.
  * Webhook URLs can be configured in the main settings; leaving the setting empty disables notifications.
  * Debug mode can suppress notifications.

* **Bug Fixes**
  * Webhook failures no longer interrupt upload processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->