### PR TITLE
fix(tags): drop DTS-HD audio leftovers captured as false group tags

### DIFF
--- a/src/tags.py
+++ b/src/tags.py
@@ -112,9 +112,14 @@ async def get_tag(video: str, meta: dict[str, Any], season_pack_check: bool = Fa
     if tag == "-":
         tag = ""
 
-    # Remove generic "no group" tags
-    if tag and tag[1:].lower() in ["hd.ma.5.1", "untouched"]:
-        tag = ""
+    # Remove generic "no group" tags: leftovers of a hyphenated audio codec
+    # (DTS-HD MA 5.1, DTS-HD.HRA.7.1, …) captured when no real group exists.
+    # The "DTS-" prefix can't be excluded in the extraction regex itself
+    # because "…DTS-GROUP" is a legitimate naming pattern.
+    if tag:
+        normalized = re.sub(r"[\s.]+", ".", tag[1:]).lower().strip(".")
+        if normalized == "untouched" or re.fullmatch(r"hd\.(?:ma|hra?)(?:\.\d\.\d)?", normalized):
+            tag = ""
 
     return tag
 

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -186,6 +186,44 @@ class TestGetTagRealGroups:
 
 
 # ═══════════════════════════════════════════════════════════════
+#  Generic "no group" tags — separator variants
+#  Regression: "…DTS-HD MA 5.1.mkv" (space separators) produced the
+#  false tag "-HD MA 5.1"; only the dotted "hd.ma.5.1" was filtered.
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestGetTagGenericNoGroup:
+    """False tags extracted from audio codecs must be dropped in all separator styles."""
+
+    def test_dts_hd_ma_dotted_returns_empty(self):
+        tag = _run(get_tag("Movie.1991.2160p.UHD.BluRay.REMUX.HDR10+.HEVC.DTS-HD.MA.5.1.mkv", _meta()))
+        assert tag == "", f"Expected empty tag, got {tag!r}"
+
+    def test_dts_hd_ma_spaced_returns_empty(self):
+        """Regression: Terminator 2 … DTS-HD MA 5.1.mkv → tag was '-HD MA 5.1'."""
+        tag = _run(get_tag("Terminator 2 Judgment Day 1991 Hybrid 2160p UHD BluRay REMUX HDR10+ HEVC DTS-HD MA 5.1.mkv", _meta()))
+        assert tag == "", f"Expected empty tag, got {tag!r}"
+
+    def test_dts_hd_hra_spaced_returns_empty(self):
+        """The whole DTS-HD family is generic: HRA profile, any channel layout."""
+        tag = _run(get_tag("Movie.2020.1080p.BluRay.DTS-HD HRA 7.1.mkv", _meta()))
+        assert tag == "", f"Expected empty tag, got {tag!r}"
+
+    def test_dts_hd_ma_stereo_returns_empty(self):
+        tag = _run(get_tag("Movie.2020.1080p.BluRay.DTS-HD.MA.2.0.mkv", _meta()))
+        assert tag == "", f"Expected empty tag, got {tag!r}"
+
+    def test_real_group_after_dts_hd_ma_still_extracted(self):
+        tag = _run(get_tag("Movie.1991.2160p.UHD.BluRay.REMUX.DTS-HD.MA.5.1-CiNEPHiLES.mkv", _meta()))
+        assert tag == "-CiNEPHiLES", f"Expected -CiNEPHiLES, got {tag!r}"
+
+    def test_real_group_directly_after_dts_still_extracted(self):
+        """…DTS-WiKi is a legitimate pattern: the hyphen after DTS can be a real separator."""
+        tag = _run(get_tag("Movie.2010.1080p.BluRay.x264.DTS-WiKi.mkv", _meta()))
+        assert tag == "-WiKi", f"Expected -WiKi, got {tag!r}"
+
+
+# ═══════════════════════════════════════════════════════════════
 #  TV-pack tag: folder has no group tag but files do
 #  Regression for the NOTAG bug where tv_pack path fell back to
 #  meta["uuid"] instead of trying the episode filename.


### PR DESCRIPTION
When a file has no group tag, the extraction regex fires on the hyphen inside "DTS-HD …" and captures the codec tail as the group, e.g.:
    … DTS-HD MA 5.1.mkv → tag "-HD MA 5.1"
    → final name "…DTS-HD MA 5.1-HD MA 5.1"

The old blocklist only matched the literal dotted "hd.ma.5.1". Generalize it to the whole DTS-HD family: MA/HRA/HR profiles, any channel layout, dot or space separators. A "DTS-" lookbehind in the regex is not an option because "…DTS-GROUP" (e.g. DTS-WiKi) is a legitimate naming pattern where the hyphen is a real group separator.