### PR TITLE
fix(ACM): catch Dual-Audio hybrids and strip Dual-Audio from titles

### DIFF
--- a/src/trackers/ACM.py
+++ b/src/trackers/ACM.py
@@ -450,14 +450,17 @@ class ACM:
         # — so we require confirmation and reject unattended (logs can't be added).
         if release_type == "WEBDL":
             audio_codec = str(meta.get("audio", "") or "").upper()
-            if audio_codec.startswith("FLAC") or audio_codec.startswith("LPCM"):
+            # Match anywhere, not just as a prefix: "Dual-Audio FLAC 2.0" is
+            # still a disc-sourced hybrid.
+            hybrid_codec = re.search(r"\b(FLAC|LPCM)\b", audio_codec)
+            if hybrid_codec:
                 if bool(meta.get("unattended")):
                     return _deny(
-                        f"[bold red]{self.tracker}: hybrid WEB-DL ({audio_codec.split()[0]} audio from a disc) requires BDInfo + eac3to logs.[/bold red]\n"
+                        f"[bold red]{self.tracker}: hybrid WEB-DL ({hybrid_codec.group(1)} audio from a disc) requires BDInfo + eac3to logs.[/bold red]\n"
                         "[red]This can't be provided in unattended mode — skipping.[/red]"
                     )
                 console.print(
-                    f"[bold yellow]{self.tracker}: this looks like a hybrid WEB-DL ({audio_codec.split()[0]} audio sourced from a disc). "
+                    f"[bold yellow]{self.tracker}: this looks like a hybrid WEB-DL ({hybrid_codec.group(1)} audio sourced from a disc). "
                     "It needs BDInfo and eac3to logs under spoilers, same as a REMUX.[/bold yellow]"
                 )
                 if not cli_ui.ask_yes_no("Do you have these logs and will you add them to the description after upload?", default=False):
@@ -482,13 +485,14 @@ class ACM:
         if release_type == "REMUX":
             audio_codec_upper = str(meta.get("audio", "") or "").upper()
             channels_str = str(meta.get("channels", "") or "")
-            if (audio_codec_upper.startswith("FLAC") or audio_codec_upper.startswith("LPCM")) and channels_str:
+            lossless_codec = re.search(r"\b(FLAC|LPCM)\b", audio_codec_upper)
+            if lossless_codec and channels_str:
                 try:
                     main_ch = int(channels_str.split(".")[0])
                 except ValueError:
                     main_ch = 0
                 if main_ch > 2:
-                    codec = "LPCM" if audio_codec_upper.startswith("LPCM") else "FLAC"
+                    codec = lossless_codec.group(1)
                     return _deny(
                         f"[bold red]{self.tracker}: Multichannel {codec} ({channels_str}) is not allowed on REMUX.[/bold red]\n"
                         "[red]Multichannel tracks must be converted to DTS-HD MA (DTS-HD Master Audio Suite).[/red]\n"
@@ -786,6 +790,9 @@ class ACM:
 
         # Remove Atmos suffix (integrated into audio codec)
         name = name.replace(" Atmos", "")
+
+        # ACM titles never carry the Dual-Audio tag (any category/type)
+        name = re.sub(r"\s*\bDual-Audio\b", "", name)
 
         # Blu-ray titles don't carry DoVi/HDR/DTS:X tags: the format has a
         # compatibility layer, so these are only tagged on WEB-DL and Remux.

--- a/tests/test_acm.py
+++ b/tests/test_acm.py
@@ -245,6 +245,21 @@ class TestGetName:
         assert "DD+5.1" in result
         assert "DD+ 5.1" not in result
 
+    def test_dual_audio_tag_is_stripped(self):
+        """Regression: Dual-Audio never appears in ACM titles."""
+        acm = ACM(_config())
+        meta = _name_meta(
+            "Title S13 1080p CR WEB-DL Dual-Audio DD+ 2.0 H.264-GRP",
+            audio="Dual-Audio DD+ 2.0",
+            type="WEBDL",
+            category="TV",
+            season="S13",
+            year="",
+        )
+        result = _run(acm.get_name(meta))
+        assert "Dual-Audio" not in result
+        assert "DD+2.0" in result
+
     def test_webdl_dd_no_space(self):
         """DD 5.1 → DD5.1 for streams (non-plus Dolby Digital)."""
         acm = ACM(_config())
@@ -1287,3 +1302,16 @@ class TestAdditionalChecksHybridWebdl:
         acm = ACM(_config())
         meta = _checks_meta(type="WEBDL", audio="DD+ 5.1", unattended=True)
         assert _run(acm.get_additional_checks(meta)) is True
+
+    def test_dual_audio_flac_hybrid_unattended_is_rejected(self):
+        """Regression: "Dual-Audio FLAC 2.0" is still a disc-sourced hybrid —
+        FLAC must be detected anywhere, not only as a prefix of the audio
+        string (and the animation dual-audio exception must not bypass it)."""
+        acm = ACM(_config())
+        meta = _checks_meta(
+            type="WEBDL",
+            audio="Dual-Audio FLAC 2.0",
+            genres="Animation",
+            unattended=True,
+        )
+        assert _run(acm.get_additional_checks(meta)) is False


### PR DESCRIPTION
- The hybrid WEB-DL check (FLAC/LPCM audio ⇒ BDInfo + eac3to logs required) only matched FLAC/LPCM as a *prefix* of the audio string, so "Dual-Audio FLAC 2.0" slipped through. Match the codec anywhere as a word instead; same fix applied to the multichannel-lossless-on-REMUX check which had the identical flaw.
- "Dual-Audio" must never appear in ACM titles (any category/type): strip it in get_name.