### PR TITLE
fix(qbit): be more patient with slow qBittorrent remotes

### DIFF
--- a/src/clients.py
+++ b/src/clients.py
@@ -384,7 +384,7 @@ class Clients(QbittorrentClientMixin, RtorrentClientMixin, DelugeClientMixin, Tr
 
                 if proxy_url:
                     ssl_context = self.create_ssl_context_for_client(client)
-                    qbt_session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=10), connector=aiohttp.TCPConnector(ssl=ssl_context))
+                    qbt_session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30), connector=aiohttp.TCPConnector(ssl=ssl_context))
                 else:
                     qbt_client = await self.init_qbittorrent_client(client)
 

--- a/src/torrent_clients/qbittorrent.py
+++ b/src/torrent_clients/qbittorrent.py
@@ -64,7 +64,7 @@ class QbittorrentClientMixin:
         if proxy_url:
             qbt_proxy_url = proxy_url.rstrip("/")
             ssl_context = self.create_ssl_context_for_client(client)
-            qbt_session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=15), connector=aiohttp.TCPConnector(ssl=ssl_context))
+            qbt_session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30), connector=aiohttp.TCPConnector(ssl=ssl_context))
             qbt_proxy_url = proxy_url.rstrip("/")
         else:
             potential_qbt_client = await self.init_qbittorrent_client(client)
@@ -245,8 +245,14 @@ class QbittorrentClientMixin:
             ssl_context.verify_mode = ssl.CERT_NONE
         return ssl_context
 
-    async def _check_qbit_reachable(self, client: dict[str, Any]) -> bool:
-        """Return True when the qBittorrent API (direct or via proxy) responds."""
+    async def _check_qbit_reachable(self, client: dict[str, Any], attempts: int = 3, timeout: float = 10.0, retry_delay: float = 5.0) -> bool:
+        """Return True when the qBittorrent API (direct or via proxy) responds.
+
+        The result is cached per process by the caller, so a false negative
+        aborts every qBit operation of the run: probe several times with a
+        generous timeout before declaring the client offline (slow remotes
+        and waking tunnels routinely exceed a single short probe).
+        """
         proxy_url = client.get("qui_proxy_url", "").strip()
         if proxy_url:
             check_url = f"{proxy_url.rstrip('/')}/api/v2/app/version"
@@ -254,19 +260,27 @@ class QbittorrentClientMixin:
             qbt_url = str(client.get("qbit_url", "")).rstrip("/")
             qbt_port = client.get("qbit_port", 8080)
             check_url = f"{qbt_url}:{qbt_port}/api/v2/app/version"
-        try:
-            ssl_ctx = self.create_ssl_context_for_client(client)
-            async with (
-                aiohttp.ClientSession(
-                    timeout=aiohttp.ClientTimeout(total=5),
-                    connector=aiohttp.TCPConnector(ssl=ssl_ctx),
-                ) as session,
-                session.get(check_url) as r,
-            ):
-                # 200 = OK, 401/403 = qBit is up but needs auth — all mean reachable
-                return r.status not in (502, 503, 504)
-        except Exception:
-            return False
+        ssl_ctx = self.create_ssl_context_for_client(client)
+        for attempt in range(attempts):
+            try:
+                async with (
+                    aiohttp.ClientSession(
+                        timeout=aiohttp.ClientTimeout(total=timeout),
+                        connector=aiohttp.TCPConnector(ssl=ssl_ctx),
+                    ) as session,
+                    session.get(check_url) as r,
+                ):
+                    # 200 = OK, 401/403 = qBit is up but needs auth — all mean
+                    # reachable. Anything else (5xx, gateway errors, misrouted
+                    # 404…) is treated as unreachable and retried.
+                    if r.status in (200, 401, 403):
+                        return True
+            except Exception:
+                pass
+            if attempt < attempts - 1:
+                console.print(f"[yellow]qBittorrent health check failed (attempt {attempt + 1}/{attempts}), retrying in {retry_delay:.0f}s...")
+                await asyncio.sleep(retry_delay)
+        return False
 
     async def _confirm_proceed_if_offline(self, client: dict[str, Any], meta: dict[str, Any]) -> bool:
         """Check qBittorrent reachability and ask the user what to do if it is offline.
@@ -307,8 +321,8 @@ class QbittorrentClientMixin:
         session: aiohttp.ClientSession,
         url: str,
         params: Optional[dict[str, Any]] = None,
-        max_retries: int = 1,
-        retry_delay: float = 3.0,
+        max_retries: int = 2,
+        retry_delay: float = 5.0,
     ) -> tuple[int, Any]:
         """GET request via QUI proxy with automatic retry on timeout / gateway errors.
 
@@ -418,7 +432,7 @@ class QbittorrentClientMixin:
                     qbt_client = potential_qbt_client
                 elif proxy_url and qbt_session is None:
                     ssl_context = self.create_ssl_context_for_client(client)
-                    qbt_session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=15), connector=aiohttp.TCPConnector(ssl=ssl_context))
+                    qbt_session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30), connector=aiohttp.TCPConnector(ssl=ssl_context))
                     created_session = True
 
             except qbittorrentapi.LoginFailed:
@@ -896,7 +910,7 @@ class QbittorrentClientMixin:
 
         if proxy_url:
             ssl_context = self.create_ssl_context_for_client(client)
-            qbt_session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=15), connector=aiohttp.TCPConnector(ssl=ssl_context))
+            qbt_session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30), connector=aiohttp.TCPConnector(ssl=ssl_context))
             qbt_proxy_url = proxy_url.rstrip("/")
         else:
             potential_qbt_client = await self.init_qbittorrent_client(client)
@@ -1424,7 +1438,7 @@ class QbittorrentClientMixin:
             if proxy_url:
                 try:
                     ssl_context = self.create_ssl_context_for_client(client_config)
-                    qbt_session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=15), connector=aiohttp.TCPConnector(ssl=ssl_context))
+                    qbt_session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30), connector=aiohttp.TCPConnector(ssl=ssl_context))
                     qbt_proxy_url = proxy_url.rstrip("/")
 
                 except Exception as e:

--- a/tests/test_qbit_reachable.py
+++ b/tests/test_qbit_reachable.py
@@ -1,0 +1,100 @@
+# Tests for QbittorrentClientMixin._check_qbit_reachable — retry patience
+"""
+Regression: the health check used a single 5s probe whose negative result
+was cached for the whole process, so a slow remote (waking tunnel, loaded
+seedbox) aborted every qBittorrent operation of the run. The probe must
+retry before declaring the client offline.
+"""
+
+import asyncio
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from src.torrent_clients.qbittorrent import QbittorrentClientMixin
+
+
+def _run(coro: Any) -> Any:
+    return asyncio.run(coro)
+
+
+def _mixin() -> QbittorrentClientMixin:
+    m = QbittorrentClientMixin()
+    m.create_ssl_context_for_client = MagicMock(return_value=None)  # type: ignore[method-assign]
+    return m
+
+
+_CLIENT = {"qbit_url": "http://qbit.test", "qbit_port": 8080, "qui_proxy_url": ""}
+
+
+def _session_factory(outcomes: list[Any]) -> Any:
+    """aiohttp.ClientSession replacement: pops one outcome per instantiation.
+
+    An Exception instance is raised on session.get(); an int becomes the
+    response status.
+    """
+
+    def factory(*args: Any, **kwargs: Any) -> Any:
+        outcome = outcomes.pop(0)
+        session = MagicMock()
+        session.__aenter__ = _async_return(session)
+        session.__aexit__ = _async_return(False)
+        if isinstance(outcome, Exception):
+            session.get = MagicMock(side_effect=outcome)
+        else:
+            response = MagicMock(status=outcome)
+            get_ctx = MagicMock()
+            get_ctx.__aenter__ = _async_return(response)
+            get_ctx.__aexit__ = _async_return(False)
+            session.get = MagicMock(return_value=get_ctx)
+        return session
+
+    return factory
+
+
+def _async_return(value: Any) -> Any:
+    async def _inner(*args: Any, **kwargs: Any) -> Any:
+        return value
+
+    return _inner
+
+
+class TestCheckQbitReachable:
+    def test_succeeds_after_transient_failures(self):
+        """Two failed probes then a 200 → reachable (the regression case)."""
+        outcomes: list[Any] = [ConnectionError("slow"), ConnectionError("slow"), 200]
+        with patch("src.torrent_clients.qbittorrent.aiohttp.ClientSession", side_effect=_session_factory(outcomes)), patch("src.torrent_clients.qbittorrent.asyncio.sleep", new=_async_return(None)):
+            assert _run(_mixin()._check_qbit_reachable(_CLIENT)) is True
+        assert not outcomes, "All three attempts should have been consumed"
+
+    def test_all_attempts_fail_returns_false(self):
+        outcomes: list[Any] = [ConnectionError("down")] * 3
+        with patch("src.torrent_clients.qbittorrent.aiohttp.ClientSession", side_effect=_session_factory(outcomes)), patch("src.torrent_clients.qbittorrent.asyncio.sleep", new=_async_return(None)):
+            assert _run(_mixin()._check_qbit_reachable(_CLIENT)) is False
+        assert not outcomes, "All three probes should have been attempted"
+
+    def test_first_probe_ok_no_retry(self):
+        outcomes: list[Any] = [200]
+        with patch("src.torrent_clients.qbittorrent.aiohttp.ClientSession", side_effect=_session_factory(outcomes)):
+            assert _run(_mixin()._check_qbit_reachable(_CLIENT)) is True
+
+    def test_gateway_error_retries(self):
+        """502/503/504 from a proxy count as unreachable and must be retried."""
+        for gateway_status in (502, 503, 504):
+            outcomes: list[Any] = [gateway_status, 200]
+            with patch("src.torrent_clients.qbittorrent.aiohttp.ClientSession", side_effect=_session_factory(outcomes)), patch("src.torrent_clients.qbittorrent.asyncio.sleep", new=_async_return(None)):
+                assert _run(_mixin()._check_qbit_reachable(_CLIENT, attempts=2)) is True, f"{gateway_status} then 200 should be reachable"
+            assert not outcomes, f"Both probes should have run for {gateway_status}"
+
+    def test_http_500_is_unreachable(self):
+        """A 500 from the API is not a healthy client: only 200/401/403 count."""
+        outcomes: list[Any] = [500, 500]
+        with patch("src.torrent_clients.qbittorrent.aiohttp.ClientSession", side_effect=_session_factory(outcomes)), patch("src.torrent_clients.qbittorrent.asyncio.sleep", new=_async_return(None)):
+            assert _run(_mixin()._check_qbit_reachable(_CLIENT, attempts=2)) is False
+        assert not outcomes
+
+    def test_auth_statuses_are_reachable(self):
+        """401/403 mean qBit is up but wants credentials → reachable."""
+        for auth_status in (401, 403):
+            outcomes: list[Any] = [auth_status]
+            with patch("src.torrent_clients.qbittorrent.aiohttp.ClientSession", side_effect=_session_factory(outcomes)):
+                assert _run(_mixin()._check_qbit_reachable(_CLIENT)) is True


### PR DESCRIPTION
"Upload process aborted: qBittorrent is offline" could fire on a remote that was merely slow to respond:

- health check: 1 probe × 5s (result cached for the whole process) → 3 probes × 10s with 5s pauses before declaring the client offline
- proxy GET retries: 2 attempts / 3s delay → 3 attempts / 5s delay
- proxy session timeouts: 10-15s → 30s

Direct qBit API operations already retry with exponential backoff up to 80s and are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved qBittorrent connection reliability by retrying temporary connection and gateway errors.
  * Increased connection timeouts to better support slower or less responsive servers.
  * Reachability checks now retry failed probes before reporting a client as unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->