### PR TITLE
fix(TOS): map WEBRIP to the unified WEB type (id 4)

### DIFF
--- a/src/trackers/TOS.py
+++ b/src/trackers/TOS.py
@@ -104,8 +104,10 @@ class TOS(FrenchTrackerMixin, UNIT3D):
                 "DISC": "1",
                 "REMUX": "2",
                 "ENCODE": "3",
+                # TOS uses a single "WEB" type (id 4) for both WEB-DL and
+                # WEBRip; there is no id 5 and the API rejects it.
                 "WEBDL": "4",
-                "WEBRIP": "5",
+                "WEBRIP": "4",
                 "HDTV": "6",
             }.get(meta["type"], "0")
         return {"type_id": type_id}

--- a/tests/test_tos.py
+++ b/tests/test_tos.py
@@ -391,3 +391,27 @@ class TestTosSceneNfoRequirement:
         meta["auto_nfo"] = False
         result = _run(t.get_additional_checks(meta))
         assert result is True
+
+
+class TestTosTypeId:
+    """TOS has a single "WEB" type (id 4) for WEB-DL and WEBRip; id 5 does
+    not exist and the upload API rejects it with a validation error."""
+
+    def _type_meta(self, release_type: str) -> dict[str, Any]:
+        return {"type": release_type, "is_disc": None, "3D": ""}
+
+    def test_webrip_maps_to_web_type_4(self):
+        t = TOS(_config())
+        result = _run(t.get_type_id(self._type_meta("WEBRIP")))
+        assert result == {"type_id": "4"}
+
+    def test_webdl_maps_to_web_type_4(self):
+        t = TOS(_config())
+        result = _run(t.get_type_id(self._type_meta("WEBDL")))
+        assert result == {"type_id": "4"}
+
+    def test_never_emits_type_5(self):
+        t = TOS(_config())
+        for release_type in ("DISC", "REMUX", "ENCODE", "WEBDL", "WEBRIP", "HDTV", "UNKNOWN"):
+            result = _run(t.get_type_id(self._type_meta(release_type)))
+            assert result["type_id"] != "5", f"{release_type} produced invalid type_id 5"


### PR DESCRIPTION
TOS has a single "WEB" torrent type covering WEB-DL and WEBRip; type id 5 does not exist there, so WEBRip uploads failed with HTTP 404 - Validation Error ("Le type id sélectionné est invalide"). Verified against the live filter API: id 4 = WEB, id 5 = no results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected torrent type classification so both WEBRIP and WEBDL releases use the appropriate web type.
  * Prevented releases from being assigned an invalid type.

* **Tests**
  * Added regression coverage for WEBRIP and WEBDL mappings and invalid type prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->