### PR TITLE
NST (fix) : force to set year if cat = TV

### DIFF
--- a/src/trackers/NST.py
+++ b/src/trackers/NST.py
@@ -390,7 +390,18 @@ class NST(FrenchTrackerMixin, UNIT3D):
         return data
 
     async def get_name(self, meta: dict[str, Any]) -> dict[str, str]:
+        # year for TV is mantatory and sometimes "search_year" from TMDB is empty
+        manual_year = meta.get("manual_year", "")
+        year = meta.get("year", "")
+        search_year = meta.get("search_year", "")
+        if meta.get("category", "") == "TV":
+            if manual_year is not None and int(manual_year) > 0:
+                year = manual_year
+                meta["year"] = manual_year
+            meta["search_year"] = year if search_year == "" else ""
+
         result = await super().get_name(meta)
+
         # Atmos before channel
         name = re.sub(
             r"\.(DDP|AC3|EAC3|DTS|TRUEHD|FLAC|AAC|LPCM|DTS\.HD\.MA|DTS\.HD\.HRA|DTS\.X)\.(\d\.\d)\.ATMOS([.-])", r".\1.Atmos.\2\3", result["name"], flags=re.IGNORECASE

--- a/src/trackers/NST.py
+++ b/src/trackers/NST.py
@@ -398,7 +398,7 @@ class NST(FrenchTrackerMixin, UNIT3D):
             if manual_year is not None and int(manual_year) > 0:
                 year = manual_year
                 meta["year"] = manual_year
-            meta["search_year"] = year if search_year == "" else ""
+            meta["search_year"] = year if search_year == "" else search_year
 
         result = await super().get_name(meta)
 


### PR DESCRIPTION
Sometimes, year for TV in title doesn't appear because of "search_year" call in FRENCH.py. Year is mandatory for NST so I force it to be set even if it's a manual year (cli args --year)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TV release naming when search-year information is unavailable.
  * Uses the manually specified year when valid and keeps related year metadata consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->