### PR TITLE
fix(G3MINI): French title for French-origin works, x264/x265 label fo…

### DIFF
--- a/src/trackers/G3MINI.py
+++ b/src/trackers/G3MINI.py
@@ -3,6 +3,7 @@ import re
 from typing import Any
 
 from src.console import console
+from src.tmdb import TmdbManager
 from src.trackers.COMMON import COMMON
 from src.trackers.FRENCH import FrenchTrackerMixin
 from src.trackers.UNIT3D import UNIT3D
@@ -15,6 +16,7 @@ class G3MINI(FrenchTrackerMixin, UNIT3D):
         super().__init__(config, tracker_name="G3MINI")
         self.config = config
         self.common = COMMON(config)
+        self.tmdb_manager = TmdbManager(config)
         self.tracker = "G3MINI"
         self.base_url = "https://gemini-tracker.org"
         self.id_url = f"{self.base_url}/api/torrents/"
@@ -193,6 +195,9 @@ class G3MINI(FrenchTrackerMixin, UNIT3D):
 
         type = meta.get("type", "").upper()
         title = meta.get("title", "")
+        # French-origin works must carry their French title in the release name.
+        if str(meta.get("original_language", "")).lower() == "fr":
+            title = await self._get_french_title(meta)
         year = meta.get("year", "")
         manual_year = meta.get("manual_year")
         if manual_year is not None and int(manual_year) > 0:
@@ -232,6 +237,11 @@ class G3MINI(FrenchTrackerMixin, UNIT3D):
         else:
             video_codec = meta.get("video_codec", "")
             video_encode = meta.get("video_encode", "").replace("H.264", "H264").replace("H.265", "H265")
+            # Encodes are labeled by their encoder (x264/x265), never H264/H265.
+            # A WEB release typed WEBDL from its filename but whose video track
+            # carries x264/x265 encoding settings is really an encode.
+            if meta.get("has_encode_settings"):
+                video_encode = video_encode.replace("H264", "x264").replace("H265", "x265")
         edition = self._format_edition(meta.get("edition", ""))
         if "hybrid" in edition.upper():
             edition = edition.replace("Hybrid", "").strip()

--- a/tests/test_g3mini.py
+++ b/tests/test_g3mini.py
@@ -819,6 +819,29 @@ class TestG3MINIFrenchTitle:
         assert name.startswith('Le.Prix.du.Danger'), f"French title expected, got: {name!r}"
         assert 'Price.of.Peril' not in name
 
+    def test_french_origin_fetches_title_when_uncached(self):
+        """Without a cached frtitle, the title comes from the localized TMDB data."""
+        meta = _meta_base(
+            title='The Price of Peril',
+            original_language='fr',
+            type='ENCODE',
+            video_encode='x264',
+            video_codec='',
+            hdr='',
+            webdv='',
+            uhd='',
+            resolution='1080p',
+        )
+        g = G3MINI(_config())
+
+        async def fake_localized(*args, **kwargs):
+            return {'title': 'Le Prix du Danger', 'original_title': 'Le Prix du Danger', 'original_language': 'fr'}
+
+        g.tmdb_manager.get_tmdb_localized_data = fake_localized
+        name = asyncio.run(g.get_name(meta))['name']
+        assert name.startswith('Le.Prix.du.Danger'), f"French title expected, got: {name!r}"
+        assert 'Price.of.Peril' not in name
+
     def test_non_french_origin_keeps_main_title(self):
         meta = _meta_base(
             title='Some English Title',
@@ -872,3 +895,10 @@ class TestG3MINIEncodeCodecLabel:
         meta = self._web_meta(has_encode_settings=False)
         name = self._get_name(meta)
         assert 'H264' in name, f"Untouched WEB-DL keeps H264, got: {name!r}"
+        assert 'x264' not in name, f"x264 must not appear for a true WEB-DL, got: {name!r}"
+
+    def test_true_webdl_keeps_h265(self):
+        meta = self._web_meta(video_encode='H.265', has_encode_settings=False)
+        name = self._get_name(meta)
+        assert 'H265' in name, f"Untouched WEB-DL keeps H265, got: {name!r}"
+        assert 'x265' not in name, f"x265 must not appear for a true WEB-DL, got: {name!r}"

--- a/tests/test_g3mini.py
+++ b/tests/test_g3mini.py
@@ -794,3 +794,81 @@ class TestG3MINIHdr10Plus:
         name = self._get_name(meta)
         assert 'HDR10P' in name, f"HDR10+ must render as HDR10P, got: {name!r}"
         assert 'HDR10+' not in name, f"'+' must be gone, got: {name!r}"
+
+
+class TestG3MINIFrenchTitle:
+    """French-origin works must use the French title in the release name."""
+
+    def _get_name(self, meta: dict) -> str:
+        return asyncio.run(G3MINI(_config()).get_name(meta))['name']
+
+    def test_french_origin_uses_french_title(self):
+        meta = _meta_base(
+            title='The Price of Peril',
+            original_language='fr',
+            frtitle='Le Prix du Danger',
+            type='ENCODE',
+            video_encode='x264',
+            video_codec='',
+            hdr='',
+            webdv='',
+            uhd='',
+            resolution='1080p',
+        )
+        name = self._get_name(meta)
+        assert name.startswith('Le.Prix.du.Danger'), f"French title expected, got: {name!r}"
+        assert 'Price.of.Peril' not in name
+
+    def test_non_french_origin_keeps_main_title(self):
+        meta = _meta_base(
+            title='Some English Title',
+            original_language='en',
+            frtitle='Un Titre Français',
+            type='ENCODE',
+            video_encode='x264',
+            video_codec='',
+            hdr='',
+            webdv='',
+            uhd='',
+            resolution='1080p',
+        )
+        name = self._get_name(meta)
+        assert name.startswith('Some.English.Title'), f"Main title expected, got: {name!r}"
+
+
+class TestG3MINIEncodeCodecLabel:
+    """Encodes must be labeled x264/x265, never H264/H265."""
+
+    def _get_name(self, meta: dict) -> str:
+        return asyncio.run(G3MINI(_config()).get_name(meta))['name']
+
+    def _web_meta(self, **overrides) -> dict:
+        base = dict(
+            type='WEBDL',
+            video_encode='H.264',
+            video_codec='',
+            hdr='',
+            webdv='',
+            uhd='',
+            resolution='1080p',
+            source='Web',
+        )
+        base.update(overrides)
+        return _meta_base(**base)
+
+    def test_webdl_with_encode_settings_uses_x264(self):
+        meta = self._web_meta(has_encode_settings=True)
+        name = self._get_name(meta)
+        assert 'x264' in name, f"x264 expected for an encode, got: {name!r}"
+        assert 'H264' not in name
+
+    def test_webdl_with_encode_settings_uses_x265(self):
+        meta = self._web_meta(video_encode='H.265', has_encode_settings=True)
+        name = self._get_name(meta)
+        assert 'x265' in name, f"x265 expected for an encode, got: {name!r}"
+        assert 'H265' not in name
+
+    def test_true_webdl_keeps_h264(self):
+        meta = self._web_meta(has_encode_settings=False)
+        name = self._get_name(meta)
+        assert 'H264' in name, f"Untouched WEB-DL keeps H264, got: {name!r}"


### PR DESCRIPTION
…r encodes

Two naming rules from the tracker's conventions were not enforced:

- A French-origin work must carry its French title in the release name; get_name used the main (English) TMDB title unconditionally because G3MINI overrides the FrenchTrackerMixin naming without calling _get_french_title.
- An encode must be labeled with its encoder (x264/x265). A WEB release typed WEBDL from its filename kept the H264/H265 format label even when its video track carries x264/x265 encoding settings, i.e. it is really an encode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * French-origin releases now use their French titles when available.
  * Release names now display codec labels consistently as x264 or x265 when encoding details are provided.
* **Bug Fixes**
  * Improved naming accuracy for French releases and WEB-DL files with or without encoding settings.
* **Tests**
  * Added coverage for French-title selection and codec-label formatting across supported release scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->