### PR TITLE
fix(C411): paginate the Torznab dupe search

### DIFF
--- a/src/trackers/C411.py
+++ b/src/trackers/C411.py
@@ -1726,31 +1726,42 @@ class C411(FrenchTrackerMixin):
 
         seen_guids: set[str] = set()
 
+        # The API caps un-paginated queries at 25 items sorted newest-first, so
+        # older packs vanish behind recent episode uploads: paginate explicitly.
+        page_size = 100
+        max_results = 300  # per query
+
         for params in queries:
-            try:
-                url_params = {**params, "apikey": self.api_key}
-                async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
-                    response = await client.get("https://c411.org/api", params=url_params)
+            offset = 0
+            while offset < max_results:
+                try:
+                    url_params = {**params, "limit": str(page_size), "offset": str(offset), "apikey": self.api_key}
+                    async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
+                        response = await client.get("https://c411.org/api", params=url_params)
 
-                if response.status_code != 200:
+                    if response.status_code != 200:
+                        if meta.get("debug"):
+                            console.print(f"[yellow]C411 Torznab search returned HTTP {response.status_code}[/yellow]")
+                        break
+
+                    # Parse XML response
+                    items = self._parse_torznab_response(response.text)
+
+                    for item in items:
+                        guid = item.get("guid", item.get("name", ""))
+                        if guid in seen_guids:
+                            continue
+                        seen_guids.add(guid)
+                        dupes.append(item)
+
+                    if len(items) < page_size:
+                        break
+                    offset += page_size
+
+                except Exception as e:
                     if meta.get("debug"):
-                        console.print(f"[yellow]C411 Torznab search returned HTTP {response.status_code}[/yellow]")
-                    continue
-
-                # Parse XML response
-                items = self._parse_torznab_response(response.text)
-
-                for item in items:
-                    guid = item.get("guid", item.get("name", ""))
-                    if guid in seen_guids:
-                        continue
-                    seen_guids.add(guid)
-                    dupes.append(item)
-
-            except Exception as e:
-                if meta.get("debug"):
-                    console.print(f"[yellow]C411 Torznab search error: {e}[/yellow]")
-                continue
+                        console.print(f"[yellow]C411 Torznab search error: {e}[/yellow]")
+                    break
 
         if meta.get("debug"):
             console.print(f"[cyan]C411 dupe search found {len(dupes)} result(s)[/cyan]")

--- a/src/trackers/C411.py
+++ b/src/trackers/C411.py
@@ -1748,7 +1748,9 @@ class C411(FrenchTrackerMixin):
                     items = self._parse_torznab_response(response.text)
 
                     for item in items:
-                        guid = item.get("guid", item.get("name", ""))
+                        # The parser stores the RSS <guid> under "id"; fall back
+                        # to the name so distinct torrents never collapse.
+                        guid = item.get("id") or item.get("name", "")
                         if guid in seen_guids:
                             continue
                         seen_guids.add(guid)

--- a/tests/test_c411.py
+++ b/tests/test_c411.py
@@ -1682,12 +1682,11 @@ class TestSearchExisting:
         c = C411(_config())
         meta = _meta_base(tmdb='', imdb_id=0)  # only the text query remains
 
-        full_page = MagicMock(status_code=200, text=self._torznab_page(100))
-        short_page = MagicMock(status_code=200, text=self._torznab_page(3, start=100))
+        pages = [MagicMock(status_code=200, text=self._torznab_page(100, start=i * 100)) for i in range(3)]
 
         with patch('httpx.AsyncClient') as mock_client_cls:
             mock_client = AsyncMock()
-            mock_client.get = AsyncMock(side_effect=[full_page, short_page])
+            mock_client.get = AsyncMock(side_effect=pages)
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_cls.return_value = mock_client
@@ -1695,7 +1694,7 @@ class TestSearchExisting:
             asyncio.run(c.search_existing(meta, 'nodisc'))
 
         offsets = [ca.kwargs['params'].get('offset') for ca in mock_client.get.call_args_list]
-        assert offsets == ['0', '100'], f"Expected two paginated calls, got offsets {offsets}"
+        assert offsets == ['0', '100', '200'], f"Expected three paginated calls capped at 300, got offsets {offsets}"
         assert all(ca.kwargs['params'].get('limit') == '100' for ca in mock_client.get.call_args_list)
 
     def test_search_short_page_stops_pagination(self):

--- a/tests/test_c411.py
+++ b/tests/test_c411.py
@@ -1661,6 +1661,61 @@ class TestSearchExisting:
 
         assert dupes == []
 
+    @staticmethod
+    def _torznab_page(count: int, start: int = 0) -> str:
+        items = "".join(
+            f"""<item>
+      <title>Film.{start + i}.2012.FRENCH.1080p.WEB.x264-GRP</title>
+      <guid>https://c411.org/torrents/{start + i}</guid>
+      <link>https://c411.org/torrents/{start + i}/download</link>
+      <size>4000000000</size>
+    </item>"""
+            for i in range(count)
+        )
+        return f"""<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:torznab="http://torznab.com/schemas/2015/feed">
+  <channel>{items}</channel>
+</rss>"""
+
+    def test_search_paginates_past_first_page(self):
+        """A full page must trigger a follow-up request with the next offset."""
+        c = C411(_config())
+        meta = _meta_base(tmdb='', imdb_id=0)  # only the text query remains
+
+        full_page = MagicMock(status_code=200, text=self._torznab_page(100))
+        short_page = MagicMock(status_code=200, text=self._torznab_page(3, start=100))
+
+        with patch('httpx.AsyncClient') as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(side_effect=[full_page, short_page])
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_cls.return_value = mock_client
+
+            asyncio.run(c.search_existing(meta, 'nodisc'))
+
+        offsets = [ca.kwargs['params'].get('offset') for ca in mock_client.get.call_args_list]
+        assert offsets == ['0', '100'], f"Expected two paginated calls, got offsets {offsets}"
+        assert all(ca.kwargs['params'].get('limit') == '100' for ca in mock_client.get.call_args_list)
+
+    def test_search_short_page_stops_pagination(self):
+        """A page smaller than the page size must not trigger another request."""
+        c = C411(_config())
+        meta = _meta_base(tmdb='', imdb_id=0)
+
+        short_page = MagicMock(status_code=200, text=self._torznab_page(3))
+
+        with patch('httpx.AsyncClient') as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=short_page)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_cls.return_value = mock_client
+
+            asyncio.run(c.search_existing(meta, 'nodisc'))
+
+        assert mock_client.get.call_count == 1
+
     def test_search_deduplicates(self):
         """When IMDB + text search return the same torrent, it should appear only once."""
         c = C411(_config())


### PR DESCRIPTION
The dupe search sent un-paginated queries, and the API caps those at 25 items sorted newest-first. On shows with frequent episode uploads, older season packs fell past the first page and were never seen by the dupe filters, letting real duplicates through. Request 100 items per page and follow offsets until a short page, capped at 300 results per query.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search reliability by retrieving results across multiple pages when more than 100 matches are available.
  * Prevented unnecessary requests once all available results have been received or the result limit is reached.
  * Maintained duplicate filtering and graceful handling of unsuccessful responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->