### PR TITLE
fix(LST): refine the micro-encode bitrate gate

### DIFF
--- a/src/trackers/LST.py
+++ b/src/trackers/LST.py
@@ -44,7 +44,8 @@ class LST(UNIT3D):
                 continue
             for field in ("BitRate", "BitRate_Nominal"):
                 value = str(track.get(field, "") or "")
-                if value.isdigit():
+                # A zero value is as unusable as a missing one: keep falling back.
+                if value.isdigit() and int(value) > 0:
                     return int(value)
             try:
                 stream_size = int(str(track.get("StreamSize", "") or ""))

--- a/src/trackers/LST.py
+++ b/src/trackers/LST.py
@@ -31,6 +31,31 @@ class LST(UNIT3D):
     async def get_additional_files(self, meta: Meta) -> dict[str, tuple[str, bytes, str]]:
         return {}
 
+    @staticmethod
+    def _get_video_bitrate(meta: Meta) -> int:
+        """Video bitrate in bps from mediainfo, 0 if undeterminable.
+
+        VBR encodes (typically x265 in MKV) often carry no BitRate field, so
+        fall back to BitRate_Nominal, then to StreamSize/Duration.
+        """
+        tracks = meta.get("mediainfo", {}).get("media", {}).get("track", [])
+        for track in tracks:
+            if track.get("@type") != "Video":
+                continue
+            for field in ("BitRate", "BitRate_Nominal"):
+                value = str(track.get(field, "") or "")
+                if value.isdigit():
+                    return int(value)
+            try:
+                stream_size = int(str(track.get("StreamSize", "") or ""))
+                duration = float(str(track.get("Duration", "") or ""))
+                if stream_size > 0 and duration > 0:
+                    return int(stream_size * 8 / duration)
+            except (ValueError, TypeError):
+                pass
+            break
+        return 0
+
     async def get_additional_checks(self, meta: Meta) -> bool:
         should_continue = True
         if not meta["valid_mi_settings"]:
@@ -42,19 +67,21 @@ class LST(UNIT3D):
         ):
             return False
 
-        # Block micro-encodes: check minimum video bitrate for ENCODE / WEBRIP / WEBDL
-        if meta.get("type", "").upper() in ("ENCODE", "WEBRIP", "WEBDL"):
+        # Block micro-encodes: check minimum video bitrate for ENCODE / WEBRIP.
+        # WEB-DL is exempt: it's the service's untouched stream, whatever its
+        # bitrate — never a micro-encode.
+        if meta.get("type", "").upper() in ("ENCODE", "WEBRIP"):
             video_encode = str(meta.get("video_encode", "")).strip().lower()
             resolution_text = str(meta.get("resolution", "")).lower().replace("p", "").replace("i", "")
             resolution = int(resolution_text) if resolution_text.isdigit() else 0
 
             MIN_BITRATE: dict[tuple[str, int], int] = {
-                ("x265", 2160): 3_000_000,
-                ("x265", 1080): 1_000_000,
-                ("x265", 720): 600_000,
-                ("x264", 2160): 8_000_000,
-                ("x264", 1080): 2_000_000,
-                ("x264", 720): 1_000_000,
+                ("x265", 2160): 4_000_000,
+                ("x265", 1080): 1_500_000,
+                ("x265", 720): 800_000,
+                ("x264", 2160): 10_000_000,
+                ("x264", 1080): 2_500_000,
+                ("x264", 720): 1_200_000,
             }
 
             codec_key = None
@@ -78,15 +105,7 @@ class LST(UNIT3D):
                     console.print(f"[bold red]{self.tracker}: Cannot verify encode quality — no bitrate rule for {resolution}p {codec_key.upper()}.[/bold red]")
                 return False
 
-            mediainfo = meta.get("mediainfo", {})
-            tracks = mediainfo.get("media", {}).get("track", [])
-            video_bitrate = 0
-            for track in tracks:
-                if track.get("@type") == "Video":
-                    br = track.get("BitRate")
-                    if br and str(br).isdigit():
-                        video_bitrate = int(br)
-                    break
+            video_bitrate = self._get_video_bitrate(meta)
 
             # Fail-closed: block if bitrate is missing or unreadable
             if not video_bitrate:

--- a/tests/test_lst.py
+++ b/tests/test_lst.py
@@ -255,31 +255,31 @@ def _bitrate_meta(
 
 
 class TestAdditionalChecksMicroEncode:
-    """Bitrate gate blocks micro-encodes for ENCODE / WEBRIP / WEBDL."""
+    """Bitrate gate blocks micro-encodes for ENCODE / WEBRIP."""
 
-    # ── x265 1080p (threshold: 1 000 000 bps) ──────────────────
+    # ── x265 1080p (threshold: 1 500 000 bps) ──────────────────
 
     def test_x265_1080p_webrip_below_threshold_is_rejected(self):
         """JATT-style release at ~748 kb/s must be blocked."""
         meta = _bitrate_meta(video_bitrate=748_000, codec="x265", resolution="1080p", type="WEBRIP")
         assert _run(_lst().get_additional_checks(meta)) is False
 
-    def test_x265_1080p_webdl_below_threshold_is_rejected(self):
-        """Same codec/resolution, WEBDL type, must also be blocked."""
+    def test_webdl_is_exempt_from_bitrate_gate(self):
+        """WEB-DL is the service's untouched stream — never a micro-encode."""
         meta = _bitrate_meta(video_bitrate=900_000, codec="x265", resolution="1080p", type="WEBDL")
-        assert _run(_lst().get_additional_checks(meta)) is False
+        assert _run(_lst().get_additional_checks(meta)) is True
 
     def test_x265_1080p_encode_below_threshold_is_rejected(self):
         meta = _bitrate_meta(video_bitrate=500_000, codec="x265", resolution="1080p", type="ENCODE")
         assert _run(_lst().get_additional_checks(meta)) is False
 
     def test_x265_1080p_just_below_threshold_is_rejected(self):
-        meta = _bitrate_meta(video_bitrate=999_999, codec="x265", resolution="1080p")
+        meta = _bitrate_meta(video_bitrate=1_499_999, codec="x265", resolution="1080p")
         assert _run(_lst().get_additional_checks(meta)) is False
 
     def test_x265_1080p_at_threshold_is_allowed(self):
         """Exactly at the minimum must pass (not strictly below)."""
-        meta = _bitrate_meta(video_bitrate=1_000_000, codec="x265", resolution="1080p")
+        meta = _bitrate_meta(video_bitrate=1_500_000, codec="x265", resolution="1080p")
         assert _run(_lst().get_additional_checks(meta)) is True
 
     def test_x265_1080p_above_threshold_is_allowed(self):
@@ -297,34 +297,34 @@ class TestAdditionalChecksMicroEncode:
         meta = _bitrate_meta(video_bitrate=500_000, codec="H.265", resolution="1080p")
         assert _run(_lst().get_additional_checks(meta)) is False
 
-    # ── x265 720p (threshold: 600 000 bps) ─────────────────────
+    # ── x265 720p (threshold: 800 000 bps) ─────────────────────
 
     def test_x265_720p_below_threshold_is_rejected(self):
         meta = _bitrate_meta(video_bitrate=400_000, codec="x265", resolution="720p")
         assert _run(_lst().get_additional_checks(meta)) is False
 
     def test_x265_720p_above_threshold_is_allowed(self):
-        meta = _bitrate_meta(video_bitrate=800_000, codec="x265", resolution="720p")
+        meta = _bitrate_meta(video_bitrate=1_000_000, codec="x265", resolution="720p")
         assert _run(_lst().get_additional_checks(meta)) is True
 
-    # ── x265 2160p (threshold: 3 000 000 bps) ──────────────────
+    # ── x265 2160p (threshold: 4 000 000 bps) ──────────────────
 
     def test_x265_2160p_below_threshold_is_rejected(self):
-        meta = _bitrate_meta(video_bitrate=2_000_000, codec="x265", resolution="2160p")
+        meta = _bitrate_meta(video_bitrate=3_000_000, codec="x265", resolution="2160p")
         assert _run(_lst().get_additional_checks(meta)) is False
 
     def test_x265_2160p_above_threshold_is_allowed(self):
-        meta = _bitrate_meta(video_bitrate=4_000_000, codec="x265", resolution="2160p")
+        meta = _bitrate_meta(video_bitrate=5_000_000, codec="x265", resolution="2160p")
         assert _run(_lst().get_additional_checks(meta)) is True
 
-    # ── x264 1080p (threshold: 2 000 000 bps) ──────────────────
+    # ── x264 1080p (threshold: 2 500 000 bps) ──────────────────
 
     def test_x264_1080p_below_threshold_is_rejected(self):
-        meta = _bitrate_meta(video_bitrate=1_500_000, codec="x264", resolution="1080p")
+        meta = _bitrate_meta(video_bitrate=2_000_000, codec="x264", resolution="1080p")
         assert _run(_lst().get_additional_checks(meta)) is False
 
     def test_x264_1080p_above_threshold_is_allowed(self):
-        meta = _bitrate_meta(video_bitrate=2_500_000, codec="x264", resolution="1080p")
+        meta = _bitrate_meta(video_bitrate=3_000_000, codec="x264", resolution="1080p")
         assert _run(_lst().get_additional_checks(meta)) is True
 
     def test_h264_label_below_threshold_is_rejected(self):
@@ -342,6 +342,26 @@ class TestAdditionalChecksMicroEncode:
         """Missing BitRate value must block the upload (fail-closed)."""
         meta = _bitrate_meta(video_bitrate=0, codec="x265", resolution="1080p")
         meta["mediainfo"] = {"media": {"track": [{"@type": "Video"}]}}
+        assert _run(_lst().get_additional_checks(meta)) is False
+
+    def test_nominal_bitrate_fallback(self):
+        """VBR encodes without BitRate must be judged on BitRate_Nominal."""
+        meta = _bitrate_meta(video_bitrate=0, codec="x265", resolution="1080p")
+        meta["mediainfo"] = {"media": {"track": [{"@type": "Video", "BitRate_Nominal": "3000000"}]}}
+        assert _run(_lst().get_additional_checks(meta)) is True
+
+    def test_stream_size_duration_fallback(self):
+        """Without any bitrate field, derive it from StreamSize/Duration."""
+        # 2.7 GB over 1h30 → ~4 800 kb/s: comfortably above the 1080p x265 floor
+        meta = _bitrate_meta(video_bitrate=0, codec="x265", resolution="1080p")
+        meta["mediainfo"] = {"media": {"track": [{"@type": "Video", "StreamSize": "2700000000", "Duration": "5400.000"}]}}
+        assert _run(_lst().get_additional_checks(meta)) is True
+
+    def test_stream_size_duration_fallback_still_blocks_junk(self):
+        """The derived bitrate must still reject a real micro-encode."""
+        # 500 MB over 1h30 → ~740 kb/s: below the 1080p x265 floor
+        meta = _bitrate_meta(video_bitrate=0, codec="x265", resolution="1080p")
+        meta["mediainfo"] = {"media": {"track": [{"@type": "Video", "StreamSize": "500000000", "Duration": "5400.000"}]}}
         assert _run(_lst().get_additional_checks(meta)) is False
 
     def test_unknown_codec_is_rejected(self):

--- a/tests/test_lst.py
+++ b/tests/test_lst.py
@@ -327,6 +327,26 @@ class TestAdditionalChecksMicroEncode:
         meta = _bitrate_meta(video_bitrate=3_000_000, codec="x264", resolution="1080p")
         assert _run(_lst().get_additional_checks(meta)) is True
 
+    # ── x264 720p (threshold: 1 200 000 bps) ───────────────────
+
+    def test_x264_720p_below_threshold_is_rejected(self):
+        meta = _bitrate_meta(video_bitrate=1_199_999, codec="x264", resolution="720p")
+        assert _run(_lst().get_additional_checks(meta)) is False
+
+    def test_x264_720p_at_threshold_is_allowed(self):
+        meta = _bitrate_meta(video_bitrate=1_200_000, codec="x264", resolution="720p")
+        assert _run(_lst().get_additional_checks(meta)) is True
+
+    # ── x264 2160p (threshold: 10 000 000 bps) ─────────────────
+
+    def test_x264_2160p_below_threshold_is_rejected(self):
+        meta = _bitrate_meta(video_bitrate=9_999_999, codec="x264", resolution="2160p")
+        assert _run(_lst().get_additional_checks(meta)) is False
+
+    def test_x264_2160p_at_threshold_is_allowed(self):
+        meta = _bitrate_meta(video_bitrate=10_000_000, codec="x264", resolution="2160p")
+        assert _run(_lst().get_additional_checks(meta)) is True
+
     def test_h264_label_below_threshold_is_rejected(self):
         """'H.264' codec label must map to x264 and be checked."""
         meta = _bitrate_meta(video_bitrate=1_000_000, codec="H.264", resolution="1080p")
@@ -343,6 +363,12 @@ class TestAdditionalChecksMicroEncode:
         meta = _bitrate_meta(video_bitrate=0, codec="x265", resolution="1080p")
         meta["mediainfo"] = {"media": {"track": [{"@type": "Video"}]}}
         assert _run(_lst().get_additional_checks(meta)) is False
+
+    def test_zero_bitrate_falls_through_to_nominal(self):
+        """A zero BitRate is unusable, not authoritative: keep falling back."""
+        meta = _bitrate_meta(video_bitrate=0, codec="x265", resolution="1080p")
+        meta["mediainfo"] = {"media": {"track": [{"@type": "Video", "BitRate": "0", "BitRate_Nominal": "3000000"}]}}
+        assert _run(_lst().get_additional_checks(meta)) is True
 
     def test_nominal_bitrate_fallback(self):
         """VBR encodes without BitRate must be judged on BitRate_Nominal."""


### PR DESCRIPTION
- Exempt WEB-DL: it's the service's untouched stream, whatever its bitrate — never a micro-encode. The gate now covers ENCODE and WEBRIP only.
- Derive the bitrate when mediainfo lacks a BitRate field (common for VBR x265 in MKV): fall back to BitRate_Nominal, then to StreamSize/Duration, instead of fail-closing on healthy encodes.
- Raise the floors: they only caught bottom-tier junk, so give them a little more bite. x265  2160p 3000→4000  1080p 1000→1500  720p 600→800 kb/s x264  2160p 8000→10000 1080p 2000→2500  720p 1000→1200 kb/s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video bitrate detection using available metadata or calculated stream information.
  * Enforced stricter minimum bitrate requirements for applicable releases.
  * WEB-DL releases are now exempt from micro-encode bitrate checks.
  * Improved handling of missing or incomplete bitrate metadata.

* **Tests**
  * Expanded coverage for bitrate thresholds, fallback calculations, low-bitrate media, and WEB-DL exemptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->