### PR TITLE
feat: add lostimg.cc image host

### DIFF
--- a/config-generator.py
+++ b/config-generator.py
@@ -389,6 +389,7 @@ def get_img_host(
         "seedpool_cdn": "seedpool_cdn_api",
         "sharex": ["sharex_url", "sharex_api_key"],
         "utppm": "utppm_api",
+        "lostimg": "lostimg_api",
         "imgbox": None,
         "pixhost": None,
     }

--- a/data/example-config.py
+++ b/data/example-config.py
@@ -47,7 +47,7 @@ config = {
         # IMAGE HOSTING SETTINGS
 
         # Order of image hosts. primary host as first with others as backup
-        # Available image hosts: imgbb, ptpimg, imgbox, pixhost, lensdump, ptscreens, onlyimage, dalexni, zipline, passtheimage, seedpool_cdn, sharex, utppm
+        # Available image hosts: imgbb, ptpimg, imgbox, pixhost, lensdump, ptscreens, onlyimage, dalexni, zipline, passtheimage, seedpool_cdn, sharex, utppm, lostimg
         "img_host_1": "",
         "img_host_2": "",
         "img_host_3": "",
@@ -73,6 +73,8 @@ config = {
         "sharex_api_key": "",
         # utp.pm API key
         "utppm_api": "",
+        # lostimg.cc API key
+        "lostimg_api": "",
 
         # GETTING METADATA
 

--- a/data/templates/config.py
+++ b/data/templates/config.py
@@ -32,7 +32,7 @@ config = {
         "ptpimg_api": "",
         "lensdump_api": "",
         "ptscreens_api": "",
-        "oeimg_api": "",
+        "onlyimage_api": "",
         "dalexni_api": "",
         "passtheima_ge_api": "",
 
@@ -48,7 +48,7 @@ config = {
         "lostimg_api": "",
 
         # Order of image hosts. primary host as first with others as backup
-        # Available image hosts: imgbb, ptpimg, imgbox, pixhost, lensdump, ptscreens, oeimg, dalexni, zipline, passtheimage, seedpool_cdn, sharex, utppm, lostimg
+        # Available image hosts: imgbb, ptpimg, imgbox, pixhost, lensdump, ptscreens, onlyimage, dalexni, zipline, passtheimage, seedpool_cdn, sharex, utppm, lostimg
         "img_host_1": "imgbb",
         "img_host_2": "imgbox",
 

--- a/data/templates/config.py
+++ b/data/templates/config.py
@@ -44,9 +44,11 @@ config = {
         # ShareX-style image host (IMageHosting) token
         "sharex_url": "https://img.digitalcore.club/api/upload",
         "sharex_api_key": "",
+        # lostimg.cc API key
+        "lostimg_api": "",
 
         # Order of image hosts. primary host as first with others as backup
-        # Available image hosts: imgbb, ptpimg, imgbox, pixhost, lensdump, ptscreens, oeimg, dalexni, zipline, passtheimage, seedpool_cdn, sharex, utppm
+        # Available image hosts: imgbb, ptpimg, imgbox, pixhost, lensdump, ptscreens, oeimg, dalexni, zipline, passtheimage, seedpool_cdn, sharex, utppm, lostimg
         "img_host_1": "imgbb",
         "img_host_2": "imgbox",
 

--- a/data/templates/config.py
+++ b/data/templates/config.py
@@ -44,6 +44,8 @@ config = {
         # ShareX-style image host (IMageHosting) token
         "sharex_url": "https://img.digitalcore.club/api/upload",
         "sharex_api_key": "",
+        # utp.pm API key
+        "utppm_api": "",
         # lostimg.cc API key
         "lostimg_api": "",
 

--- a/src/args.py
+++ b/src/args.py
@@ -278,7 +278,7 @@ class Args:
             nargs=1,
             required=False,
             help="Image Host",
-            choices=["imgbb", "ptpimg", "imgbox", "pixhost", "lensdump", "ptscreens", "onlyimage", "dalexni", "zipline", "passtheimage", "seedpool_cdn", "utppm"],
+            choices=["imgbb", "ptpimg", "imgbox", "pixhost", "lensdump", "ptscreens", "onlyimage", "dalexni", "zipline", "passtheimage", "seedpool_cdn", "utppm", "lostimg"],
         )
         parser.add_argument("-siu", "--skip-imagehost-upload", dest="skip_imghost_upload", action="store_true", required=False, help="Skip Uploading to an image host")
         parser.add_argument("-th", "--torrenthash", nargs=1, required=False, help="Torrent Hash to re-use from your client's session directory")

--- a/src/args.py
+++ b/src/args.py
@@ -278,7 +278,22 @@ class Args:
             nargs=1,
             required=False,
             help="Image Host",
-            choices=["imgbb", "ptpimg", "imgbox", "pixhost", "lensdump", "ptscreens", "onlyimage", "dalexni", "zipline", "passtheimage", "seedpool_cdn", "utppm", "lostimg"],
+            choices=[
+                "imgbb",
+                "ptpimg",
+                "imgbox",
+                "pixhost",
+                "lensdump",
+                "ptscreens",
+                "onlyimage",
+                "dalexni",
+                "zipline",
+                "passtheimage",
+                "seedpool_cdn",
+                "sharex",
+                "utppm",
+                "lostimg",
+            ],
         )
         parser.add_argument("-siu", "--skip-imagehost-upload", dest="skip_imghost_upload", action="store_true", required=False, help="Skip Uploading to an image host")
         parser.add_argument("-th", "--torrenthash", nargs=1, required=False, help="Torrent Hash to re-use from your client's session directory")

--- a/src/configvalidator.py
+++ b/src/configvalidator.py
@@ -32,6 +32,7 @@ DEFAULT_KEY_TYPES: dict[str, tuple[type, ...]] = {
     "lensdump_api": (str,),
     "ptscreens_api": (str,),
     "onlyimage_api": (str,),
+    "lostimg_api": (str,),
     "add_logo": (bool,),
     "logo_size": (str, int),
     "episode_overview": (bool,),
@@ -86,7 +87,23 @@ DEFAULT_KEY_TYPES: dict[str, tuple[type, ...]] = {
 }
 
 # Valid image hosts
-VALID_IMAGE_HOSTS = ["imgbb", "ptpimg", "imgbox", "pixhost", "lensdump", "ptscreens", "onlyimage", "dalexni", "zipline", "passtheimage", "seedpool_cdn", "sharex", "utppm", ""]
+VALID_IMAGE_HOSTS = [
+    "imgbb",
+    "ptpimg",
+    "imgbox",
+    "pixhost",
+    "lensdump",
+    "ptscreens",
+    "onlyimage",
+    "dalexni",
+    "zipline",
+    "passtheimage",
+    "seedpool_cdn",
+    "sharex",
+    "utppm",
+    "lostimg",
+    "",
+]
 
 # Image hosts that require API keys and their corresponding config key names
 IMAGE_HOST_API_KEYS: dict[str, str] = {
@@ -101,6 +118,7 @@ IMAGE_HOST_API_KEYS: dict[str, str] = {
     "sharex": "sharex_api_key",
     "zipline": "zipline_api_key",
     "utppm": "utppm_api",
+    "lostimg": "lostimg_api",
     # imgbox and pixhost don't require API keys
 }
 

--- a/src/takescreens.py
+++ b/src/takescreens.py
@@ -296,7 +296,19 @@ async def disc_screenshots(
                     else:
                         console.print(f"[red]Image {image_path} with size {image_size} bytes: does not meet size requirements for {img_host}, retaking.")
                         retake = True
-                elif img_host and img_host in ["ptpimg", "lensdump", "ptscreens", "onlyimage", "dalexni", "zipline", "passtheimage", "seedpool_cdn", "sharex", "utppm"]:
+                elif img_host and img_host in [
+                    "ptpimg",
+                    "lensdump",
+                    "ptscreens",
+                    "onlyimage",
+                    "dalexni",
+                    "zipline",
+                    "passtheimage",
+                    "seedpool_cdn",
+                    "sharex",
+                    "utppm",
+                    "lostimg",
+                ]:
                     if meta["debug"]:
                         console.print(f"[green]Image {image_path} meets size requirements for {img_host}.[/green]")
                 else:
@@ -327,7 +339,7 @@ async def disc_screenshots(
                                 valid_image = True
                         elif (
                             img_host
-                            and img_host in ["ptpimg", "lensdump", "ptscreens", "onlyimage", "dalexni", "zipline", "passtheimage", "seedpool_cdn", "sharex", "utppm"]
+                            and img_host in ["ptpimg", "lensdump", "ptscreens", "onlyimage", "dalexni", "zipline", "passtheimage", "seedpool_cdn", "sharex", "utppm", "lostimg"]
                             and new_size > 75000
                         ):
                             console.print(f"[green]Successfully retaken screenshot for: {image_path} ({new_size} bytes)[/green]")
@@ -1057,7 +1069,19 @@ async def screenshots(
                     else:
                         console.print(f"[red]Image {image_path} with size {image_size} bytes: does not meet size requirements for {img_host}, retaking.")
                         retake = True
-                elif img_host and img_host in ["ptpimg", "lensdump", "ptscreens", "onlyimage", "dalexni", "zipline", "passtheimage", "seedpool_cdn", "sharex", "utppm"]:
+                elif img_host and img_host in [
+                    "ptpimg",
+                    "lensdump",
+                    "ptscreens",
+                    "onlyimage",
+                    "dalexni",
+                    "zipline",
+                    "passtheimage",
+                    "seedpool_cdn",
+                    "sharex",
+                    "utppm",
+                    "lostimg",
+                ]:
                     if meta["debug"]:
                         console.print(f"[green]Image {image_path} meets size requirements for {img_host}.[/green]")
                 else:
@@ -1107,7 +1131,8 @@ async def screenshots(
                                     valid_image = True
                             elif (
                                 img_host
-                                and img_host in ["ptpimg", "lensdump", "ptscreens", "onlyimage", "dalexni", "zipline", "passtheimage", "seedpool_cdn", "sharex", "utppm"]
+                                and img_host
+                                in ["ptpimg", "lensdump", "ptscreens", "onlyimage", "dalexni", "zipline", "passtheimage", "seedpool_cdn", "sharex", "utppm", "lostimg"]
                                 and new_size > 75000
                             ):
                                 console.print(f"[green]Successfully retaken screenshot for: {screenshot_path} ({new_size} bytes)[/green]")
@@ -1152,7 +1177,7 @@ async def screenshots(
                                 valid_image = True
                         elif (
                             img_host
-                            and img_host in ["ptpimg", "lensdump", "ptscreens", "onlyimage", "dalexni", "zipline", "passtheimage", "seedpool_cdn", "sharex", "utppm"]
+                            and img_host in ["ptpimg", "lensdump", "ptscreens", "onlyimage", "dalexni", "zipline", "passtheimage", "seedpool_cdn", "sharex", "utppm", "lostimg"]
                             and new_size > 75000
                         ):
                             valid_image = True

--- a/src/trackers/PTP.py
+++ b/src/trackers/PTP.py
@@ -524,6 +524,7 @@ class PTP:
             "passtheimage": ("passtheima.ge",),
             "seedpool_cdn": ("cdn.seedpool.org",),
             "utppm": ("utp.pm",),
+            "lostimg": ("lostimg.cc",),
         }
         aliases = host_aliases.get(selected_host, (selected_host,))
         return any(hostname == alias or hostname.endswith(f".{alias}") for alias in aliases)

--- a/src/uploadscreens.py
+++ b/src/uploadscreens.py
@@ -505,6 +505,49 @@ async def upload_image_task(args: Sequence[Any]) -> dict[str, Any]:
                 console.print(f"[red]Unexpected error with Seedpool CDN: {e}")
                 return {"status": "failed", "reason": f"Unexpected error: {str(e)}"}
 
+        elif img_host == "lostimg":
+            url = "https://lostimg.cc/api/v1/images"
+            api_key = config["DEFAULT"].get("lostimg_api")
+
+            if not api_key:
+                console.print("[red]Lostimg API key not found in config.")
+                return {"status": "failed", "reason": "Missing Lostimg API key"}
+
+            try:
+                headers = {"Authorization": f"Bearer {api_key}"}
+
+                async with httpx.AsyncClient() as client, aiofiles.open(image, "rb") as img_file:
+                    files = {"file[]": (os.path.basename(image), await img_file.read())}
+
+                    response = await client.post(url, headers=headers, files=files, timeout=timeout)
+
+                    if response.status_code != 200:
+                        console.print(f"[yellow]Lostimg failed with status code {response.status_code}, trying next image host")
+                        return {"status": "failed", "reason": f"Lostimg upload failed with status code {response.status_code}"}
+
+                    response_data = response.json()
+                    # A single file returns {"url": ...}, several files {"urls": [...]}.
+                    hosted_url = response_data.get("url") or next(iter(response_data.get("urls", [])), None)
+
+                    if not hosted_url:
+                        console.print(f"[yellow]No URL in Lostimg response: {response_data}")
+                        return {"status": "failed", "reason": "No URL in Lostimg response"}
+
+                    img_url = raw_url = web_url = hosted_url
+
+            except httpx.TimeoutException:
+                console.print("[red]Request to Lostimg timed out.")
+                return {"status": "failed", "reason": "Request timed out"}
+            except httpx.RequestError as e:
+                console.print(f"[red]Lostimg request failed: {e}")
+                return {"status": "failed", "reason": str(e)}
+            except ValueError as e:
+                console.print(f"[red]Invalid JSON response from Lostimg: {e}")
+                return {"status": "failed", "reason": "Invalid JSON response"}
+            except Exception as e:
+                console.print(f"[red]Unexpected error with Lostimg: {e}")
+                return {"status": "failed", "reason": f"Unexpected error: {str(e)}"}
+
         elif img_host == "sharex":
             # Generic "ShareX-style" image host (IMageHosting and similar).
             url = config["DEFAULT"].get("sharex_url", "https://img.digitalcore.club/api/upload")


### PR DESCRIPTION
Bearer-authenticated multipart upload to https://lostimg.cc/api/v1/images, wired through the CLI choices, config validation, screenshot size checks, config generator/templates and the PTP poster-host domain map.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Lostimg as a supported image-host option.
  * Added configuration support for the Lostimg API key.
  * Images can now be uploaded to Lostimg using single- or multi-file responses.
  * Added validation and error handling for Lostimg uploads.
  * Recognizes `lostimg.cc` when checking existing poster hosts.
* **Bug Fixes**
  * Updated image-host configuration naming and documentation for OnlyImage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->