### PR TITLE
fix: let the multi-host loop handle a fully failed image host

### DIFF
--- a/src/uploadscreens.py
+++ b/src/uploadscreens.py
@@ -865,7 +865,10 @@ async def _upload_screens(
             if not using_custom_img_list:
                 console.print(f"[green]Successfully obtained and uploaded {len(new_images)} images.")
         else:
-            raise Exception("No images uploaded. Configure additional image hosts or use a different -ih")
+            # Return an empty result instead of raising: callers (notably the
+            # multi-host loop in upload.py) handle the shortfall by switching
+            # to the next configured host.
+            console.print(f"[yellow]No images uploaded to {img_host}.")
 
         if meta.get("debug") and upload_start_time is not None:
             console.print(f"Screenshot uploads processed in {time.time() - upload_start_time:.4f} seconds")

--- a/src/uploadscreens.py
+++ b/src/uploadscreens.py
@@ -807,7 +807,6 @@ async def _upload_screens(
         return None
 
     try:
-        max_retries = 3
         results: list[tuple[int, dict[str, Any]]] = []
         try:
             upload_results = await asyncio.gather(*[async_upload(task, max_retries) for task in upload_tasks])
@@ -865,9 +864,9 @@ async def _upload_screens(
             if not using_custom_img_list:
                 console.print(f"[green]Successfully obtained and uploaded {len(new_images)} images.")
         else:
-            # Return an empty result instead of raising: callers (notably the
-            # multi-host loop in upload.py) handle the shortfall by switching
-            # to the next configured host.
+            # A fully failed host is not an error here: when the internal
+            # failover above did not apply, return an empty result and let the
+            # caller decide how to handle the shortfall.
             console.print(f"[yellow]No images uploaded to {img_host}.")
 
         if meta.get("debug") and upload_start_time is not None:

--- a/tests/test_uploadscreens_failover.py
+++ b/tests/test_uploadscreens_failover.py
@@ -1,0 +1,62 @@
+# Regression test: when every upload to the current image host fails and the
+# internal failover does not apply (the current host was remapped away from
+# img_host_1, e.g. for tracker approval), _upload_screens must return an empty
+# result so the multi-host loop in upload.py can try the next host — not raise
+# and abort the whole upload.
+
+import asyncio
+import base64
+from typing import Any
+
+import pytest
+
+import src.uploadscreens as uploadscreens
+
+PNG = base64.b64decode("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGP4z8DwHwAFAAH/q842iQAAAABJRU5ErkJggg==")
+
+
+def _setup(tmp_path: Any, monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    uuid = "fake-release"
+    shot_dir = tmp_path / "tmp" / uuid
+    shot_dir.mkdir(parents=True)
+    for n in range(3):
+        (shot_dir / f"shot-{n}.png").write_bytes(PNG)
+
+    async def failing_upload(args: Any) -> dict[str, Any]:
+        return {"status": "failed", "reason": "host down"}
+
+    monkeypatch.setattr(uploadscreens, "upload_image_task", failing_upload)
+
+    return {
+        "base_dir": str(tmp_path),
+        "uuid": uuid,
+        "debug": False,
+        "screens": 3,
+        "image_list": [],
+        "cutoff": 3,
+    }
+
+
+def test_total_failure_on_remapped_host_returns_instead_of_raising(tmp_path: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    # imghost was remapped to img_host_2 (tracker approval), so the internal
+    # failover (which requires imghost == img_host_1) is inactive.
+    config = {"DEFAULT": {"img_host_1": "hostA", "img_host_2": "hostB"}}
+    meta = _setup(tmp_path, monkeypatch)
+    meta["imghost"] = "hostB"
+
+    image_list, count = asyncio.run(uploadscreens._upload_screens(config, meta, 3, 1, 0, 3, [], {}, max_retries=0))
+    assert image_list == []
+    assert count == 0
+
+
+def test_total_failure_with_custom_list_returns_empty(tmp_path: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    config = {"DEFAULT": {"img_host_1": "hostA"}}
+    meta = _setup(tmp_path, monkeypatch)
+    meta["imghost"] = "hostA"
+    custom = [str(tmp_path / "tmp" / meta["uuid"] / f"shot-{n}.png") for n in range(3)]
+
+    # Custom image lists disable the internal failover; a dead host must
+    # surface as an empty result for the caller (e.g. PTP poster upload).
+    image_list, count = asyncio.run(uploadscreens._upload_screens(config, meta, 3, 1, 0, 3, custom, {}, max_retries=0))
+    assert image_list == []
+    assert count == 0

--- a/tests/test_uploadscreens_failover.py
+++ b/tests/test_uploadscreens_failover.py
@@ -16,6 +16,9 @@ PNG = base64.b64decode("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4
 
 
 def _setup(tmp_path: Any, monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    # _upload_screens os.chdir()s into the screenshot dir; monkeypatch restores
+    # the original working directory on teardown.
+    monkeypatch.chdir(tmp_path)
     uuid = "fake-release"
     shot_dir = tmp_path / "tmp" / uuid
     shot_dir.mkdir(parents=True)


### PR DESCRIPTION
When every upload to the current host failed and the internal failover was inactive (the host had been remapped away from img_host_1 for tracker approval), _upload_screens raised and aborted the whole upload before the multi-host loop in upload.py could switch to the next configured host. Return an empty result instead; callers already handle the shortfall and report a clear error once all hosts are exhausted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Upload processing now handles cases where no images are available without raising an exception.
  * Complete image upload failures return an empty result and zero count instead of interrupting processing.

* **Tests**
  * Added regression coverage for failed uploads involving remapped hosts and custom image lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->