### PR TITLE
fix: never queue partially resolved split paths

### DIFF
--- a/src/queuemanage.py
+++ b/src/queuemanage.py
@@ -275,6 +275,13 @@ class QueueManager:
             queue.append(p1)
         else:
             console.print(f"[red]Path: [bold red]{p1}[/bold red] does not exist")
+            # All-or-nothing: a leftover fragment means the input was not a
+            # clean list of paths (e.g. a vanished path whose existing prefix
+            # is a parent directory). Queuing the resolved fragments anyway
+            # could enqueue an entire unrelated directory.
+            if queue:
+                console.print(f"[red]Discarding {len(queue)} partially resolved path(s); check the input path: [bold red]{path}[/bold red]")
+            return []
 
         return queue
 

--- a/tests/test_queue_split_path.py
+++ b/tests/test_queue_split_path.py
@@ -1,0 +1,44 @@
+# Regression tests for QueueManager._resolve_split_path.
+#
+# When a queued path no longer exists (e.g. a cross-seed dir cleaned up between
+# queueing and processing), the greedy space-split used to stop at the longest
+# existing *prefix* directory and queue it — which could enqueue an entire
+# parent directory full of unrelated releases. Resolution must be
+# all-or-nothing: any unresolved fragment discards the whole queue.
+
+import asyncio
+from typing import Any
+
+from src.queuemanage import QueueManager
+
+
+def _resolve(path: str) -> list[str]:
+    return asyncio.run(QueueManager._resolve_split_path(path))
+
+
+def test_vanished_path_with_existing_prefix_dir_returns_nothing(tmp_path: Any) -> None:
+    (tmp_path / "seedpool").mkdir()
+    gone = f"{tmp_path}/seedpool (API)/Some Movie (2001) (1080p WEB-DL - GRP).mkv"
+    assert _resolve(gone) == []
+
+
+def test_single_existing_path_with_spaces_resolves(tmp_path: Any) -> None:
+    d = tmp_path / "dir with space"
+    d.mkdir()
+    f = d / "file.mkv"
+    f.write_bytes(b"x")
+    assert _resolve(str(f)) == [str(f)]
+
+
+def test_two_existing_paths_split_on_space(tmp_path: Any) -> None:
+    a = tmp_path / "a.mkv"
+    b = tmp_path / "b.mkv"
+    a.write_bytes(b"x")
+    b.write_bytes(b"x")
+    assert _resolve(f"{a} {b}") == [str(a), str(b)]
+
+
+def test_existing_path_then_missing_path_returns_nothing(tmp_path: Any) -> None:
+    a = tmp_path / "a.mkv"
+    a.write_bytes(b"x")
+    assert _resolve(f"{a} {tmp_path}/missing.mkv") == []


### PR DESCRIPTION
The greedy space-split fallback stopped at the longest existing prefix of a vanished path and queued it, which could enqueue an entire parent directory of unrelated releases. Make resolution all-or-nothing: any fragment that fails to resolve discards the whole queue with a clear message.