### PR TITLE
fix(C411): embed screenshot thumbnails instead of full-size images

### DIFF
--- a/src/trackers/C411.py
+++ b/src/trackers/C411.py
@@ -1117,13 +1117,17 @@ class C411(FrenchTrackerMixin):
             parts.append("")
             img_lines: list[str] = []
             for img in image_list:
+                # Embed the thumbnail, linked to the full-size image: the site
+                # does not scale [img] tags, so a raw screenshot renders full width.
                 raw = img.get("raw_url", "")
                 web = img.get("web_url", "")
-                if raw:
-                    if web:
-                        img_lines.append(f"[url={web}][img]{raw}[/img][/url]")
+                thumb = img.get("img_url", "") or raw
+                link = web or (raw if thumb != raw else "")
+                if thumb:
+                    if link:
+                        img_lines.append(f"[url={link}][img]{thumb}[/img][/url]")
                     else:
-                        img_lines.append(f"[img]{raw}[/img]")
+                        img_lines.append(f"[img]{thumb}[/img]")
             if img_lines:
                 parts.append("[center]")
                 parts.append("\n".join(img_lines))

--- a/tests/test_c411.py
+++ b/tests/test_c411.py
@@ -1390,12 +1390,24 @@ class TestDescription:
 
     def test_with_screenshots(self):
         meta = _meta_base(image_list=[
+            {'img_url': 'https://img.host/1.md.png', 'raw_url': 'https://img.host/1.png', 'web_url': 'https://img.host/view/1'},
+            {'img_url': 'https://img.host/2.md.png', 'raw_url': 'https://img.host/2.png', 'web_url': ''},
+        ])
+        c = C411(_config({'include_screenshots': True}))
+        desc = asyncio.run(c._build_description(meta))
+        assert "[color=#3d85c6]Captures d'écran[/color]" in desc
+        # Thumbnails are embedded, linked to the full-size image
+        assert '[url=https://img.host/view/1][img]https://img.host/1.md.png[/img][/url]' in desc
+        assert '[url=https://img.host/2.png][img]https://img.host/2.md.png[/img][/url]' in desc
+
+    def test_with_screenshots_no_thumbnail(self):
+        # Hosts without a separate thumbnail fall back to the full-size URL
+        meta = _meta_base(image_list=[
             {'raw_url': 'https://img.host/1.png', 'web_url': 'https://img.host/view/1'},
             {'raw_url': 'https://img.host/2.png', 'web_url': ''},
         ])
         c = C411(_config({'include_screenshots': True}))
         desc = asyncio.run(c._build_description(meta))
-        assert "[color=#3d85c6]Captures d'écran[/color]" in desc
         assert '[url=https://img.host/view/1][img]https://img.host/1.png[/img][/url]' in desc
         assert '[img]https://img.host/2.png[/img]' in desc
 


### PR DESCRIPTION
The description builder inlined raw_url in [img] tags, so hosts that serve their full-size images on hotlink (e.g. ptscreens) rendered full-width screenshots instead of thumbnails. Embed img_url (the host thumbnail) linked to the full-size image, matching the pattern used by the other trackers, with a fallback to raw_url for hosts that provide no separate thumbnail.