### PR TITLE
fix(G3MINI): transliterate accented titles instead of dropping the le…

### DIFF
--- a/src/trackers/G3MINI.py
+++ b/src/trackers/G3MINI.py
@@ -186,12 +186,9 @@ class G3MINI(FrenchTrackerMixin, UNIT3D):
         def _clean_filename(name):
             # G3MINI keeps title-internal hyphens (WALL·E → WALL-E), so
             # middle dot / bullet map to hyphen instead of space.
-            _g3_map = {**FrenchTrackerMixin._TITLE_CHAR_MAP, "\u00b7": "-", "\u2022": "-"}
-            for char, repl in _g3_map.items():
-                name = name.replace(char, repl)
-            # Strip all non-alphanumeric chars except spaces, dots, hyphens, and + (for DD+, HDR10+)
-            name = re.sub(r"[^a-zA-Z0-9 .+\-]", "", name)
-            return name
+            name = name.replace("\u00b7", "-").replace("\u2022", "-")
+            # The shared cleaning transliterates accents and expands elisions.
+            return self._fr_clean(name)
 
         type = meta.get("type", "").upper()
         title = meta.get("title", "")

--- a/tests/test_g3mini.py
+++ b/tests/test_g3mini.py
@@ -819,6 +819,40 @@ class TestG3MINIFrenchTitle:
         assert name.startswith('Le.Prix.du.Danger'), f"French title expected, got: {name!r}"
         assert 'Price.of.Peril' not in name
 
+    def test_accented_title_is_transliterated_not_stripped(self):
+        """Accented letters must transliterate (é→e, à→a), never vanish."""
+        meta = _meta_base(
+            title='Cleo from 5 to 7',
+            original_language='fr',
+            frtitle='Cléo de 5 à 7',
+            type='ENCODE',
+            video_encode='x264',
+            video_codec='',
+            hdr='',
+            webdv='',
+            uhd='',
+            resolution='1080p',
+        )
+        name = self._get_name(meta)
+        assert name.startswith('Cleo.de.5.a.7'), f"Transliterated title expected, got: {name!r}"
+
+    def test_elided_article_apostrophe_becomes_separator(self):
+        """L'autre → L.autre (apostrophe expanded, not glued)."""
+        meta = _meta_base(
+            title="One Sings, the Other Doesn't",
+            original_language='fr',
+            frtitle="L'une chante, l'autre pas",
+            type='ENCODE',
+            video_encode='x264',
+            video_codec='',
+            hdr='',
+            webdv='',
+            uhd='',
+            resolution='1080p',
+        )
+        name = self._get_name(meta)
+        assert name.startswith('L.une.chante.l.autre.pas'), f"Expanded elision expected, got: {name!r}"
+
     def test_french_origin_fetches_title_when_uncached(self):
         """Without a cached frtitle, the title comes from the localized TMDB data."""
         meta = _meta_base(


### PR DESCRIPTION
…tters

The local filename cleaning stripped every non-ASCII character before any transliteration, so accented letters vanished from release names (Cléo de 5 à 7 → Clo.de.5.7). Reuse the shared _fr_clean, which normalizes, transliterates (é→e, à→a) and expands elided articles, keeping only the G3MINI-specific middle-dot→hyphen mapping.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generated release names for French titles by preserving readable accent transliterations.
  * Expanded apostrophe-based French elisions into consistent, dot-separated name tokens.
  * Standardized handling of middle dots and bullet characters in generated names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->