### PR TITLE
fix: fetch tracker metadata even when an Arr already provided IDs

### DIFF
--- a/src/prep.py
+++ b/src/prep.py
@@ -75,6 +75,13 @@ def _to_int(value: Any, default: int = 0) -> int:
         return default
 
 
+def _should_fetch_tracker_data(meta: dict[str, Any], ids: Optional[dict[str, Any]], tracker_ids: list[str]) -> bool:
+    # Arr results only provide database IDs, while a known tracker torrent
+    # also carries a description and hosted images: a tracker ID must still
+    # trigger the tracker-data fetch even when an Arr answered first.
+    return not meta.get("edit", False) and (not ids or any(meta.get(key) for key in tracker_ids))
+
+
 def _title_without_leading_article(title: str) -> str:
     return re.sub(r"^(the|a|an)\s+", "", title.strip().lower(), flags=re.IGNORECASE)
 
@@ -704,7 +711,7 @@ class Prep:
             if meta.get("infohash") is not None and not meta["base_torrent_created"] and not meta["we_checked_them_all"] and not ids:
                 meta = await client.get_ptp_from_hash(meta)
 
-            if not meta.get("edit", False) and not ids:
+            if _should_fetch_tracker_data(meta, ids, tracker_ids):
                 # Reuse information from trackers with fallback
                 await self.tracker_data_manager.get_tracker_data(video, meta, search_term, search_file_folder, meta["category"], only_id=only_id)
 

--- a/tests/test_tracker_reuse_vs_arr.py
+++ b/tests/test_tracker_reuse_vs_arr.py
@@ -1,0 +1,24 @@
+# Radarr/Sonarr results only carry database IDs; a tracker torrent found in
+# the client also carries a description and hosted images. A known tracker ID
+# must therefore still trigger the tracker-data fetch even when an Arr
+# answered first.
+
+from src.prep import _should_fetch_tracker_data
+
+TRACKER_IDS = ["lst", "blu", "ptp"]
+
+
+def test_no_arr_ids_fetches() -> None:
+    assert _should_fetch_tracker_data({}, None, TRACKER_IDS)
+
+
+def test_arr_ids_alone_skip_fetch() -> None:
+    assert not _should_fetch_tracker_data({}, {"tmdb_id": 33324}, TRACKER_IDS)
+
+
+def test_tracker_id_overrides_arr_ids() -> None:
+    assert _should_fetch_tracker_data({"lst": 188090}, {"tmdb_id": 33324}, TRACKER_IDS)
+
+
+def test_edit_mode_never_fetches() -> None:
+    assert not _should_fetch_tracker_data({"edit": True, "lst": 188090}, None, TRACKER_IDS)


### PR DESCRIPTION
Radarr/Sonarr results only carry database IDs, but the gate before get_tracker_data treated them as a full substitute for tracker data. When a tracker torrent was found in the client, its ID was extracted and then never used: descriptions and hosted images were not reused and fresh screenshots were generated instead.

Keep the Arr short-circuit only when no tracker ID is known.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved tracker data retrieval when relevant tracker IDs are available, including cases where other metadata is also present.
  - Prevented unnecessary tracker requests when only unrelated IDs are available or when processing edits.

- **Tests**
  - Added coverage for tracker-fetch eligibility across common and edge-case scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->