### PR TITLE
fix: strip seedpool signature from reused descriptions

### DIFF
--- a/src/bbcode.py
+++ b/src/bbcode.py
@@ -509,6 +509,11 @@ class BBCODE:
             desc,
             flags=re.IGNORECASE,
         )
+        # Remove seedpool signature: the ASCII-art block (identified by its
+        # distinctive ".4HH" strokes, so real NFO code blocks survive) and the
+        # closing seedbrr sentence
+        desc = re.sub(r"\s*\[code\]\[center\][^\[]*\.4HH[^\[]*\[/center\]\[/code\]\s*", "\n\n", desc, flags=re.IGNORECASE).strip()
+        desc = re.sub(r"\s*Posted to this fine tracker with seedbrr\.?", "", desc, flags=re.IGNORECASE)
         desc = re.sub(r"\[center\].*Created by.*Upload Assistant.*\[\/center\]", "", desc, flags=re.IGNORECASE)
         desc = re.sub(r"\[right\].*Created by.*Upload Assistant.*\[\/right\]", "", desc, flags=re.IGNORECASE)
 

--- a/src/bbcode.py
+++ b/src/bbcode.py
@@ -509,10 +509,11 @@ class BBCODE:
             desc,
             flags=re.IGNORECASE,
         )
-        # Remove seedpool signature: the ASCII-art block (identified by its
-        # distinctive ".4HH" strokes, so real NFO code blocks survive) and the
-        # closing seedbrr sentence
-        desc = re.sub(r"\s*\[code\]\[center\][^\[]*\.4HH[^\[]*\[/center\]\[/code\]\s*", "\n\n", desc, flags=re.IGNORECASE).strip()
+        # Remove seedpool signature: the ASCII-art block and the closing
+        # seedbrr sentence. The block must show two distinct anchors of the
+        # logo — a ".4HH" stroke and the closing ".JHHL." line — so a real
+        # NFO code block that merely shares one stroke survives.
+        desc = re.sub(r"\s*\[code\]\[center\][^\[]*\.4HH[^\[]*\.JHHL\.\s*\[/center\]\[/code\]\s*", "\n\n", desc, flags=re.IGNORECASE).strip()
         desc = re.sub(r"\s*Posted to this fine tracker with seedbrr\.?", "", desc, flags=re.IGNORECASE)
         desc = re.sub(r"\[center\].*Created by.*Upload Assistant.*\[\/center\]", "", desc, flags=re.IGNORECASE)
         desc = re.sub(r"\[right\].*Created by.*Upload Assistant.*\[\/right\]", "", desc, flags=re.IGNORECASE)

--- a/tests/test_bbcode_sp_cleanup.py
+++ b/tests/test_bbcode_sp_cleanup.py
@@ -39,3 +39,12 @@ def test_other_code_blocks_survive() -> None:
     desc = "[code][center]NFO contents worth keeping[/center][/code]\nSummary."
     cleaned, _ = BBCODE().clean_unit3d_description(desc, "https://seedpool.org")
     assert "NFO contents worth keeping" in cleaned
+
+
+def test_nfo_block_containing_art_strokes_is_preserved() -> None:
+    # A genuine ASCII-art NFO can contain the same ".4HH" strokes as the
+    # seedpool logo; one token alone must not wipe the block.
+    nfo = "[code][center].4HH  release notes\nripped from a pristine source[/center][/code]"
+    desc = f"{nfo}\nSummary line."
+    cleaned, _ = BBCODE().clean_unit3d_description(desc, "https://seedpool.org")
+    assert cleaned == desc

--- a/tests/test_bbcode_sp_cleanup.py
+++ b/tests/test_bbcode_sp_cleanup.py
@@ -1,0 +1,41 @@
+# Descriptions reused from seedpool carry an ASCII-art signature block and a
+# closing "Posted to this fine tracker with seedbrr." sentence; both must be
+# stripped by the generic UNIT3D description cleaner.
+
+from src.bbcode import BBCODE
+
+SEEDPOOL_ART = """[code][center]..                                   ..
+                                 .4HH                                 .4HH
+                                   HH                                   HH
+  ,pP"Yb.  .gP"Ya   .gP"Ya    ,H""bHH  .4HHpdHAo.  ,pW"Wq.   ,pW"Wq.    HH
+  8I   `" ,H'   Yb ,H'   Yb ,AP    HH    HH   `Wb 6W'   `Wb 6W'   `Wb   HH
+  `YHHHa. 8H\"\"\"\"\"\" 8H\"\"\"\"\"\" 8HI    HH    HH    H8 8H     H8 8H     H8   HH
+  L.   I8 YH.    , YH.    , `Hb    HH    HH   ,AP YA.   ,A9 YA.   ,A9   HH
+  `9hhhP'  `Hbmhd'  `Hbmhd'  `Wbhd"HHL.  HHbhhd'   `Ybhd9'   `Ybhd9'  .JHHL.
+                                         HH
+                                       .JHHL.[/center][/code]"""
+
+
+def test_seedpool_art_block_is_removed() -> None:
+    desc = f"{SEEDPOOL_ART}\nA plot summary that must stay."
+    cleaned, _ = BBCODE().clean_unit3d_description(desc, "https://seedpool.org")
+    assert cleaned == "A plot summary that must stay."
+
+
+def test_seedpool_art_mid_description_leaves_clean_spacing() -> None:
+    desc = f"Summary line.\n\n{SEEDPOOL_ART}\n\nMore."
+    cleaned, _ = BBCODE().clean_unit3d_description(desc, "https://seedpool.org")
+    assert cleaned == "Summary line.\n\nMore."
+
+
+def test_seedbrr_sentence_is_removed() -> None:
+    desc = "A plot summary that must stay. Posted to this fine tracker with seedbrr."
+    cleaned, _ = BBCODE().clean_unit3d_description(desc, "https://seedpool.org")
+    assert "seedbrr" not in cleaned
+    assert "A plot summary that must stay." in cleaned
+
+
+def test_other_code_blocks_survive() -> None:
+    desc = "[code][center]NFO contents worth keeping[/center][/code]\nSummary."
+    cleaned, _ = BBCODE().clean_unit3d_description(desc, "https://seedpool.org")
+    assert "NFO contents worth keeping" in cleaned


### PR DESCRIPTION
Descriptions reused from seedpool carry an ASCII-art code block and a closing "Posted to this fine tracker with seedbrr." sentence. Remove both in the generic UNIT3D description cleaner, next to the existing Aither signature strip. The art block is matched via its distinctive ".4HH" strokes so genuine NFO code blocks are kept.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * UNIT3D descriptions now automatically remove seedpool signatures and seedbrr closing messages.
  * Unrelated code blocks and surrounding description content are preserved.

* **Tests**
  * Added coverage for removing seedpool artwork, maintaining clean spacing, removing closing messages, and preserving unrelated code blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->