### PR TITLE
fix: strip seedpool sample spoiler from reused descriptions

### DIFF
--- a/src/bbcode.py
+++ b/src/bbcode.py
@@ -515,6 +515,8 @@ class BBCODE:
         # NFO code block that merely shares one stroke survives.
         desc = re.sub(r"\s*\[code\]\[center\][^\[]*\.4HH[^\[]*\.JHHL\.\s*\[/center\]\[/code\]\s*", "\n\n", desc, flags=re.IGNORECASE).strip()
         desc = re.sub(r"\s*Posted to this fine tracker with seedbrr\.?", "", desc, flags=re.IGNORECASE)
+        # ...and its sample-link spoiler ([b][spoiler=Sample: xyz]url[/spoiler][/b])
+        desc = re.sub(r"\s*(\[b\])?\[spoiler=Sample[^\]]*\][\s\S]*?\[/spoiler\](\[/b\])?\s*", "\n\n", desc, flags=re.IGNORECASE).strip()
         desc = re.sub(r"\[center\].*Created by.*Upload Assistant.*\[\/center\]", "", desc, flags=re.IGNORECASE)
         desc = re.sub(r"\[right\].*Created by.*Upload Assistant.*\[\/right\]", "", desc, flags=re.IGNORECASE)
 

--- a/tests/test_bbcode_sp_cleanup.py
+++ b/tests/test_bbcode_sp_cleanup.py
@@ -48,3 +48,24 @@ def test_nfo_block_containing_art_strokes_is_preserved() -> None:
     desc = f"{nfo}\nSummary line."
     cleaned, _ = BBCODE().clean_unit3d_description(desc, "https://seedpool.org")
     assert cleaned == desc
+
+
+def test_seedpool_sample_spoiler_is_removed() -> None:
+    desc = (
+        "A plot summary that must stay.\n\n"
+        "[b][spoiler=Sample: xFAKESAMPLEIDx]https://img.example.invalid/xFAKESAMPLEIDx[/spoiler][/b]"
+    )
+    cleaned, _ = BBCODE().clean_unit3d_description(desc, "https://seedpool.org")
+    assert cleaned == "A plot summary that must stay."
+
+
+def test_seedpool_sample_spoiler_mid_description_leaves_clean_spacing() -> None:
+    block = "[b][spoiler=Sample: xFAKESAMPLEIDx]https://img.example.invalid/xFAKESAMPLEIDx[/spoiler][/b]"
+    cleaned, _ = BBCODE().clean_unit3d_description(f"Summary.\n\n{block}\n\nMore.", "https://seedpool.org")
+    assert cleaned == "Summary.\n\nMore."
+
+
+def test_regular_spoiler_survives() -> None:
+    desc = "Summary.\n\n[spoiler=Screens]some content[/spoiler]"
+    cleaned, _ = BBCODE().clean_unit3d_description(desc, "https://seedpool.org")
+    assert "[spoiler=Screens]some content[/spoiler]" in cleaned


### PR DESCRIPTION
Descriptions reused from seedpool can also carry a sample link inside a [b][spoiler=Sample: ...]...[/spoiler][/b] block; remove it alongside the other seedpool signatures. Regular spoilers are kept.