### PR TITLE
feat: proxy_url config option to route uploads through an HTTP proxy

### DIFF
--- a/data/example-config.py
+++ b/data/example-config.py
@@ -15,6 +15,16 @@ config = {
         # succeeded. Leave empty to disable.
         "webhook_url": "",
 
+        # Route Upload-Assistant's outgoing HTTP(S) traffic (tracker APIs,
+        # image hosts, metadata providers) through an HTTP proxy, e.g. a
+        # VPN container proxy: "http://127.0.0.1:3128".
+        # Leave empty to disable. Explicit HTTP_PROXY/HTTPS_PROXY environment
+        # variables take precedence over this setting.
+        "proxy_url": "",
+        # Comma-separated hosts that bypass the proxy (keep your local
+        # torrent client here so it is not routed through the VPN).
+        "proxy_bypass": "localhost,127.0.0.1",
+
         # tmdb api key **REQUIRED**
         # visit "https://www.themoviedb.org/settings/api" copy api key and insert below
         "tmdb_api": "",

--- a/src/proxy_env.py
+++ b/src/proxy_env.py
@@ -1,0 +1,20 @@
+import os
+from typing import Any
+
+
+def apply_proxy_env(config: dict[str, Any]) -> None:
+    """Export the configured proxy as standard proxy environment variables.
+
+    httpx, requests and aiohttp sessions created with trust_env pick these up,
+    so every tracker/image-host request is routed through the proxy without
+    per-callsite changes. Explicit environment variables set by the user win
+    over the config values.
+    """
+    default = config.get("DEFAULT", {}) if isinstance(config.get("DEFAULT"), dict) else {}
+    proxy_url = str(default.get("proxy_url") or "").strip()
+    if not proxy_url:
+        return
+    for var in ("HTTP_PROXY", "HTTPS_PROXY"):
+        os.environ.setdefault(var, proxy_url)
+    proxy_bypass = str(default.get("proxy_bypass") or "").strip() or "localhost,127.0.0.1"
+    os.environ.setdefault("NO_PROXY", proxy_bypass)

--- a/src/proxy_env.py
+++ b/src/proxy_env.py
@@ -1,20 +1,44 @@
 import os
-from typing import Any
+from typing import Any, Optional
+from urllib.parse import urlsplit
+from urllib.request import getproxies, proxy_bypass
+
+from src.console import console
+
+_ALLOWED_SCHEMES = ("http", "https")
 
 
 def apply_proxy_env(config: dict[str, Any]) -> None:
     """Export the configured proxy as standard proxy environment variables.
 
-    httpx, requests and aiohttp sessions created with trust_env pick these up,
-    so every tracker/image-host request is routed through the proxy without
+    httpx and requests pick these up when creating clients, so every
+    tracker/image-host request is routed through the proxy without
     per-callsite changes. Explicit environment variables set by the user win
-    over the config values.
+    over the config values. Invalid proxy URLs are rejected with a warning
+    instead of being exported.
     """
     default = config.get("DEFAULT", {}) if isinstance(config.get("DEFAULT"), dict) else {}
     proxy_url = str(default.get("proxy_url") or "").strip()
     if not proxy_url:
         return
+    parts = urlsplit(proxy_url)
+    if parts.scheme not in _ALLOWED_SCHEMES or not parts.hostname:
+        console.print(f"[bold red]Ignoring invalid proxy_url {proxy_url!r}: expected http(s)://host[:port][/bold red]")
+        return
     for var in ("HTTP_PROXY", "HTTPS_PROXY"):
         os.environ.setdefault(var, proxy_url)
-    proxy_bypass = str(default.get("proxy_bypass") or "").strip() or "localhost,127.0.0.1"
-    os.environ.setdefault("NO_PROXY", proxy_bypass)
+    no_proxy = str(default.get("proxy_bypass") or "").strip() or "localhost,127.0.0.1"
+    os.environ.setdefault("NO_PROXY", no_proxy)
+
+
+def proxy_for(url: str) -> Optional[str]:
+    """Proxy to use for ``url`` per HTTP(S)_PROXY/NO_PROXY, or None for direct.
+
+    For aiohttp call sites: pass the result as the request's ``proxy=`` so
+    proxy routing works without ``trust_env`` (which would also enable
+    automatic .netrc credential lookup for arbitrary target hosts).
+    """
+    parts = urlsplit(url)
+    if not parts.hostname or proxy_bypass(parts.hostname):
+        return None
+    return getproxies().get(parts.scheme or "https")

--- a/src/trackermeta.py
+++ b/src/trackermeta.py
@@ -166,7 +166,7 @@ async def check_images_concurrently(imagelist: Sequence[ImageDict], meta: Meta) 
         try:
             if await check_image_link(img_url, timeout):
                 try:
-                    async with aiohttp.ClientSession(timeout=timeout) as session:
+                    async with aiohttp.ClientSession(timeout=timeout, trust_env=True) as session:
                         try:
                             async with session.get(img_url) as response:
                                 if response.status == 200:
@@ -251,7 +251,7 @@ async def check_image_link(url: str, timeout: Optional[aiohttp.ClientTimeout] = 
     connector = aiohttp.TCPConnector(ssl=False)  # Disable SSL verification for testing
 
     try:
-        async with aiohttp.ClientSession(timeout=timeout, connector=connector) as session:
+        async with aiohttp.ClientSession(timeout=timeout, connector=connector, trust_env=True) as session:
             try:
                 async with session.get(url) as response:
                     if response.status == 200:

--- a/src/trackermeta.py
+++ b/src/trackermeta.py
@@ -17,6 +17,7 @@ from typing_extensions import TypeAlias
 from src.bbcode import BBCODE
 from src.btnid import BtnIdManager
 from src.console import console
+from src.proxy_env import proxy_for
 from src.trackers.COMMON import COMMON
 from src.type_utils import to_int
 
@@ -166,9 +167,9 @@ async def check_images_concurrently(imagelist: Sequence[ImageDict], meta: Meta) 
         try:
             if await check_image_link(img_url, timeout):
                 try:
-                    async with aiohttp.ClientSession(timeout=timeout, trust_env=True) as session:
+                    async with aiohttp.ClientSession(timeout=timeout) as session:
                         try:
-                            async with session.get(img_url) as response:
+                            async with session.get(img_url, proxy=proxy_for(img_url)) as response:
                                 if response.status == 200:
                                     image_content = await response.read()
 
@@ -251,9 +252,9 @@ async def check_image_link(url: str, timeout: Optional[aiohttp.ClientTimeout] = 
     connector = aiohttp.TCPConnector(ssl=False)  # Disable SSL verification for testing
 
     try:
-        async with aiohttp.ClientSession(timeout=timeout, connector=connector, trust_env=True) as session:
+        async with aiohttp.ClientSession(timeout=timeout, connector=connector) as session:
             try:
-                async with session.get(url) as response:
+                async with session.get(url, proxy=proxy_for(url)) as response:
                     if response.status == 200:
                         content_type = response.headers.get("Content-Type", "").lower()
                         if "image" in content_type:

--- a/tests/test_proxy_env.py
+++ b/tests/test_proxy_env.py
@@ -1,0 +1,52 @@
+"""Tests for the proxy_url config option (src/proxy_env.py)."""
+
+from src.proxy_env import apply_proxy_env
+
+PROXY = "http://127.0.0.1:3128"
+
+
+def _clear(monkeypatch):
+    for var in ("HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"):
+        # setenv first so monkeypatch records the original (absent) state and
+        # removes anything apply_proxy_env sets during the test at teardown
+        monkeypatch.setenv(var, "sentinel")
+        monkeypatch.delenv(var)
+
+
+def test_sets_proxy_env_vars(monkeypatch):
+    _clear(monkeypatch)
+    apply_proxy_env({"DEFAULT": {"proxy_url": PROXY}})
+    import os
+
+    assert os.environ["HTTP_PROXY"] == PROXY
+    assert os.environ["HTTPS_PROXY"] == PROXY
+    assert os.environ["NO_PROXY"] == "localhost,127.0.0.1"
+
+
+def test_custom_bypass_list(monkeypatch):
+    _clear(monkeypatch)
+    apply_proxy_env({"DEFAULT": {"proxy_url": PROXY, "proxy_bypass": "localhost,127.0.0.1,qbit.lan"}})
+    import os
+
+    assert os.environ["NO_PROXY"] == "localhost,127.0.0.1,qbit.lan"
+
+
+def test_empty_config_leaves_env_untouched(monkeypatch):
+    _clear(monkeypatch)
+    apply_proxy_env({"DEFAULT": {"proxy_url": ""}})
+    apply_proxy_env({"DEFAULT": {}})
+    apply_proxy_env({})
+    import os
+
+    for var in ("HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"):
+        assert var not in os.environ
+
+
+def test_explicit_env_vars_win(monkeypatch):
+    _clear(monkeypatch)
+    monkeypatch.setenv("HTTPS_PROXY", "http://user-proxy:3128")
+    apply_proxy_env({"DEFAULT": {"proxy_url": PROXY}})
+    import os
+
+    assert os.environ["HTTPS_PROXY"] == "http://user-proxy:3128"
+    assert os.environ["HTTP_PROXY"] == PROXY

--- a/tests/test_proxy_env.py
+++ b/tests/test_proxy_env.py
@@ -1,6 +1,10 @@
 """Tests for the proxy_url config option (src/proxy_env.py)."""
 
-from src.proxy_env import apply_proxy_env
+import os
+
+import pytest
+
+from src.proxy_env import apply_proxy_env, proxy_for
 
 PROXY = "http://127.0.0.1:3128"
 
@@ -16,7 +20,6 @@ def _clear(monkeypatch):
 def test_sets_proxy_env_vars(monkeypatch):
     _clear(monkeypatch)
     apply_proxy_env({"DEFAULT": {"proxy_url": PROXY}})
-    import os
 
     assert os.environ["HTTP_PROXY"] == PROXY
     assert os.environ["HTTPS_PROXY"] == PROXY
@@ -26,7 +29,6 @@ def test_sets_proxy_env_vars(monkeypatch):
 def test_custom_bypass_list(monkeypatch):
     _clear(monkeypatch)
     apply_proxy_env({"DEFAULT": {"proxy_url": PROXY, "proxy_bypass": "localhost,127.0.0.1,qbit.lan"}})
-    import os
 
     assert os.environ["NO_PROXY"] == "localhost,127.0.0.1,qbit.lan"
 
@@ -36,7 +38,6 @@ def test_empty_config_leaves_env_untouched(monkeypatch):
     apply_proxy_env({"DEFAULT": {"proxy_url": ""}})
     apply_proxy_env({"DEFAULT": {}})
     apply_proxy_env({})
-    import os
 
     for var in ("HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"):
         assert var not in os.environ
@@ -45,8 +46,55 @@ def test_empty_config_leaves_env_untouched(monkeypatch):
 def test_explicit_env_vars_win(monkeypatch):
     _clear(monkeypatch)
     monkeypatch.setenv("HTTPS_PROXY", "http://user-proxy:3128")
-    apply_proxy_env({"DEFAULT": {"proxy_url": PROXY}})
-    import os
+    monkeypatch.setenv("NO_PROXY", "myhost.lan")
+    apply_proxy_env({"DEFAULT": {"proxy_url": PROXY, "proxy_bypass": "other.lan"}})
 
     assert os.environ["HTTPS_PROXY"] == "http://user-proxy:3128"
     assert os.environ["HTTP_PROXY"] == PROXY
+    assert os.environ["NO_PROXY"] == "myhost.lan"
+
+
+@pytest.mark.parametrize(
+    "bad_url",
+    [
+        "127.0.0.1:3128",  # missing scheme
+        "ftp://127.0.0.1:3128",  # unsupported scheme
+        "http://",  # no host
+        "http:///path",  # no host either
+        "not a url",
+    ],
+)
+def test_invalid_proxy_url_is_rejected(monkeypatch, bad_url):
+    _clear(monkeypatch)
+    apply_proxy_env({"DEFAULT": {"proxy_url": bad_url}})
+
+    for var in ("HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"):
+        assert var not in os.environ
+
+
+def test_https_scheme_accepted(monkeypatch):
+    _clear(monkeypatch)
+    apply_proxy_env({"DEFAULT": {"proxy_url": "https://proxy.lan:3128"}})
+
+    assert os.environ["HTTPS_PROXY"] == "https://proxy.lan:3128"
+
+
+def test_proxy_for_returns_proxy_for_external_host(monkeypatch):
+    _clear(monkeypatch)
+    apply_proxy_env({"DEFAULT": {"proxy_url": PROXY}})
+
+    assert proxy_for("https://img.example.invalid/a.png") == PROXY
+
+
+def test_proxy_for_respects_no_proxy(monkeypatch):
+    _clear(monkeypatch)
+    apply_proxy_env({"DEFAULT": {"proxy_url": PROXY, "proxy_bypass": "localhost,127.0.0.1,qbit.lan"}})
+
+    assert proxy_for("http://qbit.lan/api") is None
+    assert proxy_for("http://127.0.0.1:7476/api") is None
+
+
+def test_proxy_for_without_proxy_configured(monkeypatch):
+    _clear(monkeypatch)
+
+    assert proxy_for("https://img.example.invalid/a.png") is None

--- a/upload.py
+++ b/upload.py
@@ -43,6 +43,7 @@ from src.get_tracker_data import TrackerDataManager
 from src.internal_exclusivity import check_internal_destination_bans, check_internal_exclusivity
 from src.languages import languages_manager
 from src.nfo_link import NfoLinkManager
+from src.proxy_env import apply_proxy_env
 from src.qbitwait import Wait
 from src.queuemanage import QueueManager
 from src.takescreens import TakeScreensManager
@@ -241,6 +242,7 @@ if os.path.exists(_config_path):
         from data.config import config as _imported_config  # pyright: ignore[reportMissingImports,reportUnknownVariableType]
 
         config = cast(dict[str, Any], _imported_config)
+        apply_proxy_env(config)
         parser = Args(config)
         client = Clients(config)
         name_manager = NameManager(config)


### PR DESCRIPTION
Exports the configured proxy as standard HTTP_PROXY/HTTPS_PROXY/NO_PROXY environment variables at startup, so httpx and requests route all tracker and image-host traffic through it without per-callsite changes. External aiohttp sessions in trackermeta opt in via trust_env; local torrent-client traffic stays direct through proxy_bypass. Explicit environment variables set by the user take precedence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable HTTP(S) proxy support for outgoing connections.
  * Added proxy bypass settings, with localhost excluded by default.
  * Existing `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` environment variables remain prioritized.
* **Bug Fixes**
  * Image downloads and link validation now honor configured proxy and connection settings.
* **Tests**
  * Added coverage for default settings, custom bypass lists, empty configurations, and environment-variable precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->