### PR TITLE
feat: v3x fiche name

### DIFF
--- a/data/example-config.py
+++ b/data/example-config.py
@@ -1012,8 +1012,10 @@ config = {
             "api_key": "V3X api key (both read and upload scopes)",
             "announce_url": "get from V3X",
             # The site displays the .torrent's internal name: UA renames the
-            # torrent root to the generated release name. Seeding it requires
-            # a client with linking enabled (the link folder takes that name).
+            # torrent root to the generated release name (single files are
+            # wrapped in a folder so the inner file keeps its original,
+            # cross-seedable name). Seeding it requires a client with linking
+            # enabled (the link folder takes that name).
             "anon": False,
             # Include screenshot thumbnails in the description (default True)
             "include_screenshots": True,

--- a/data/example-config.py
+++ b/data/example-config.py
@@ -1014,8 +1014,10 @@ config = {
             # The site displays the .torrent's internal name: UA renames the
             # torrent root to the generated release name (single files are
             # wrapped in a folder so the inner file keeps its original,
-            # cross-seedable name). Seeding it requires a client with linking
-            # enabled (the link folder takes that name).
+            # cross-seedable name). The rename only happens with a qBittorrent
+            # client that has linking enabled — the link folder takes the new
+            # name so seeding works without touching the on-disk content
+            # (unless your content path already carries that exact name).
             "anon": False,
             # Include screenshot thumbnails in the description (default True)
             "include_screenshots": True,

--- a/data/example-config.py
+++ b/data/example-config.py
@@ -1011,6 +1011,9 @@ config = {
         "V3X": {
             "api_key": "V3X api key (both read and upload scopes)",
             "announce_url": "get from V3X",
+            # The site displays the .torrent's internal name: UA renames the
+            # torrent root to the generated release name. Seeding it requires
+            # a client with linking enabled (the link folder takes that name).
             "anon": False,
             # Include screenshot thumbnails in the description (default True)
             "include_screenshots": True,

--- a/src/torrent_clients/qbittorrent.py
+++ b/src/torrent_clients/qbittorrent.py
@@ -924,7 +924,10 @@ class QbittorrentClientMixin:
             if cross:
                 linking_success = await create_cross_seed_links(meta=meta, torrent=torrent, tracker_dir=tracker_dir, use_hardlink=use_hardlink, tracker=tracker)
             else:
-                src_name = os.path.basename(src.rstrip(os.sep))
+                # Name the link directory after the torrent's internal root so a
+                # tracker-renamed torrent (e.g. V3X) finds its content; for
+                # torrents that keep the source name this is the same value.
+                src_name = str(getattr(torrent, "name", "") or "") or os.path.basename(src.rstrip(os.sep))
                 dst = os.path.join(tracker_dir, src_name)
                 # Per-tracker skip_nfo: only skip NFO for trackers that don't want it
                 tracker_skip_nfo = tracker.upper() in nfo_skip_trackers
@@ -933,6 +936,8 @@ class QbittorrentClientMixin:
             allow_fallback = client.get("allow_fallback", True)
             if not linking_success and allow_fallback:
                 console.print(f"[yellow]Using original path without linking: {src}")
+                if str(getattr(torrent, "name", "") or "") not in ("", os.path.basename(src.rstrip(os.sep))):
+                    console.print("[bold yellow]This tracker's torrent has a renamed root; seeding from the original path will not find the files.[/bold yellow]")
                 use_hardlink = False
                 use_symlink = False
             elif not linking_success:

--- a/src/torrent_clients/qbittorrent.py
+++ b/src/torrent_clients/qbittorrent.py
@@ -760,7 +760,30 @@ class QbittorrentClientMixin:
             # len(filelist) != 1; for single_file+isdir, path arrives as the release dir.
             # meta["path"] may be a raw file path, so capture path (the release dir) as
             # src BEFORE any dirname adjustment below.
-            src = path
+            raw_path = str(meta.get("path", ""))
+            try:
+                info = torrent.metainfo.get("info", {})
+                torrent_file_entries = info.get("files") or []
+                torrent_root = str(info.get("name", "") or "")
+            except Exception:
+                torrent_file_entries = []
+                torrent_root = ""
+            if (
+                torrent_is_multi_file
+                and len(torrent_file_entries) == 1
+                and os.path.isfile(raw_path)
+                and torrent_root
+                and os.path.basename(os.path.normpath(path)) != torrent_root
+            ):
+                # Wrapped single-file torrent (renamed folder root, one file)
+                # over a bare file: only the file itself is needed as link
+                # source — the parent directory is a shared folder that may
+                # hold unrelated sibling files. When path IS the release dir
+                # (root matches) or the torrent has several entries (e.g.
+                # mkv + nfo), the whole directory stays the source.
+                src = raw_path
+            else:
+                src = path
             if not meta.get("keep_folder") and os.path.isdir(path) and (tracker_wants_nfo or torrent_is_multi_file):
                 path = os.path.dirname(path)
         else:

--- a/src/torrent_clients/qbittorrent.py
+++ b/src/torrent_clients/qbittorrent.py
@@ -929,6 +929,10 @@ class QbittorrentClientMixin:
                 # torrents that keep the source name this is the same value.
                 src_name = str(getattr(torrent, "name", "") or "") or os.path.basename(src.rstrip(os.sep))
                 dst = os.path.join(tracker_dir, src_name)
+                if getattr(torrent, "mode", None) == "multifile" and await asyncio.to_thread(os.path.isfile, src):
+                    # Single file wrapped in a torrent folder: link the file
+                    # inside the root directory under its original name.
+                    dst = os.path.join(dst, os.path.basename(src))
                 # Per-tracker skip_nfo: only skip NFO for trackers that don't want it
                 tracker_skip_nfo = tracker.upper() in nfo_skip_trackers
                 linking_success = await async_link_directory(src=src, dst=dst, use_hardlink=use_hardlink, debug=meta.get("debug", False), skip_nfo=tracker_skip_nfo)

--- a/src/torrent_clients/rtorrent.py
+++ b/src/torrent_clients/rtorrent.py
@@ -130,9 +130,31 @@ class RtorrentClientMixin:
                     console.print(f"[bold yellow]Linking to tracker directory: {tracker_dir}")
                     console.print(f"[cyan]Source path: {src}")
 
-                # Extract only the folder or file name from `src`
-                src_name = os.path.basename(src.rstrip(os.sep))  # Ensure we get just the name
+                # Name the link destination after the torrent's internal root so
+                # a tracker-renamed torrent (e.g. V3X) finds its content; for
+                # torrents that keep the source name this is the same value.
+                src_name = str(getattr(torrent, "name", "") or "") or os.path.basename(src.rstrip(os.sep))
                 dst = os.path.join(tracker_dir, src_name)  # Destination inside linked folder
+
+                try:
+                    torrent_is_multi_file = bool(torrent.metainfo.get("info", {}).get("files"))
+                except Exception:
+                    torrent_is_multi_file = False
+                if torrent_is_multi_file and os.path.isfile(src):
+                    # Single file wrapped in a torrent folder: link the file
+                    # inside the root directory under its original name. The
+                    # generic branches below then see dst as already handled.
+                    os.makedirs(dst, exist_ok=True)
+                    dst_file = os.path.join(dst, os.path.basename(src))
+                    if not os.path.exists(dst_file):
+                        try:
+                            if use_hardlink:
+                                os.link(src, dst_file)
+                            else:
+                                os.symlink(src, dst_file)
+                        except OSError as e:
+                            console.print(f"[yellow]Linking failed for wrapped single file: {e}")
+                            shutil.copy2(src, dst_file)
 
                 # path magic
                 if os.path.exists(dst) or os.path.islink(dst):

--- a/src/trackers/V3X.py
+++ b/src/trackers/V3X.py
@@ -13,11 +13,13 @@
 
 import asyncio
 import contextlib
+import os
 import re
 from typing import Any, Optional
 
 import aiofiles
 import httpx
+from torf import Torrent
 from unidecode import unidecode
 
 from src.console import console
@@ -458,6 +460,38 @@ class V3X(FrenchTrackerMixin):
 
         return "\n".join(parts).strip()
 
+    def _rename_torrent_root(self, meta: Meta, name: str) -> None:
+        """Set the [V3X].torrent internal root name to the generated release name.
+
+        Only metadata outside the piece hashes changes, so no rehash happens —
+        but the infohash does change, letting the client seed this torrent
+        separately through the tracker link directory (which the qBittorrent
+        injection names after the torrent root).
+        """
+        if not name:
+            return
+        torrent_path = os.path.join(meta["base_dir"], "tmp", meta["uuid"], f"[{self.tracker}].torrent")
+        try:
+            torrent = Torrent.read(torrent_path)
+            new_name = name
+            if torrent.mode == "singlefile":
+                # Single-file torrent: the root IS the file — keep its extension
+                ext = os.path.splitext(str(torrent.name))[1]
+                if ext and not new_name.lower().endswith(ext.lower()):
+                    new_name = f"{name}{ext}"
+            if torrent.name == new_name:
+                return
+            torrent.name = new_name
+            torrent.write(torrent_path, overwrite=True)
+            clients_cfg = self.config.get("TORRENT_CLIENTS", {})
+            has_linking = any(str(c.get("linking", "")).strip() for c in clients_cfg.values() if isinstance(c, dict))
+            if not has_linking:
+                console.print(
+                    f"[yellow]{self.tracker}: torrent root renamed to match the site's naming rules, but no client has linking configured — seeding needs the content path to carry that name.[/yellow]"
+                )
+        except Exception as e:
+            console.print(f"[yellow]{self.tracker}: could not rename torrent root ({e}); the fiche will show the original name.[/yellow]")
+
     async def _read_tmp_file(self, meta: Meta, filename: str) -> Optional[bytes]:
         path = f"{meta['base_dir']}/tmp/{meta['uuid']}/{filename}"
         try:
@@ -485,6 +519,10 @@ class V3X(FrenchTrackerMixin):
 
         name_result = await self.get_name(meta)
         name = name_result.get("name", "") if isinstance(name_result, dict) else str(name_result)
+
+        # The site displays the .torrent's internal name, not the name field:
+        # rewrite the root so the fiche carries the generated release name.
+        await asyncio.to_thread(self._rename_torrent_root, meta, name)
 
         torrent_bytes = await self._read_tmp_file(meta, f"[{self.tracker}].torrent")
         if not torrent_bytes:

--- a/src/trackers/V3X.py
+++ b/src/trackers/V3X.py
@@ -470,6 +470,17 @@ class V3X(FrenchTrackerMixin):
         """
         if not name:
             return
+        # Seeding a renamed torrent relies on the qBittorrent link directory
+        # taking the torrent's root name. Without a qbit client with linking,
+        # keep the original root so the upload stays seedable — the fiche
+        # will simply show the on-disk release name.
+        clients_cfg = self.config.get("TORRENT_CLIENTS", {})
+        has_qbit_linking = any(
+            isinstance(c, dict) and str(c.get("torrent_client", "")).lower() == "qbit" and str(c.get("linking", "") or "").strip() for c in clients_cfg.values()
+        )
+        if not has_qbit_linking:
+            console.print(f"[yellow]{self.tracker}: no qBittorrent client with linking configured — keeping the original torrent name so seeding still works.[/yellow]")
+            return
         torrent_path = os.path.join(meta["base_dir"], "tmp", meta["uuid"], f"[{self.tracker}].torrent")
         try:
             torrent = Torrent.read(torrent_path)
@@ -491,12 +502,6 @@ class V3X(FrenchTrackerMixin):
                     return
                 torrent.name = name
             torrent.write(torrent_path, overwrite=True)
-            clients_cfg = self.config.get("TORRENT_CLIENTS", {})
-            has_linking = any(str(c.get("linking", "")).strip() for c in clients_cfg.values() if isinstance(c, dict))
-            if not has_linking:
-                console.print(
-                    f"[yellow]{self.tracker}: torrent root renamed to match the site's naming rules, but no client has linking configured — seeding needs the content path to carry that name.[/yellow]"
-                )
         except Exception as e:
             console.print(f"[yellow]{self.tracker}: could not rename torrent root ({e}); the fiche will show the original name.[/yellow]")
 

--- a/src/trackers/V3X.py
+++ b/src/trackers/V3X.py
@@ -470,16 +470,18 @@ class V3X(FrenchTrackerMixin):
         """
         if not name:
             return
-        # Seeding a renamed torrent relies on the qBittorrent link directory
-        # taking the torrent's root name. Without a qbit client with linking,
-        # keep the original root so the upload stays seedable — the fiche
-        # will simply show the on-disk release name.
+        # Seeding a renamed torrent relies on the client's link directory
+        # taking the torrent's root name (supported for qBittorrent and
+        # rTorrent). Without such a client, keep the original root so the
+        # upload stays seedable — the fiche will show the on-disk name.
         clients_cfg = self.config.get("TORRENT_CLIENTS", {})
-        has_qbit_linking = any(
-            isinstance(c, dict) and str(c.get("torrent_client", "")).lower() == "qbit" and str(c.get("linking", "") or "").strip() for c in clients_cfg.values()
+        has_link_client = any(
+            isinstance(c, dict) and str(c.get("torrent_client", "")).lower() in ("qbit", "rtorrent") and str(c.get("linking", "") or "").strip() for c in clients_cfg.values()
         )
-        if not has_qbit_linking:
-            console.print(f"[yellow]{self.tracker}: no qBittorrent client with linking configured — keeping the original torrent name so seeding still works.[/yellow]")
+        if not has_link_client:
+            console.print(
+                f"[yellow]{self.tracker}: no qBittorrent/rTorrent client with linking configured — keeping the original torrent name so seeding still works.[/yellow]"
+            )
             return
         torrent_path = os.path.join(meta["base_dir"], "tmp", meta["uuid"], f"[{self.tracker}].torrent")
         try:

--- a/src/trackers/V3X.py
+++ b/src/trackers/V3X.py
@@ -473,15 +473,23 @@ class V3X(FrenchTrackerMixin):
         torrent_path = os.path.join(meta["base_dir"], "tmp", meta["uuid"], f"[{self.tracker}].torrent")
         try:
             torrent = Torrent.read(torrent_path)
-            new_name = name
             if torrent.mode == "singlefile":
-                # Single-file torrent: the root IS the file — keep its extension
-                ext = os.path.splitext(str(torrent.name))[1]
-                if ext and not new_name.lower().endswith(ext.lower()):
-                    new_name = f"{name}{ext}"
-            if torrent.name == new_name:
-                return
-            torrent.name = new_name
+                # Wrap the file in a folder named after the release instead of
+                # renaming the file itself: the fiche shows the folder name
+                # while the inner file keeps its original (cross-seedable)
+                # name. Pieces cover the same byte stream either way — no
+                # rehash needed.
+                info = torrent.metainfo["info"]
+                original_file = str(info["name"])
+                if original_file == name:
+                    return
+                info["files"] = [{"length": info.pop("length"), "path": [original_file]}]
+                info.pop("md5sum", None)
+                info["name"] = name
+            else:
+                if torrent.name == name:
+                    return
+                torrent.name = name
             torrent.write(torrent_path, overwrite=True)
             clients_cfg = self.config.get("TORRENT_CLIENTS", {})
             has_linking = any(str(c.get("linking", "")).strip() for c in clients_cfg.values() if isinstance(c, dict))

--- a/tests/test_nfo_torrent_flow.py
+++ b/tests/test_nfo_torrent_flow.py
@@ -1111,3 +1111,25 @@ class TestResolveSrcAndSavePath:
             "Single-file torrent must use the mkv as src regardless of tracker_wants_nfo. "
             "Linking the folder when the torrent expects a bare file causes missing-file errors."
         )
+
+
+class TestResolveSrcBareSingleFile:
+    """A bare single file (no release directory) must resolve to the file
+    itself as link source — resolving to the parent directory would link
+    unrelated sibling files into the tracker link folder."""
+
+    def test_bare_file_with_multifile_torrent_keeps_file_as_src(self, tmp_path):
+        from src.torrent_clients.qbittorrent import QbittorrentClientMixin
+
+        movie = tmp_path / "Movie.2024.1080p.WEB-GRP.mkv"
+        movie.write_bytes(b"x")
+        (tmp_path / "Unrelated.Sibling.mkv").write_bytes(b"y")
+
+        class _FakeTorrent:
+            metainfo = {"info": {"files": [{"length": 1, "path": ["Movie.2024.1080p.WEB-GRP.mkv"]}], "name": "Wrapped.Root"}}
+
+        meta = {"path": str(movie), "filelist": [str(movie)], "keep_nfo": False}
+        obj = QbittorrentClientMixin.__new__(QbittorrentClientMixin)
+        # Caller normalisation for a bare file collapses path to the parent dir
+        src, save_path = obj._resolve_src_and_save_path(str(tmp_path), _FakeTorrent(), meta, "V3X")
+        assert src == str(movie)

--- a/tests/test_v3x.py
+++ b/tests/test_v3x.py
@@ -732,3 +732,55 @@ def test_description_survives_non_numeric_ids(monkeypatch: Any, tmp_path: Any):
     desc = asyncio.run(tracker._build_description(meta))
     assert "[url=https://www.imdb.com/title/tt1375666/]IMDb[/url]" in desc
     assert "themoviedb.org" not in desc
+
+
+class TestTorrentRootRename:
+    """The site displays the .torrent internal name — V3X renames the root."""
+
+    def _make_torrent(self, tmp_path: Any, uuid: str, single_file: bool = False) -> str:
+        from torf import Torrent
+
+        content = tmp_path / "content" / uuid
+        if single_file:
+            content.parent.mkdir(parents=True, exist_ok=True)
+            content = content.with_suffix(".mkv")
+            content.write_bytes(b"x" * 2048)
+        else:
+            content.mkdir(parents=True)
+            (content / "movie.mkv").write_bytes(b"x" * 2048)
+        t = Torrent(path=str(content), trackers=["https://tracker.example/announce"], piece_size=16384)
+        t.generate()
+        out_dir = tmp_path / "tmp" / uuid
+        out_dir.mkdir(parents=True, exist_ok=True)
+        out = out_dir / "[V3X].torrent"
+        t.write(str(out))
+        return str(out)
+
+    def test_folder_torrent_root_renamed_without_rehash(self, tmp_path: Any):
+        from torf import Torrent
+
+        uuid = "Some.Movie.2024.1080p.WEB-GRP"
+        path = self._make_torrent(tmp_path, uuid)
+        pieces_before = Torrent.read(path).metainfo["info"]["pieces"]
+        tracker = V3X(_config())
+        meta = {"base_dir": str(tmp_path), "uuid": uuid}
+        tracker._rename_torrent_root(meta, "Un.Film.2024.VOSTFR.1080p.WEB-GRP")
+        t = Torrent.read(path)
+        assert t.name == "Un.Film.2024.VOSTFR.1080p.WEB-GRP"
+        assert t.metainfo["info"]["pieces"] == pieces_before
+        assert [str(f) for f in t.files] == ["Un.Film.2024.VOSTFR.1080p.WEB-GRP/movie.mkv"]
+
+    def test_single_file_torrent_keeps_extension(self, tmp_path: Any):
+        from torf import Torrent
+
+        uuid = "Some.Movie.2024.1080p.WEB-GRP"
+        path = self._make_torrent(tmp_path, uuid, single_file=True)
+        tracker = V3X(_config())
+        meta = {"base_dir": str(tmp_path), "uuid": uuid}
+        tracker._rename_torrent_root(meta, "Un.Film.2024.VOSTFR.1080p.WEB-GRP")
+        assert Torrent.read(path).name == "Un.Film.2024.VOSTFR.1080p.WEB-GRP.mkv"
+
+    def test_missing_torrent_is_tolerated(self, tmp_path: Any):
+        tracker = V3X(_config())
+        meta = {"base_dir": str(tmp_path), "uuid": "nope"}
+        tracker._rename_torrent_root(meta, "Whatever")  # must not raise

--- a/tests/test_v3x.py
+++ b/tests/test_v3x.py
@@ -813,3 +813,23 @@ def test_rename_skipped_without_qbit_linking(tmp_path: Any):
     tracker._rename_torrent_root({"base_dir": str(tmp_path), "uuid": uuid}, "Un.Film.2024.VOSTFR.1080p.WEB-GRP")
     # No qbit+linking client: the root must stay untouched so seeding works
     assert Torrent.read(str(out / "[V3X].torrent")).name == uuid
+
+
+def test_rename_allowed_with_rtorrent_linking(tmp_path: Any):
+    from torf import Torrent
+
+    uuid = "Some.Movie.2024.1080p.WEB-GRP"
+    content = tmp_path / "content" / uuid
+    content.mkdir(parents=True)
+    (content / "movie.mkv").write_bytes(b"x" * 2048)
+    t = Torrent(path=str(content), trackers=["https://tracker.example/announce"], piece_size=16384)
+    t.generate()
+    out = tmp_path / "tmp" / uuid
+    out.mkdir(parents=True)
+    t.write(str(out / "[V3X].torrent"))
+
+    config = _config()
+    config["TORRENT_CLIENTS"] = {"rt": {"torrent_client": "rtorrent", "linking": "symlink"}}
+    tracker = V3X(config)
+    tracker._rename_torrent_root({"base_dir": str(tmp_path), "uuid": uuid}, "Un.Film.2024.VOSTFR.1080p.WEB-GRP")
+    assert Torrent.read(str(out / "[V3X].torrent")).name == "Un.Film.2024.VOSTFR.1080p.WEB-GRP"

--- a/tests/test_v3x.py
+++ b/tests/test_v3x.py
@@ -743,7 +743,7 @@ class TestTorrentRootRename:
         content = tmp_path / "content" / uuid
         if single_file:
             content.parent.mkdir(parents=True, exist_ok=True)
-            content = content.with_suffix(".mkv")
+            content = content.parent / f"{uuid}.mkv"
             content.write_bytes(b"x" * 2048)
         else:
             content.mkdir(parents=True)
@@ -770,15 +770,22 @@ class TestTorrentRootRename:
         assert t.metainfo["info"]["pieces"] == pieces_before
         assert [str(f) for f in t.files] == ["Un.Film.2024.VOSTFR.1080p.WEB-GRP/movie.mkv"]
 
-    def test_single_file_torrent_keeps_extension(self, tmp_path: Any):
+    def test_single_file_torrent_is_wrapped_in_a_folder(self, tmp_path: Any):
         from torf import Torrent
 
         uuid = "Some.Movie.2024.1080p.WEB-GRP"
         path = self._make_torrent(tmp_path, uuid, single_file=True)
+        pieces_before = Torrent.read(path).metainfo["info"]["pieces"]
         tracker = V3X(_config())
         meta = {"base_dir": str(tmp_path), "uuid": uuid}
         tracker._rename_torrent_root(meta, "Un.Film.2024.VOSTFR.1080p.WEB-GRP")
-        assert Torrent.read(path).name == "Un.Film.2024.VOSTFR.1080p.WEB-GRP.mkv"
+        t = Torrent.read(path)
+        # Root folder carries the release name; the inner file keeps its
+        # original (cross-seedable) name; pieces are untouched.
+        assert t.mode == "multifile"
+        assert t.name == "Un.Film.2024.VOSTFR.1080p.WEB-GRP"
+        assert [str(f) for f in t.files] == ["Un.Film.2024.VOSTFR.1080p.WEB-GRP/Some.Movie.2024.1080p.WEB-GRP.mkv"]
+        assert t.metainfo["info"]["pieces"] == pieces_before
 
     def test_missing_torrent_is_tolerated(self, tmp_path: Any):
         tracker = V3X(_config())

--- a/tests/test_v3x.py
+++ b/tests/test_v3x.py
@@ -15,6 +15,7 @@ def _config() -> dict[str, Any]:
     return {
         "TRACKERS": {"V3X": {"api_key": "test-key", "announce_url": "https://api.v3x.club/announce/FAKE"}},
         "DEFAULT": {"tmdb_api": "fake"},
+        "TORRENT_CLIENTS": {"qbt": {"torrent_client": "qbit", "linking": "hardlink"}},
     }
 
 
@@ -791,3 +792,24 @@ class TestTorrentRootRename:
         tracker = V3X(_config())
         meta = {"base_dir": str(tmp_path), "uuid": "nope"}
         tracker._rename_torrent_root(meta, "Whatever")  # must not raise
+
+
+def test_rename_skipped_without_qbit_linking(tmp_path: Any):
+    from torf import Torrent
+
+    uuid = "Some.Movie.2024.1080p.WEB-GRP"
+    content = tmp_path / "content" / uuid
+    content.mkdir(parents=True)
+    (content / "movie.mkv").write_bytes(b"x" * 2048)
+    t = Torrent(path=str(content), trackers=["https://tracker.example/announce"], piece_size=16384)
+    t.generate()
+    out = tmp_path / "tmp" / uuid
+    out.mkdir(parents=True)
+    t.write(str(out / "[V3X].torrent"))
+
+    config = _config()
+    config["TORRENT_CLIENTS"] = {"rt": {"torrent_client": "rtorrent"}}
+    tracker = V3X(config)
+    tracker._rename_torrent_root({"base_dir": str(tmp_path), "uuid": uuid}, "Un.Film.2024.VOSTFR.1080p.WEB-GRP")
+    # No qbit+linking client: the root must stay untouched so seeding works
+    assert Torrent.read(str(out / "[V3X].torrent")).name == uuid


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * V3X-generated torrents now use the release name as their internal root folder.
  * Single-file torrents are organized under the release-name folder while preserving the original filename and data.
  * qBittorrent linking now follows the torrent’s internal root structure.
* **Bug Fixes**
  * Added warnings for renamed torrent roots when automatic seeding links cannot be created.
  * Improved handling of missing torrent files and unchanged names without affecting piece data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->