### PR TITLE
feat: v3x upload fields

### DIFF
--- a/data/example-config.py
+++ b/data/example-config.py
@@ -1009,7 +1009,12 @@ config = {
             "modq": False,
         },
         "V3X": {
-            "api_key": "V3X api key (both read and upload scopes)",
+            "api_key": "V3X api key (upload scope)",
+            # Site credentials — the dupe search browses the catalog through a
+            # web session (API keys are upload-only since the 2026-08 update).
+            # Without them V3X is skipped at upload time (no blind uploads).
+            "username": "",
+            "password": "",
             "announce_url": "get from V3X",
             # The site displays the .torrent's internal name: UA renames the
             # torrent root to the generated release name (single files are

--- a/data/example-config.py
+++ b/data/example-config.py
@@ -1012,7 +1012,7 @@ config = {
             "api_key": "V3X api key (upload scope)",
             # Site credentials — the dupe search browses the catalog through a
             # web session (API keys are upload-only since the 2026-08 update).
-            # Without them V3X is skipped at upload time (no blind uploads).
+            # Without them V3X is skipped before upload (no blind uploads).
             "username": "",
             "password": "",
             "announce_url": "get from V3X",

--- a/src/trackers/V3X.py
+++ b/src/trackers/V3X.py
@@ -7,9 +7,15 @@
 #     the filter param is q — "search" and the like are silently ignored
 #   GET  /torrents/{uuid}               detail: tmdbId, infoHash, description, nfo, files…
 #   GET  /categories                    public category tree (id/name/children)
+#   GET  /api/categories                key-authenticated tree with subcategory ids
 #   POST /api/torrents                  upload — multipart, Authorization: Bearer <api key>
-#     required: file (.torrent), name, categoryId (subcategory number), rightsDeclared
-#     accepted: description, nfo, tmdbId, anonymous, language
+#                                       (?apikey= also accepted; X-Api-Key is NOT)
+#     required: file (.torrent), categoryId (SUBcategory id), rightsDeclared;
+#               movies/series also require nfo and tmdbId (or tmdbUrl)
+#     accepted: name, description, descriptionFormat, language, title,
+#               posterUrl, backdropUrl, anonymous
+#   Browse routes (/torrents listing & detail) require a web session cookie —
+#   API keys are rejected there since the 2026-08 site update.
 
 import asyncio
 import contextlib
@@ -571,6 +577,13 @@ class V3X(FrenchTrackerMixin):
             data["nfo"] = nfo_text
         if int(meta.get("tmdb_id") or 0):
             data["tmdbId"] = str(meta["tmdb_id"])
+        fr_title = str(meta.get("frtitle") or "") or await self._get_french_title(meta)
+        if fr_title:
+            data["title"] = fr_title
+        if meta.get("poster"):
+            data["posterUrl"] = str(meta["poster"])
+        if meta.get("backdrop"):
+            data["backdropUrl"] = str(meta["backdrop"])
         # MediaInfo-based tag first (knows VOF/VOQ/VFB/AD/MUET); fall back
         # to name tokens when MediaInfo is unavailable (e.g. discs).
         language = (await self._build_audio_string(meta)).replace(".", ",") or self._get_language_tag(name)

--- a/src/trackers/V3X.py
+++ b/src/trackers/V3X.py
@@ -153,21 +153,19 @@ class V3X(FrenchTrackerMixin):
         def _normalize(s: str) -> str:
             return re.sub(r"[^a-z0-9]", "", unidecode(s).lower())
 
-        # The q filter is a raw case-insensitive substring over the stored
-        # NAME, and site names mix dot- and space-separators — so a
-        # multi-word query silently misses half the catalog. Query by the
-        # longest word of each title (separator-agnostic) and rely on the
-        # normalized client-side filters below for precision.
-        def _query_word(s: str) -> str:
-            words = re.sub(r"[^a-zA-Z0-9 ]", " ", unidecode(s)).split()
-            return max(words, key=len) if words else ""
+        # The q filter matches ordered words against both the stored name and
+        # the French title, separator- and accent-insensitive (improved since
+        # the 2026-08 update). Query the full cleaned title — but never append
+        # the year: TV names carry none and a year token yields zero matches.
+        def _q(s: str) -> str:
+            return " ".join(re.sub(r"[^a-zA-Z0-9 ]", " ", unidecode(s)).split())
 
         queries: list[str] = []
         ordered_titles = (fr_title, title) if str(meta.get("original_language", "")).lower() == "fr" else (title, fr_title)
         for t in ordered_titles:
-            word = _query_word(t)
-            if word and word.lower() not in (q.lower() for q in queries):
-                queries.append(word)
+            cleaned = _q(t)
+            if cleaned and cleaned.lower() not in (q.lower() for q in queries):
+                queries.append(cleaned)
         if not queries:
             return dupes
 

--- a/src/trackers/V3X.py
+++ b/src/trackers/V3X.py
@@ -56,6 +56,32 @@ class V3X(FrenchTrackerMixin):
         self.api_key = str(self.config["TRACKERS"].get(self.tracker, {}).get("api_key", "") or "").strip()
         self.tmdb_manager = TmdbManager(config)
         self.banned_groups: list[Any] = []
+        self._session_cookies: Optional[httpx.Cookies] = None
+
+    async def _login_session_cookies(self) -> Optional[httpx.Cookies]:
+        """Log in with the site credentials and cache the session cookie.
+
+        Browse routes (listing/detail) only accept a web session since the
+        2026-08 site update — API keys are upload-only there.
+        """
+        if self._session_cookies is not None:
+            return self._session_cookies
+        cfg = self.config["TRACKERS"].get(self.tracker, {})
+        login = str(cfg.get("username", "") or "").strip()
+        password = str(cfg.get("password", "") or "")
+        if not login or not password:
+            return None
+        try:
+            async with httpx.AsyncClient(timeout=20.0) as client:
+                response = await client.post(f"{self.api_base}/auth/login", json={"login": login, "password": password})
+        except (httpx.RequestError, httpx.TimeoutException) as e:
+            console.print(f"[yellow]{self.tracker}: login failed: {type(e).__name__}[/yellow]")
+            return None
+        if response.status_code != 200:
+            console.print(f"[yellow]{self.tracker}: login failed (HTTP {response.status_code}) — check the username/password in your config.[/yellow]")
+            return None
+        self._session_cookies = response.cookies
+        return self._session_cookies
 
     async def get_name(self, meta: Meta) -> dict[str, str]:
         result = await super().get_name(meta)
@@ -112,6 +138,12 @@ class V3X(FrenchTrackerMixin):
             meta["skipping"] = self.tracker
             return dupes
 
+        cookies = await self._login_session_cookies()
+        if cookies is None:
+            console.print(f"[yellow]{self.tracker}: the dupe search needs the site username/password in your config — skipping tracker to avoid a false negative.[/yellow]")
+            meta["skipping"] = self.tracker
+            return dupes
+
         title = str(meta.get("title") or "")
         fr_title = str(meta.get("frtitle") or "") or await self._get_french_title(meta)
         year_str = str(meta.get("year") or "").strip()
@@ -153,7 +185,7 @@ class V3X(FrenchTrackerMixin):
             total = None
             while page <= 50:  # hard cap so a misreported total can't loop forever
                 try:
-                    async with httpx.AsyncClient(timeout=30.0) as client:
+                    async with httpx.AsyncClient(timeout=30.0, cookies=cookies) as client:
                         response = await client.get(self.search_url, params={"q": search_term, "perPage": 100, "page": page})
                     if response.status_code != 200:
                         incomplete = True
@@ -239,14 +271,13 @@ class V3X(FrenchTrackerMixin):
         enrich_limit = 25  # one request per dupe — bound the sequential cost
         if len(dupes) > enrich_limit:
             console.print(f"[yellow]{self.tracker}: enriching only the first {enrich_limit} of {len(dupes)} dupes; the rest fall back to name similarity.[/yellow]")
-        headers = {"Authorization": f"Bearer {self.api_key}"} if self.api_key else {}
-        async with httpx.AsyncClient(timeout=20.0) as client:
+        async with httpx.AsyncClient(timeout=20.0, cookies=self._session_cookies) as client:
             for entry in dupes[:enrich_limit]:
                 torrent_id = entry.get("id")
                 if not torrent_id:
                     continue
                 try:
-                    response = await client.get(f"{self.search_url}/{torrent_id}", headers=headers)
+                    response = await client.get(f"{self.search_url}/{torrent_id}")
                     if response.status_code != 200:
                         continue
                     detail = response.json()

--- a/src/trackers/V3X.py
+++ b/src/trackers/V3X.py
@@ -42,6 +42,10 @@ RETRY_DELAY = 5.0  # seconds between upload retries
 class V3X(FrenchTrackerMixin):
     WEB_LABEL: str = "WEB"
     notag_label: str = "NOTAG"
+    # Site catalog convention: original title in the release name (the French
+    # title goes in the fiche's separate title field); originally-French
+    # works keep their French title.
+    PREFER_ORIGINAL_TITLE: bool = True
 
     def __init__(self, config: dict[str, Any]) -> None:
         self.config = config

--- a/tests/test_v3x.py
+++ b/tests/test_v3x.py
@@ -913,3 +913,9 @@ def test_login_returns_cookies_and_caches(monkeypatch: Any):
     # Second call hits the cache, no new request
     asyncio.run(tracker._login_session_cookies())
     assert len(calls) == 1
+
+
+def test_prefers_original_title_in_names():
+    # Original title in the release name (French title goes in the fiche's
+    # title field); originally-French works keep their French title.
+    assert V3X.PREFER_ORIGINAL_TITLE is True

--- a/tests/test_v3x.py
+++ b/tests/test_v3x.py
@@ -208,9 +208,13 @@ class TestUpload:
         async def fake_desc(*args: Any, **kwargs: Any) -> str:
             return "desc"
 
+        async def fake_fr_title(meta: Any) -> str:
+            return ""
+
         monkeypatch.setattr(tracker.common, "create_torrent_for_upload", fake_create)
         monkeypatch.setattr(tracker, "get_name", fake_get_name)
         monkeypatch.setattr(tracker, "_build_description", fake_desc)
+        monkeypatch.setattr(tracker, "_get_french_title", fake_fr_title)
 
     def test_upload_sends_required_contract(self, monkeypatch: Any, tmp_path: Any):
         tracker = V3X(_config())
@@ -477,10 +481,14 @@ def _prep_upload(monkeypatch: Any, tmp_path: Any, name: str, *, mediainfo: str =
     async def fake_desc(*args: Any, **kwargs: Any) -> str:
         return "desc"
 
+    async def fake_fr_title(meta: Any) -> str:
+        return ""
+
     monkeypatch.setattr(tracker.common, "create_torrent_for_upload", fake_create)
     monkeypatch.setattr(tracker, "get_name", fake_get_name)
     monkeypatch.setattr(tracker, "_build_description", fake_desc)
     monkeypatch.setattr(tracker, "_get_nfo_files", lambda meta: [])
+    monkeypatch.setattr(tracker, "_get_french_title", fake_fr_title)
     monkeypatch.setattr(v3x_module.httpx, "AsyncClient", client)
     monkeypatch.setattr(v3x_module, "RETRY_DELAY", 0)
     _FakeClient.response = _FakeResponse(201, {"id": "x"})
@@ -833,3 +841,25 @@ def test_rename_allowed_with_rtorrent_linking(tmp_path: Any):
     tracker = V3X(config)
     tracker._rename_torrent_root({"base_dir": str(tmp_path), "uuid": uuid}, "Un.Film.2024.VOSTFR.1080p.WEB-GRP")
     assert Torrent.read(str(out / "[V3X].torrent")).name == "Un.Film.2024.VOSTFR.1080p.WEB-GRP"
+
+
+def test_upload_sends_title_and_artwork_fields(monkeypatch: Any, tmp_path: Any):
+    name = "Some.Movie.2024.MULTi.VFF.1080p.WEB-GRP"
+    tracker, meta = _prep_upload(monkeypatch, tmp_path, name)
+    meta["frtitle"] = "Un Film"
+    meta["poster"] = "https://image.tmdb.org/t/p/original/poster.jpg"
+    meta["backdrop"] = "https://image.tmdb.org/t/p/original/backdrop.jpg"
+    asyncio.run(tracker.upload(meta, ""))
+    data = _FakeClient.captured["data"]
+    assert data["title"] == "Un Film"
+    assert data["posterUrl"] == "https://image.tmdb.org/t/p/original/poster.jpg"
+    assert data["backdropUrl"] == "https://image.tmdb.org/t/p/original/backdrop.jpg"
+
+
+def test_upload_omits_artwork_when_absent(monkeypatch: Any, tmp_path: Any):
+    tracker, meta = _prep_upload(monkeypatch, tmp_path, "Some.Movie.2024.1080p.WEB-GRP")
+    asyncio.run(tracker.upload(meta, ""))
+    data = _FakeClient.captured["data"]
+    assert "title" not in data
+    assert "posterUrl" not in data
+    assert "backdropUrl" not in data

--- a/tests/test_v3x.py
+++ b/tests/test_v3x.py
@@ -94,8 +94,8 @@ class TestSearchExisting:
         self._prep(monkeypatch, tracker)
         dupes = asyncio.run(tracker.search_existing({"title": "Some Movie"}))
         assert dupes == [{"name": "Some Movie (2024)", "size": 123, "link": "https://v3x.club/torrents/some-slug", "id": "uuid-1"}]
-        # Query uses the longest single word (separator-agnostic substring match)
-        assert _FakeClient.captured["params"]["q"] == "Movie"
+        # Full cleaned title (the API matches ordered words, separator-agnostic)
+        assert _FakeClient.captured["params"]["q"] == "Some Movie"
 
     def test_search_filters_irrelevant_results(self, monkeypatch: Any):
         monkeypatch.setattr(v3x_module.httpx, "AsyncClient", _FakeClient)
@@ -166,7 +166,7 @@ class TestSearchExisting:
         tracker = V3X(_config())
         self._prep(monkeypatch, tracker, fr_title="Les Infiltrés")
         asyncio.run(tracker.search_existing({"title": "The Departed"}))
-        assert seen_queries == ["Departed", "Infiltres"]
+        assert seen_queries == ["The Departed", "Les Infiltres"]
 
     def test_enrichment_adds_file_lists(self, monkeypatch: Any):
         class _DetailClient(_FakeClient):

--- a/tests/test_v3x.py
+++ b/tests/test_v3x.py
@@ -76,9 +76,13 @@ class TestSearchExisting:
         async def fake_enrich(dupes: Any, *, debug: bool = False) -> None:
             return None
 
+        async def fake_login() -> Any:
+            return v3x_module.httpx.Cookies()
+
         monkeypatch.setattr(tracker, "get_additional_checks", fake_checks)
         monkeypatch.setattr(tracker, "_get_french_title", fake_fr)
         monkeypatch.setattr(tracker, "_enrich_with_files", fake_enrich)
+        monkeypatch.setattr(tracker, "_login_session_cookies", fake_login)
 
     def test_search_maps_listing_to_dupes(self, monkeypatch: Any):
         monkeypatch.setattr(v3x_module.httpx, "AsyncClient", _FakeClient)
@@ -533,10 +537,14 @@ def test_search_existing_routes_dupes_through_french_lang_filter(monkeypatch: An
     async def fake_enrich(dupes: Any, *, debug: bool = False) -> None:
         return None
 
+    async def fake_login() -> Any:
+        return v3x_module.httpx.Cookies()
+
     monkeypatch.setattr(tracker, "get_additional_checks", fake_checks)
     monkeypatch.setattr(tracker, "_get_french_title", fake_fr)
     monkeypatch.setattr(tracker, "_enrich_with_files", fake_enrich)
     monkeypatch.setattr(tracker, "_check_french_lang_dupes", fake_filter)
+    monkeypatch.setattr(tracker, "_login_session_cookies", fake_login)
     dupes = asyncio.run(tracker.search_existing({"title": "Some Movie"}))
     assert seen["dupes"][0]["name"] == "Some.Movie.2024.VOSTFR.1080p.WEB-GRP"
     assert dupes[0]["flags"] == ["filtered"]
@@ -713,9 +721,13 @@ def test_search_paginates_without_total_until_short_page(monkeypatch: Any):
     async def fake_enrich(dupes: Any, *, debug: bool = False) -> None:
         return None
 
+    async def fake_login() -> Any:
+        return v3x_module.httpx.Cookies()
+
     monkeypatch.setattr(tracker, "get_additional_checks", fake_checks)
     monkeypatch.setattr(tracker, "_get_french_title", fake_fr)
     monkeypatch.setattr(tracker, "_enrich_with_files", fake_enrich)
+    monkeypatch.setattr(tracker, "_login_session_cookies", fake_login)
     dupes = asyncio.run(tracker.search_existing({"title": "Some Movie"}))
     # Full first page without a total → a second page is fetched; the short
     # second page ends the walk. No skipping, all 101 results kept.
@@ -863,3 +875,41 @@ def test_upload_omits_artwork_when_absent(monkeypatch: Any, tmp_path: Any):
     assert "title" not in data
     assert "posterUrl" not in data
     assert "backdropUrl" not in data
+
+
+def test_search_skips_without_site_credentials(monkeypatch: Any):
+    tracker = V3X(_config())
+
+    async def fake_checks(meta: Any) -> bool:
+        return True
+
+    monkeypatch.setattr(tracker, "get_additional_checks", fake_checks)
+    meta: dict[str, Any] = {"title": "X"}
+    # No username/password in config → login returns None → fail-closed skip
+    assert asyncio.run(tracker.search_existing(meta)) == []
+    assert meta["skipping"] == "V3X"
+
+
+def test_login_returns_cookies_and_caches(monkeypatch: Any):
+    config = _config()
+    config["TRACKERS"]["V3X"]["username"] = "user"
+    config["TRACKERS"]["V3X"]["password"] = "pass"
+    tracker = V3X(config)
+    calls: list[str] = []
+
+    class _LoginResponse:
+        status_code = 200
+        cookies = v3x_module.httpx.Cookies({"v3x_sid": "abc"})
+
+    class _LoginClient(_FakeClient):
+        async def post(self, url: str, **kwargs: Any) -> Any:
+            calls.append(url)
+            assert kwargs["json"] == {"login": "user", "password": "pass"}
+            return _LoginResponse()
+
+    monkeypatch.setattr(v3x_module.httpx, "AsyncClient", _LoginClient)
+    cookies = asyncio.run(tracker._login_session_cookies())
+    assert cookies is not None and cookies.get("v3x_sid") == "abc"
+    # Second call hits the cache, no new request
+    asyncio.run(tracker._login_session_cookies())
+    assert len(calls) == 1

--- a/tests/test_v3x.py
+++ b/tests/test_v3x.py
@@ -915,7 +915,47 @@ def test_login_returns_cookies_and_caches(monkeypatch: Any):
     assert len(calls) == 1
 
 
-def test_prefers_original_title_in_names():
+def test_prefers_original_title_in_names(monkeypatch: Any):
     # Original title in the release name (French title goes in the fiche's
     # title field); originally-French works keep their French title.
-    assert V3X.PREFER_ORIGINAL_TITLE is True
+    tracker = V3X(_config())
+
+    async def fake_fr(meta: Any) -> str:
+        return "Les Infiltrés"
+
+    monkeypatch.setattr(tracker, "_get_french_title", fake_fr)
+    meta = {"title": "The Departed", "original_language": "en", "year": 2006, "resolution": "1080p", "type": "ENCODE", "source": "BluRay", "category": "MOVIE", "tag": "-GRP", "video_encode": "x264"}
+    assert asyncio.run(tracker.get_name(meta))["name"] == "The.Departed.2006.1080p.BluRay.x264-GRP"
+    assert asyncio.run(tracker.get_name(dict(meta, original_language="fr")))["name"] == "Les.Infiltres.2006.1080p.BluRay.x264-GRP"
+
+
+def test_session_cookie_reaches_search_and_enrichment(monkeypatch: Any):
+    constructed: list[Any] = []
+
+    class _CookieClient(_FakeClient):
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            constructed.append(kwargs.get("cookies"))
+
+        async def get(self, url: str, **kwargs: Any) -> _FakeResponse:
+            if url.endswith("/torrents"):
+                return _FakeResponse(200, {"torrents": [{"id": "u1", "slug": "s1", "name": "Some.Movie.2024.1080p.WEB-GRP", "size": 1}], "total": 1})
+            return _FakeResponse(200, {"files": [{"path": "a.mkv", "size": 1}]})
+
+    monkeypatch.setattr(v3x_module.httpx, "AsyncClient", _CookieClient)
+    tracker = V3X(_config())
+    jar = v3x_module.httpx.Cookies({"v3x_sid": "abc"})
+    tracker._session_cookies = jar
+
+    async def fake_checks(meta: Any) -> bool:
+        return True
+
+    async def fake_fr(meta: Any) -> str:
+        return ""
+
+    monkeypatch.setattr(tracker, "get_additional_checks", fake_checks)
+    monkeypatch.setattr(tracker, "_get_french_title", fake_fr)
+    dupes = asyncio.run(tracker.search_existing({"title": "Some Movie"}))
+    assert dupes and dupes[0]["file_count"] == 1
+    # Both the paginated search client and the enrichment client carry the jar
+    assert len(constructed) >= 2
+    assert all(c is not None and c.get("v3x_sid") == "abc" for c in constructed)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added separate V3X credentials for catalog browsing and document uploads.
  * Uploads now include French titles, posters, and backdrop artwork when available.
  * Original titles are preferred for naming.
* **Bug Fixes**
  * Improved duplicate searches using complete, cleaned titles.
  * Added reliable session-based browsing and detail lookups.
  * Prevented uploads when required site credentials are unavailable.
  * Reused authenticated sessions to reduce repeated logins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->