### PR TITLE
fix(V3X): VOSTFR uploads see superior French releases from any group

### DIFF
--- a/src/trackers/V3X.py
+++ b/src/trackers/V3X.py
@@ -32,6 +32,7 @@ from src.console import console
 from src.get_desc import DescriptionBuilder
 from src.tmdb import TmdbManager
 from src.trackers.COMMON import COMMON
+from src.trackers.FRENCH import _FRENCH_AUDIO_THRESHOLD as FRENCH_AUDIO_THRESHOLD
 from src.trackers.FRENCH import FrenchTrackerMixin
 
 Meta = dict[str, Any]
@@ -180,6 +181,13 @@ class V3X(FrenchTrackerMixin):
         seen_names: set[str] = set()
         debug = bool(meta.get("debug"))
 
+        # A VOSTFR/VO upload must be blocked by an equivalent French-audio
+        # release from ANY group, so the group filter below must not drop
+        # those candidates before _check_french_lang_dupes can flag them.
+        upload_audio = await self._build_audio_string(meta)
+        upload_level = max((self._extract_french_lang_tag(part)[1] for part in upload_audio.split(".")), default=0)
+        upload_lacks_french_audio = upload_level < FRENCH_AUDIO_THRESHOLD
+
         for search_term in queries:
             items: list[Any] = []
             page = 1
@@ -244,9 +252,13 @@ class V3X(FrenchTrackerMixin):
                         console.print(f"[dim]{self.tracker} dupe skip (resolution mismatch): {name}[/dim]")
                     continue
                 if group_norm and group_norm not in name_norm:
-                    if debug:
-                        console.print(f"[dim]{self.tracker} dupe skip (group mismatch): {name}[/dim]")
-                    continue
+                    _, existing_level = self._extract_french_lang_tag(name)
+                    if not (upload_lacks_french_audio and existing_level >= FRENCH_AUDIO_THRESHOLD):
+                        if debug:
+                            console.print(f"[dim]{self.tracker} dupe skip (group mismatch): {name}[/dim]")
+                        continue
+                    # Keep: superior French audio from another group — a
+                    # potential language supersede for this VOSTFR/VO upload.
                 seen_names.add(name_norm)
                 dupes.append(
                     {

--- a/tests/test_v3x.py
+++ b/tests/test_v3x.py
@@ -1015,6 +1015,16 @@ class TestFrenchLanguageSupersede:
         assert len(dupes) == 1
         assert "french_lang_supersede" in dupes[0].get("flags", [])
 
+    def test_vo_upload_blocked_by_multi_from_another_group(self, monkeypatch: Any):
+        # Empty audio string = plain VO (no French audio, no French subs)
+        dupes = self._search(
+            monkeypatch,
+            "",
+            ["Some.Movie.2024.MULTi.VFF.1080p.WEB-OTHERGRP"],
+        )
+        assert len(dupes) == 1
+        assert "french_lang_supersede" in dupes[0].get("flags", [])
+
     def test_vostfr_upload_not_blocked_by_other_group_vostfr(self, monkeypatch: Any):
         dupes = self._search(
             monkeypatch,

--- a/tests/test_v3x.py
+++ b/tests/test_v3x.py
@@ -959,3 +959,65 @@ def test_session_cookie_reaches_search_and_enrichment(monkeypatch: Any):
     # Both the paginated search client and the enrichment client carry the jar
     assert len(constructed) >= 2
     assert all(c is not None and c.get("v3x_sid") == "abc" for c in constructed)
+
+
+class TestFrenchLanguageSupersede:
+    """VOSTFR uploads must be blocked by an equivalent French-audio release
+    from ANY group; French-audio uploads drop inferior VOSTFR dupes."""
+
+    def _search(self, monkeypatch: Any, upload_audio: str, listing_names: list[str]) -> list[dict[str, Any]]:
+        monkeypatch.setattr(v3x_module.httpx, "AsyncClient", _FakeClient)
+        _FakeClient.response = _FakeResponse(
+            200,
+            {"torrents": [{"id": f"u{i}", "slug": f"s{i}", "name": n, "size": i + 1} for i, n in enumerate(listing_names)], "total": len(listing_names)},
+        )
+        tracker = V3X(_config())
+
+        async def fake_checks(meta: Any) -> bool:
+            return True
+
+        async def fake_fr(meta: Any) -> str:
+            return ""
+
+        async def fake_enrich(dupes: Any, *, debug: bool = False) -> None:
+            return None
+
+        async def fake_login() -> Any:
+            return v3x_module.httpx.Cookies()
+
+        async def fake_audio(meta: Any) -> str:
+            return upload_audio
+
+        monkeypatch.setattr(tracker, "get_additional_checks", fake_checks)
+        monkeypatch.setattr(tracker, "_get_french_title", fake_fr)
+        monkeypatch.setattr(tracker, "_enrich_with_files", fake_enrich)
+        monkeypatch.setattr(tracker, "_login_session_cookies", fake_login)
+        monkeypatch.setattr(tracker, "_build_audio_string", fake_audio)
+        meta = {"title": "Some Movie", "year": 2024, "resolution": "1080p", "tag": "-MYGRP"}
+        return asyncio.run(tracker.search_existing(meta))
+
+    def test_vostfr_upload_blocked_by_multi_from_another_group(self, monkeypatch: Any):
+        dupes = self._search(
+            monkeypatch,
+            "VOSTFR",
+            ["Some.Movie.2024.MULTi.VFF.1080p.WEB-OTHERGRP"],
+        )
+        assert len(dupes) == 1
+        assert "french_lang_supersede" in dupes[0].get("flags", [])
+
+    def test_vostfr_upload_not_blocked_by_other_group_vostfr(self, monkeypatch: Any):
+        dupes = self._search(
+            monkeypatch,
+            "VOSTFR",
+            ["Some.Movie.2024.VOSTFR.1080p.WEB-OTHERGRP"],
+        )
+        # Same-language release from another group: normal group filter applies
+        assert dupes == []
+
+    def test_multi_upload_drops_inferior_vostfr(self, monkeypatch: Any):
+        dupes = self._search(
+            monkeypatch,
+            "MULTI.VFF",
+            ["Some.Movie.2024.VOSTFR.1080p.WEB-MYGRP"],
+        )
+        assert dupes == []


### PR DESCRIPTION
The client-side group filter dropped differently-grouped candidates before the language check, so a VOSTFR upload could slip past an existing MULTI/VF release. When the upload lacks French audio, group- mismatched candidates carrying superior French audio are kept so _check_french_lang_dupes can flag them as blocking dupes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate detection for French-language releases.
  * VOSTFR uploads can now be flagged when an equivalent release with sufficient French audio exists from another release group.
  * MULTI and VFF releases now correctly supersede lower-quality VOSTFR duplicates.
  * Same-language releases from other groups continue to be filtered normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->