### PR TITLE
refactor: centralize the image-host domain mapping

### DIFF
--- a/src/rehostimages.py
+++ b/src/rehostimages.py
@@ -16,6 +16,28 @@ from src.takescreens import TakeScreensManager
 from src.type_utils import to_int
 from src.uploadscreens import UploadScreensManager
 
+# Canonical domain → image-host slug mapping, shared by every tracker.
+# The per-tracker policy lives in each tracker's approved_image_hosts list;
+# this table only serves to recognize where an existing image is hosted.
+URL_HOST_MAPPING: dict[str, str] = {
+    "beyondhd.co": "bhd",
+    "digitalcore.club": "sharex",
+    "ibb.co": "imgbb",
+    "imagebam.com": "imagebam",
+    "img.digitalcore.club": "sharex",
+    "img.passtheima.ge": "passtheimage",
+    "img.pterclub.com": "pterclub",
+    "imgbox.com": "imgbox",
+    "imgur.com": "imgur",
+    "kshare.club": "kshare",
+    "onlyimage.org": "onlyimage",
+    "pixhost.to": "pixhost",
+    "postimg.cc": "postimg",
+    "ptpimg.me": "ptpimg",
+    "ptscreens.com": "ptscreens",
+    "yes.ilikeshots.club": "ilikeshots",
+}
+
 
 def _as_str(value: Any) -> Union[str, None]:
     return value if isinstance(value, str) else None
@@ -54,7 +76,7 @@ class RehostImagesManager:
         self,
         meta: dict[str, Any],
         tracker: str,
-        url_host_mapping: dict[str, str],
+        url_host_mapping: Optional[dict[str, str]] = None,
         img_host_index: int = 1,
         approved_image_hosts: Optional[list[str]] = None,
     ) -> tuple[list[dict[str, str]], bool, bool]:
@@ -73,7 +95,7 @@ class RehostImagesManager:
         self,
         meta: dict[str, Any],
         tracker: str,
-        url_host_mapping: dict[str, str],
+        url_host_mapping: Optional[dict[str, str]] = None,
         approved_image_hosts: Optional[list[str]] = None,
         img_host_index: int = 1,
         file: Optional[str] = None,
@@ -94,7 +116,7 @@ class RehostImagesManager:
 async def _check_hosts(
     meta: dict[str, Any],
     tracker: str,
-    url_host_mapping: dict[str, str],
+    url_host_mapping: Optional[dict[str, str]] = None,
     img_host_index: int = 1,
     approved_image_hosts: Optional[list[str]] = None,
     default_config: Optional[Mapping[str, Any]] = None,
@@ -107,6 +129,8 @@ async def _check_hosts(
         raise ValueError("takescreens_manager is required")
     if uploadscreens_manager is None:
         raise ValueError("uploadscreens_manager is required")
+    if url_host_mapping is None:
+        url_host_mapping = URL_HOST_MAPPING
     if approved_image_hosts is None:
         approved_image_hosts = []
     new_images_key = f"{tracker}_images_key"
@@ -273,7 +297,7 @@ async def _check_hosts(
 async def _handle_image_upload(
     meta: dict[str, Any],
     tracker: str,
-    url_host_mapping: dict[str, str],
+    url_host_mapping: Optional[dict[str, str]] = None,
     approved_image_hosts: Optional[list[str]] = None,
     img_host_index: int = 1,
     file: Optional[str] = None,
@@ -287,6 +311,8 @@ async def _handle_image_upload(
         raise ValueError("takescreens_manager is required")
     if uploadscreens_manager is None:
         raise ValueError("uploadscreens_manager is required")
+    if url_host_mapping is None:
+        url_host_mapping = URL_HOST_MAPPING
     if approved_image_hosts is None:
         approved_image_hosts = []
     original_imghost = meta.get("imghost")

--- a/src/trackers/A4K.py
+++ b/src/trackers/A4K.py
@@ -116,19 +116,9 @@ class A4K(UNIT3D):
         return data
 
     async def check_image_hosts(self, meta: dict[str, Any]) -> None:
-        url_host_mapping = {
-            "ibb.co": "imgbb",
-            "imgbox.com": "imgbox",
-            "imgur.com": "imgur",
-            "postimg.cc": "postimg",
-            "ptscreens.com": "ptscreens",
-            "onlyimage.org": "onlyimage",
-            "ptpimg.me": "ptpimg",
-        }
         await self.rehost_images_manager.check_hosts(
             meta,
             self.tracker,
-            url_host_mapping=url_host_mapping,
             img_host_index=1,
             approved_image_hosts=self.approved_image_hosts,
         )

--- a/src/trackers/ACM.py
+++ b/src/trackers/ACM.py
@@ -302,18 +302,9 @@ class ACM:
         return f" [{dub} dub only, {inner}]" if inner else f" [{dub} dub only]"
 
     async def check_image_hosts(self, meta: dict[str, Any]) -> None:
-        url_host_mapping = {
-            "ibb.co": "imgbb",
-            "imgbox.com": "imgbox",
-            "postimg.cc": "postimg",
-            "pixhost.to": "pixhost",
-            "ptpimg.me": "ptpimg",
-            "imagebam.com": "imagebam",
-        }
         await self.rehost_images_manager.check_hosts(
             meta,
             self.tracker,
-            url_host_mapping=url_host_mapping,
             img_host_index=1,
             approved_image_hosts=self.approved_image_hosts,
         )

--- a/src/trackers/BHD.py
+++ b/src/trackers/BHD.py
@@ -66,23 +66,14 @@ class BHD:
             "OFT",
             "TGS",
         ]
-        self.approved_image_hosts = ["ptpimg", "imgbox", "imgbb", "pixhost", "bhd", "bam"]
+        self.approved_image_hosts = ["ptpimg", "imgbox", "imgbb", "pixhost", "bhd", "imagebam"]
         pass
 
     async def check_image_hosts(self, meta: dict[str, Any]) -> None:
-        url_host_mapping = {
-            "ibb.co": "imgbb",
-            "ptpimg.me": "ptpimg",
-            "pixhost.to": "pixhost",
-            "imgbox.com": "imgbox",
-            "beyondhd.co": "bhd",
-            "imagebam.com": "bam",
-        }
 
         await self.rehost_images_manager.check_hosts(
             meta,
             self.tracker,
-            url_host_mapping=url_host_mapping,
             img_host_index=1,
             approved_image_hosts=self.approved_image_hosts,
         )

--- a/src/trackers/DC.py
+++ b/src/trackers/DC.py
@@ -243,19 +243,9 @@ class DC:
         return dc_name
 
     async def check_image_hosts(self, meta: Meta) -> None:
-        url_host_mapping = {
-            "ibb.co": "imgbb",
-            "imgbox.com": "imgbox",
-            "beyondhd.co": "bhd",
-            "imgur.com": "imgur",
-            "postimg.cc": "postimg",
-            "digitalcore.club": "sharex",
-            "img.digitalcore.club": "sharex",
-        }
         await self.rehost_images_manager.check_hosts(
             meta,
             self.tracker,
-            url_host_mapping=url_host_mapping,
             img_host_index=1,
             approved_image_hosts=self.approved_image_hosts,
         )

--- a/src/trackers/GPW.py
+++ b/src/trackers/GPW.py
@@ -96,14 +96,6 @@ class GPW:
             "YIFY",
         ]
         self.approved_image_hosts = ["kshare", "pixhost", "ptpimg", "pterclub", "ilikeshots", "imgbox"]
-        self.url_host_mapping = {
-            "kshare.club": "kshare",
-            "pixhost.to": "pixhost",
-            "imgbox.com": "imgbox",
-            "ptpimg.me": "ptpimg",
-            "img.pterclub.com": "pterclub",
-            "yes.ilikeshots.club": "ilikeshots",
-        }
 
     async def load_cookies(self, meta: dict[str, Any]) -> Any:
         cookie_file = os.path.abspath(f"{meta['base_dir']}/data/cookies/{self.tracker}.txt")
@@ -248,7 +240,6 @@ class GPW:
         await self.rehost_images_manager.check_hosts(
             meta,
             self.tracker,
-            url_host_mapping=self.url_host_mapping,
             img_host_index=1,
             approved_image_hosts=self.approved_image_hosts,
         )

--- a/src/trackers/HUNO.py
+++ b/src/trackers/HUNO.py
@@ -70,7 +70,7 @@ class HUNO(UNIT3D):
             "YIFY",
             "YTS",
         ]
-        self.approved_image_hosts = ["ptpimg", "imgbox", "imgbb", "pixhost", "bam"]
+        self.approved_image_hosts = ["ptpimg", "imgbox", "imgbb", "pixhost", "imagebam"]
         pass
 
     async def get_additional_checks(self, meta: dict[str, Any]) -> bool:
@@ -129,17 +129,9 @@ class HUNO(UNIT3D):
         return {"stream": str(await self.is_plex_friendly(meta))}
 
     async def check_image_hosts(self, meta: dict[str, Any]) -> None:
-        url_host_mapping = {
-            "ibb.co": "imgbb",
-            "ptpimg.me": "ptpimg",
-            "pixhost.to": "pixhost",
-            "imgbox.com": "imgbox",
-            "imagebam.com": "bam",
-        }
         await self.rehost_images_manager.check_hosts(
             meta,
             self.tracker,
-            url_host_mapping=url_host_mapping,
             img_host_index=1,
             approved_image_hosts=self.approved_image_hosts,
         )

--- a/src/trackers/MTV.py
+++ b/src/trackers/MTV.py
@@ -104,16 +104,10 @@ class MTV:
         return await loop.run_in_executor(None, json.dumps, obj)
 
     async def check_image_hosts(self, meta: Meta) -> None:
-        url_host_mapping = {
-            "ibb.co": "imgbb",
-            "ptpimg.me": "ptpimg",
-            "imgbox.com": "imgbox",
-        }
 
         await self.rehost_images_manager.check_hosts(
             meta,
             self.tracker,
-            url_host_mapping=url_host_mapping,
             img_host_index=1,
             approved_image_hosts=self.approved_image_hosts,
         )

--- a/src/trackers/NST.py
+++ b/src/trackers/NST.py
@@ -205,16 +205,9 @@ class NST(FrenchTrackerMixin, UNIT3D):
     # ── Image host gating ─────────────────────────────────────────────
 
     async def check_image_hosts(self, meta: dict[str, Any]) -> None:
-        url_host_mapping = {
-            "imgbox.com": "imgbox",
-            "ptscreens.com": "ptscreens",
-            "onlyimage.org": "onlyimage",
-            "pixhost.to": "pixhost",
-        }
         await self.rehost_images_manager.check_hosts(
             meta,
             self.tracker,
-            url_host_mapping=url_host_mapping,
             img_host_index=1,
             approved_image_hosts=self.approved_image_hosts,
         )

--- a/src/trackers/OE.py
+++ b/src/trackers/OE.py
@@ -181,20 +181,10 @@ class OE(UNIT3D):
         )
 
     async def check_image_hosts(self, meta: Meta) -> None:
-        url_host_mapping = {
-            "ibb.co": "imgbb",
-            "ptpimg.me": "ptpimg",
-            "imgbox.com": "imgbox",
-            "onlyimage.org": "onlyimage",
-            "imagebam.com": "bam",
-            "ptscreens.com": "ptscreens",
-            "img.passtheima.ge": "passtheimage",
-        }
 
         await self.rehost_images_manager.check_hosts(
             meta,
             self.tracker,
-            url_host_mapping=url_host_mapping,
             img_host_index=1,
             approved_image_hosts=self.approved_image_hosts,
         )

--- a/src/trackers/PTP.py
+++ b/src/trackers/PTP.py
@@ -825,15 +825,10 @@ class PTP:
         return desc
 
     async def check_image_hosts(self, meta: dict[str, Any]) -> None:
-        url_host_mapping = {
-            "ptpimg.me": "ptpimg",
-            "pixhost.to": "pixhost",
-        }
 
         await self.rehost_images_manager.check_hosts(
             meta,
             self.tracker,
-            url_host_mapping=url_host_mapping,
             img_host_index=1,
             approved_image_hosts=self.approved_image_hosts,
         )

--- a/src/trackers/STC.py
+++ b/src/trackers/STC.py
@@ -78,14 +78,9 @@ class STC(UNIT3D):
         return should_continue
 
     async def check_image_hosts(self, meta: Meta) -> None:
-        url_host_mapping = {
-            "ibb.co": "imgbb",
-            "imgbox.com": "imgbox",
-        }
         await self.rehost_images_manager.check_hosts(
             meta,
             self.tracker,
-            url_host_mapping=url_host_mapping,
             img_host_index=1,
             approved_image_hosts=self.approved_image_hosts,
         )

--- a/src/trackers/TVC.py
+++ b/src/trackers/TVC.py
@@ -40,7 +40,7 @@ class TVC:
         self.torrent_url = "https://tvchaosuk.com/torrents/"
         self.signature = ""
         self.banned_groups = []
-        self.approved_image_hosts = ["imgbb", "ptpimg", "imgbox", "pixhost", "bam", "onlyimage"]
+        self.approved_image_hosts = ["imgbb", "ptpimg", "imgbox", "pixhost", "imagebam", "onlyimage"]
         tmdb.API_KEY = config["DEFAULT"]["tmdb_api"]
 
         # TV type mapping as a dict for clarity and maintainability
@@ -426,16 +426,8 @@ class TVC:
         return await asyncio.to_thread(_read)
 
     async def check_image_hosts(self, meta: Meta) -> None:
-        url_host_mapping = {
-            "ibb.co": "imgbb",
-            "ptpimg.me": "ptpimg",
-            "imgbox.com": "imgbox",
-            "pixhost.to": "pixhost",
-            "imagebam.com": "bam",
-            "onlyimage.org": "onlyimage",
-        }
 
-        await self.rehost_images_manager.check_hosts(meta, self.tracker, url_host_mapping=url_host_mapping, img_host_index=1, approved_image_hosts=self.approved_image_hosts)
+        await self.rehost_images_manager.check_hosts(meta, self.tracker, img_host_index=1, approved_image_hosts=self.approved_image_hosts)
         return
 
     async def upload(self, meta: Meta, _disctype: str) -> Optional[bool]:

--- a/src/trackers/V3X.py
+++ b/src/trackers/V3X.py
@@ -69,17 +69,9 @@ class V3X(FrenchTrackerMixin):
     async def check_image_hosts(self, meta: Meta) -> None:
         """Rehost screenshots to an approved host when needed; the result
         lands in meta["V3X_images_key"] and the description prefers it."""
-        url_host_mapping = {
-            "ibb.co": "imgbb",
-            "imgbox.com": "imgbox",
-            "postimg.cc": "postimg",
-            "pixhost.to": "pixhost",
-            "ptscreens.com": "ptscreens",
-        }
         await self.rehost_images_manager.check_hosts(
             meta,
             self.tracker,
-            url_host_mapping=url_host_mapping,
             img_host_index=1,
             approved_image_hosts=self.approved_image_hosts,
         )

--- a/tests/test_rehost_mapping.py
+++ b/tests/test_rehost_mapping.py
@@ -1,0 +1,38 @@
+"""The domain → image-host mapping is defined once in src/rehostimages.py;
+every host a tracker approves must be recognizable through it."""
+
+import glob
+import re
+
+from src.rehostimages import URL_HOST_MAPPING
+
+
+def _approved_lists() -> dict[str, list[str]]:
+    lists: dict[str, list[str]] = {}
+    for path in glob.glob("src/trackers/*.py"):
+        source = open(path, encoding="utf-8").read()
+        match = re.search(r"approved_image_hosts(?::[^=]+)? = \[([^\]]*)\]", source)
+        if match:
+            hosts = re.findall(r'"([^"]+)"', match.group(1))
+            if hosts:
+                lists[path] = hosts
+    return lists
+
+
+def test_trackers_no_longer_define_local_mappings():
+    for path in glob.glob("src/trackers/*.py"):
+        assert "url_host_mapping" not in open(path, encoding="utf-8").read(), path
+
+
+def test_every_approved_host_has_a_domain_in_the_central_mapping():
+    known_hosts = set(URL_HOST_MAPPING.values())
+    lists = _approved_lists()
+    assert lists, "no approved_image_hosts lists found"
+    for path, hosts in lists.items():
+        missing = [h for h in hosts if h not in known_hosts]
+        assert not missing, f"{path}: approved hosts without a domain mapping: {missing}"
+
+
+def test_mapping_uses_the_imagebam_slug():
+    assert URL_HOST_MAPPING["imagebam.com"] == "imagebam"
+    assert "bam" not in URL_HOST_MAPPING.values()

--- a/tests/test_v3x.py
+++ b/tests/test_v3x.py
@@ -1048,21 +1048,14 @@ class TestApprovedImageHosts:
         tracker = V3X(_config())
         seen: dict[str, Any] = {}
 
-        async def fake_check_hosts(meta: Any, tracker_name: Any, url_host_mapping: Any, img_host_index: int, approved_image_hosts: Any) -> Any:
-            seen.update(tracker=tracker_name, mapping=url_host_mapping, hosts=approved_image_hosts)
+        async def fake_check_hosts(meta: Any, tracker_name: Any, img_host_index: int, approved_image_hosts: Any) -> Any:
+            seen.update(tracker=tracker_name, hosts=approved_image_hosts)
             return [], False, False
 
         monkeypatch.setattr(tracker.rehost_images_manager, "check_hosts", fake_check_hosts)
         asyncio.run(tracker.check_image_hosts({}))
         assert seen["tracker"] == "V3X"
         assert seen["hosts"] == ["imgbox", "imgbb", "postimg", "pixhost", "ptscreens"]
-        assert seen["mapping"] == {
-            "ibb.co": "imgbb",
-            "imgbox.com": "imgbox",
-            "postimg.cc": "postimg",
-            "pixhost.to": "pixhost",
-            "ptscreens.com": "ptscreens",
-        }
 
     def test_description_prefers_rehosted_images(self, monkeypatch: Any, tmp_path: Any):
         tracker = V3X(_config())


### PR DESCRIPTION
Thirteen trackers each redeclared subsets of the same domain → host table, with one drifted slug (imagebam.com as 'bam' in four of them vs 'imagebam' in ACM). The canonical URL_HOST_MAPPING now lives in src/rehostimages.py and check_hosts/handle_image_upload default to it; trackers only declare their approved_image_hosts policy. The imagebam slug is standardized and consistency tests guard the invariants.