### PR TITLE
fix: reused images host check

### DIFF
--- a/src/rehostimages.py
+++ b/src/rehostimages.py
@@ -16,6 +16,34 @@ from src.takescreens import TakeScreensManager
 from src.type_utils import to_int
 from src.uploadscreens import UploadScreensManager
 
+# Trackers whose sites only accept screenshots from specific image hosts.
+TRACKERS_WITH_IMAGE_HOST_REQUIREMENTS = frozenset({"A4K", "ACM", "BHD", "DC", "GPW", "HUNO", "MTV", "NST", "OE", "PTP", "STC", "TVC", "V3X"})
+
+
+async def validate_reused_image_hosts(meta: dict[str, Any], config: dict[str, Any], tracker_class_map: Mapping[str, Any]) -> list[str]:
+    """Validate an already-populated image list against approved hosts.
+
+    Runs each relevant tracker's ``check_image_hosts`` so images reused from
+    another tracker's description get rehosted when needed. No-op when the
+    user asked to skip image hosting or when no image list exists. Returns
+    the trackers that were validated.
+    """
+    if meta.get("skip_imghost_upload", False) or not meta.get("image_list"):
+        return []
+    relevant = [t for t in meta.get("trackers", []) if isinstance(t, str) and t in TRACKERS_WITH_IMAGE_HOST_REQUIREMENTS and t in tracker_class_map]
+    if relevant:
+        console.print(f"[yellow]Validating existing images against approved hosts for: {', '.join(relevant)}[/yellow]")
+    for tracker_name in relevant:
+        tracker_instance = tracker_class_map[tracker_name](config=config)
+        await tracker_instance.check_image_hosts(meta)
+        images_key = f"{tracker_name}_images_key"
+        if meta.get(images_key):
+            console.print(f"[green]{tracker_name}: {len(meta[images_key])} image(s) ready on approved hosts.[/green]")
+        else:
+            console.print(f"[yellow]{tracker_name}: existing images could not be validated/rehosted; the description will fall back to the original links.[/yellow]")
+    return relevant
+
+
 # Canonical domain → image-host slug mapping, shared by every tracker.
 # The per-tracker policy lives in each tracker's approved_image_hosts list;
 # this table only serves to recognize where an existing image is hosted.

--- a/tests/test_image_host_arbitration_set.py
+++ b/tests/test_image_host_arbitration_set.py
@@ -1,11 +1,13 @@
-# The common-image-host arbitration in upload.py relies on a hard-coded set of
-# tracker names. Keep it in sync with the trackers that actually define
-# approved_image_hosts, so a new restricted tracker is not silently skipped.
+# The common-image-host arbitration relies on the central
+# TRACKERS_WITH_IMAGE_HOST_REQUIREMENTS set. Keep it in sync with the trackers
+# that actually define approved_image_hosts, so a new restricted tracker is
+# not silently skipped.
 
 import ast
 import glob
 import os
-import re
+
+from src.rehostimages import TRACKERS_WITH_IMAGE_HOST_REQUIREMENTS
 
 BASE = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -27,11 +29,7 @@ def _trackers_with_approved_hosts() -> set[str]:
 
 
 def _hardcoded_arbitration_set() -> set[str]:
-    with open(os.path.join(BASE, "upload.py"), encoding="utf-8") as f:
-        source = f.read()
-    match = re.search(r"trackers_with_image_host_requirements\s*=\s*\{([^}]*)\}", source)
-    assert match, "trackers_with_image_host_requirements not found in upload.py"
-    return set(re.findall(r'"([^"]+)"', match.group(1)))
+    return set(TRACKERS_WITH_IMAGE_HOST_REQUIREMENTS)
 
 
 def test_arbitration_set_matches_trackers_defining_approved_hosts() -> None:

--- a/tests/test_rehost_mapping.py
+++ b/tests/test_rehost_mapping.py
@@ -1,10 +1,11 @@
 """The domain → image-host mapping is defined once in src/rehostimages.py;
 every host a tracker approves must be recognizable through it."""
 
+import asyncio
 import glob
 import re
 
-from src.rehostimages import URL_HOST_MAPPING
+from src.rehostimages import URL_HOST_MAPPING, validate_reused_image_hosts
 
 
 def _approved_lists() -> dict[str, list[str]]:
@@ -38,9 +39,50 @@ def test_mapping_uses_the_imagebam_slug():
     assert "bam" not in URL_HOST_MAPPING.values()
 
 
-def test_reused_images_also_go_through_check_image_hosts():
-    """upload.py must validate approved hosts both when uploading new
-    screenshots and when the image list was reused from another tracker's
-    description (cutoff already satisfied)."""
+class TestValidateReusedImageHosts:
+    """Behavioral coverage of validate_reused_image_hosts with tracker doubles."""
+
+    class _FakeTracker:
+        instances: list["TestValidateReusedImageHosts._FakeTracker"] = []
+
+        def __init__(self, config: object) -> None:
+            self.calls: list[dict] = []
+            type(self).instances.append(self)
+
+        async def check_image_hosts(self, meta: dict) -> None:
+            self.calls.append(meta)
+            meta["V3X_images_key"] = [{"img_url": "https://approved.example/a.png"}]
+
+    def _map(self):
+        self._FakeTracker.instances = []
+        return {"V3X": self._FakeTracker, "LST": self._FakeTracker}
+
+    def test_relevant_tracker_is_validated(self):
+        meta = {"trackers": ["V3X", "LST"], "image_list": [{"img_url": "x"}]}
+        validated = asyncio.run(validate_reused_image_hosts(meta, {}, self._map()))
+        # LST has no host requirements — only V3X is validated
+        assert validated == ["V3X"]
+        assert len(self._FakeTracker.instances) == 1
+        assert self._FakeTracker.instances[0].calls == [meta]
+        assert meta["V3X_images_key"]
+
+    def test_skip_imghost_upload_bypasses_validation(self):
+        meta = {"trackers": ["V3X"], "image_list": [{"img_url": "x"}], "skip_imghost_upload": True}
+        assert asyncio.run(validate_reused_image_hosts(meta, {}, self._map())) == []
+        assert self._FakeTracker.instances == []
+
+    def test_no_relevant_trackers_is_a_noop(self):
+        meta = {"trackers": ["LST"], "image_list": [{"img_url": "x"}]}
+        assert asyncio.run(validate_reused_image_hosts(meta, {}, self._map())) == []
+        assert self._FakeTracker.instances == []
+
+    def test_empty_image_list_is_a_noop(self):
+        meta = {"trackers": ["V3X"], "image_list": []}
+        assert asyncio.run(validate_reused_image_hosts(meta, {}, self._map())) == []
+        assert self._FakeTracker.instances == []
+
+
+def test_upload_wires_the_reused_images_validation():
+    # Wiring guard only — the behavior itself is covered above.
     source = open("upload.py", encoding="utf-8").read()
-    assert source.count("check_image_hosts(meta)") >= 2
+    assert "await validate_reused_image_hosts(meta, config, tracker_class_map)" in source

--- a/tests/test_rehost_mapping.py
+++ b/tests/test_rehost_mapping.py
@@ -36,3 +36,11 @@ def test_every_approved_host_has_a_domain_in_the_central_mapping():
 def test_mapping_uses_the_imagebam_slug():
     assert URL_HOST_MAPPING["imagebam.com"] == "imagebam"
     assert "bam" not in URL_HOST_MAPPING.values()
+
+
+def test_reused_images_also_go_through_check_image_hosts():
+    """upload.py must validate approved hosts both when uploading new
+    screenshots and when the image list was reused from another tracker's
+    description (cutoff already satisfied)."""
+    source = open("upload.py", encoding="utf-8").read()
+    assert source.count("check_image_hosts(meta)") >= 2

--- a/tests/test_v3x.py
+++ b/tests/test_v3x.py
@@ -1083,8 +1083,6 @@ class TestApprovedImageHosts:
         assert "original.example" not in desc
 
     def test_v3x_registered_for_image_host_requirements(self):
-        source = open("upload.py", encoding="utf-8").read()
-        import re as _re
+        from src.rehostimages import TRACKERS_WITH_IMAGE_HOST_REQUIREMENTS
 
-        match = _re.search(r"trackers_with_image_host_requirements = \{([^}]*)\}", source)
-        assert match and '"V3X"' in match.group(1)
+        assert "V3X" in TRACKERS_WITH_IMAGE_HOST_REQUIREMENTS

--- a/upload.py
+++ b/upload.py
@@ -1305,11 +1305,18 @@ async def process_meta(meta: Meta, base_dir: str, bot: Any = None) -> Optional[b
                     reused_relevant_trackers = [
                         t for t in cast(list[Any], meta.get("trackers", [])) if isinstance(t, str) and t in trackers_with_image_host_requirements and t in tracker_class_map
                     ]
+                    if reused_relevant_trackers:
+                        console.print(f"[yellow]Validating existing images against approved hosts for: {', '.join(reused_relevant_trackers)}[/yellow]")
                     for tracker_name in reused_relevant_trackers:
                         tracker_instance = tracker_class_map[tracker_name](config=config)
-                        if meta.get("debug"):
-                            console.print(f"[cyan]Image host debug: validating reused images for {tracker_name}[/cyan]")
                         await tracker_instance.check_image_hosts(meta)
+                        images_key = f"{tracker_name}_images_key"
+                        if meta.get(images_key):
+                            console.print(f"[green]{tracker_name}: {len(meta[images_key])} image(s) ready on approved hosts.[/green]")
+                        else:
+                            console.print(
+                                f"[yellow]{tracker_name}: existing images could not be validated/rehosted; the description will fall back to the original links.[/yellow]"
+                            )
 
                 elif meta.get("skip_imghost_upload", False) is True and meta.get("image_list", False) is False:
                     meta["image_list"] = []

--- a/upload.py
+++ b/upload.py
@@ -1127,10 +1127,9 @@ async def process_meta(meta: Meta, base_dir: str, bot: Any = None) -> Optional[b
                 if manual_frames_count > 0:
                     meta["screens"] = manual_frames_count
                 cutoff = int(meta.get("cutoff") or 1)
+                trackers_with_image_host_requirements = {"A4K", "ACM", "BHD", "DC", "GPW", "HUNO", "MTV", "NST", "OE", "PTP", "STC", "TVC", "V3X"}
                 if len(meta.get("image_list", [])) < cutoff and meta.get("skip_imghost_upload", False) is False:
                     # Validate and (if needed) rehost images to tracker-approved hosts before uploading any new screenshots.
-                    trackers_with_image_host_requirements = {"A4K", "ACM", "BHD", "DC", "GPW", "HUNO", "MTV", "NST", "OE", "PTP", "STC", "TVC", "V3X"}
-
                     relevant_trackers = [
                         t for t in cast(list[Any], meta.get("trackers", [])) if isinstance(t, str) and t in trackers_with_image_host_requirements and t in tracker_class_map
                     ]
@@ -1297,6 +1296,20 @@ async def process_meta(meta: Meta, base_dir: str, bot: Any = None) -> Optional[b
                         if meta["debug"]:
                             console.print("[yellow]Cleaning up resources...[/yellow]")
                         gc.collect()
+
+                elif meta.get("skip_imghost_upload", False) is False and meta.get("image_list"):
+                    # Enough images already (e.g. reused from another tracker's
+                    # description) — the screenshot-upload block above was skipped,
+                    # but trackers with approved-host requirements still need the
+                    # existing images validated and rehosted when necessary.
+                    reused_relevant_trackers = [
+                        t for t in cast(list[Any], meta.get("trackers", [])) if isinstance(t, str) and t in trackers_with_image_host_requirements and t in tracker_class_map
+                    ]
+                    for tracker_name in reused_relevant_trackers:
+                        tracker_instance = tracker_class_map[tracker_name](config=config)
+                        if meta.get("debug"):
+                            console.print(f"[cyan]Image host debug: validating reused images for {tracker_name}[/cyan]")
+                        await tracker_instance.check_image_hosts(meta)
 
                 elif meta.get("skip_imghost_upload", False) is True and meta.get("image_list", False) is False:
                     meta["image_list"] = []

--- a/upload.py
+++ b/upload.py
@@ -46,6 +46,7 @@ from src.nfo_link import NfoLinkManager
 from src.proxy_env import apply_proxy_env
 from src.qbitwait import Wait
 from src.queuemanage import QueueManager
+from src.rehostimages import TRACKERS_WITH_IMAGE_HOST_REQUIREMENTS, validate_reused_image_hosts
 from src.takescreens import TakeScreensManager
 from src.torrentcreate import TorrentCreator
 from src.trackerhandle import process_trackers
@@ -1127,7 +1128,7 @@ async def process_meta(meta: Meta, base_dir: str, bot: Any = None) -> Optional[b
                 if manual_frames_count > 0:
                     meta["screens"] = manual_frames_count
                 cutoff = int(meta.get("cutoff") or 1)
-                trackers_with_image_host_requirements = {"A4K", "ACM", "BHD", "DC", "GPW", "HUNO", "MTV", "NST", "OE", "PTP", "STC", "TVC", "V3X"}
+                trackers_with_image_host_requirements = TRACKERS_WITH_IMAGE_HOST_REQUIREMENTS
                 if len(meta.get("image_list", [])) < cutoff and meta.get("skip_imghost_upload", False) is False:
                     # Validate and (if needed) rehost images to tracker-approved hosts before uploading any new screenshots.
                     relevant_trackers = [
@@ -1302,21 +1303,7 @@ async def process_meta(meta: Meta, base_dir: str, bot: Any = None) -> Optional[b
                     # description) — the screenshot-upload block above was skipped,
                     # but trackers with approved-host requirements still need the
                     # existing images validated and rehosted when necessary.
-                    reused_relevant_trackers = [
-                        t for t in cast(list[Any], meta.get("trackers", [])) if isinstance(t, str) and t in trackers_with_image_host_requirements and t in tracker_class_map
-                    ]
-                    if reused_relevant_trackers:
-                        console.print(f"[yellow]Validating existing images against approved hosts for: {', '.join(reused_relevant_trackers)}[/yellow]")
-                    for tracker_name in reused_relevant_trackers:
-                        tracker_instance = tracker_class_map[tracker_name](config=config)
-                        await tracker_instance.check_image_hosts(meta)
-                        images_key = f"{tracker_name}_images_key"
-                        if meta.get(images_key):
-                            console.print(f"[green]{tracker_name}: {len(meta[images_key])} image(s) ready on approved hosts.[/green]")
-                        else:
-                            console.print(
-                                f"[yellow]{tracker_name}: existing images could not be validated/rehosted; the description will fall back to the original links.[/yellow]"
-                            )
+                    await validate_reused_image_hosts(meta, config, tracker_class_map)
 
                 elif meta.get("skip_imghost_upload", False) is True and meta.get("image_list", False) is False:
                     meta["image_list"] = []


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reused images are now checked against approved image hosts before being displayed.
  * Image validation and rehosting status is now reported consistently for reused and newly uploaded screenshots.

* **Tests**
  * Added regression coverage to verify image-host checks run for both new and reused images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->