### PR TITLE
fix(C411): catch same-infohash dupes and classify upload audio by tracks

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -19,16 +19,22 @@ reviews:
     - path: "src/trackers/**"
       instructions: |
         These are tracker modules for a torrent upload assistant.
-        Each tracker (C411, TORR9, ACM, GF, etc.) implements upload logic for a specific
+        Each tracker (C411, V3X, ACM, GF, etc.) implements upload logic for a specific
         French or international private tracker. Pay attention to:
         - Correct BBCode formatting in description builders
         - Proper async/await usage (all tracker methods are async)
-        - French language conventions in user-facing strings
         - Dupe-checking logic and slot-based filtering (especially C411)
+        Language conventions: console/log messages are ALWAYS English, project-wide —
+        never suggest translating them to French. French belongs only in content sent
+        to the tracker sites themselves (BBCode descriptions, upload field values).
     - path: "tests/**"
       instructions: |
         Test suite using pytest. Tests are synchronous wrappers around async code.
         Ensure assertions are specific and cover edge cases.
+        Do not suggest tests that import or exercise upload.py / process_meta:
+        upload.py runs the user-config load at module level (sys.exit without a
+        config), so it is not importable in tests. Logic that needs behavioral
+        tests should be extracted into src/ modules instead.
     - path: "web_ui/**"
       instructions: |
         Flask-based web UI for the upload assistant.

--- a/src/trackers/C411.py
+++ b/src/trackers/C411.py
@@ -1652,6 +1652,10 @@ class C411(FrenchTrackerMixin):
             for dupe in dupes:
                 if str(dupe.get("infohash") or "").lower() == own_infohash:
                     console.print(f"[yellow]C411: this exact torrent (same infohash) is already on the tracker: {dupe.get('name')}[/yellow]")
+                    # Same unattended-abort rule as the normal path below, so
+                    # the upload gate blocks even if the generic DupeChecker
+                    # later discards this entry on name similarity.
+                    meta["_c411_slot_occupied"] = not self._is_corrective_version_meta(meta)
                     return [dupe]
 
         # ── Corrective versions: note but still check dupes ──

--- a/src/trackers/C411.py
+++ b/src/trackers/C411.py
@@ -1643,6 +1643,17 @@ class C411(FrenchTrackerMixin):
         if meta.get("debug"):
             console.print(f"[cyan]C411 dupe search found {len(dupes)} result(s)[/cyan]")
 
+        # ── Same infohash: definite dupe, bypass every filter ──
+        # The upload torrent is a deterministic BASE clone, so an identical
+        # infohash on the tracker means this exact torrent was already
+        # uploaded — no relevance/slot/coexistence rule can change that.
+        own_infohash = self._prospective_infohash(meta)
+        if own_infohash:
+            for dupe in dupes:
+                if str(dupe.get("infohash") or "").lower() == own_infohash:
+                    console.print(f"[yellow]C411: this exact torrent (same infohash) is already on the tracker: {dupe.get('name')}[/yellow]")
+                    return [dupe]
+
         # ── Corrective versions: note but still check dupes ──
         # PROPER/REPACK/… may replace the original, but we still need to
         # show the user what currently occupies the slot so they can decide.
@@ -1727,7 +1738,12 @@ class C411(FrenchTrackerMixin):
         # french_lang_supersede. Without this, a MULTI EAC3 release would be silently
         # removed before the language-hierarchy check can see it.
         if dupes:
-            upload_audio_str = str(meta.get("audio", ""))
+            # Classify the upload with the same track-based logic that names
+            # C411 releases (_get_audio_for_name picks a lossless track when
+            # one exists) — the generic meta audio string can understate a
+            # multi-track file (e.g. "DD 2.0" on a REMUX carrying DTS-HD MA),
+            # which would wrongly let the same file coexist with itself.
+            upload_audio_str = self._get_audio_for_name(meta) or str(meta.get("audio", ""))
             upload_lossless = self._is_lossless_audio(upload_audio_str)
             upload_audio_tag = await self._build_audio_string(meta)
             _, upload_lang_level = self._extract_french_lang_tag(upload_audio_tag)
@@ -1769,6 +1785,28 @@ class C411(FrenchTrackerMixin):
         meta["_c411_slot_occupied"] = len(final_dupes) > 0 and not is_corrective
 
         return final_dupes
+
+    def _prospective_infohash(self, meta: Meta) -> str:
+        """Infohash the [C411].torrent will have (BASE clone + source flag).
+
+        Lets the dupe check catch "this exact torrent is already on the
+        tracker" before any relevance/coexistence filtering. Returns "" when
+        BASE.torrent is missing or when NFO embedding will recreate the
+        torrent (hash not predictable here).
+        """
+        base_path = os.path.join(meta.get("base_dir", ""), "tmp", meta.get("uuid", ""), "BASE.torrent")
+        if not os.path.isfile(base_path):
+            return ""
+        if self._get_nfo_files(meta):
+            return ""
+        try:
+            from torf import Torrent
+
+            torrent = Torrent.read(base_path)
+            torrent.metainfo["info"]["source"] = self.source_flag
+            return str(torrent.infohash).lower()
+        except Exception:
+            return ""
 
     @staticmethod
     def _parse_torznab_response(xml_text: str) -> list[dict[str, Any]]:
@@ -1820,6 +1858,7 @@ class C411(FrenchTrackerMixin):
             # Extract torznab attributes (resolution, category, files, etc.)
             files_count = 0
             resolution = ""
+            infohash = ""
             for attr in item.findall("torznab:attr", ns):
                 attr_name = attr.get("name", "")
                 attr_value = attr.get("value", "")
@@ -1828,6 +1867,8 @@ class C411(FrenchTrackerMixin):
                         files_count = int(attr_value)
                 elif attr_name == "resolution":
                     resolution = attr_value
+                elif attr_name == "infohash":
+                    infohash = attr_value
 
             if name:
                 results.append(
@@ -1838,6 +1879,7 @@ class C411(FrenchTrackerMixin):
                         "id": guid or None,
                         "file_count": files_count,
                         "res": resolution or None,
+                        "infohash": infohash or None,
                         "files": [],
                         "trumpable": False,
                         "internal": False,

--- a/tests/test_c411.py
+++ b/tests/test_c411.py
@@ -2996,3 +2996,109 @@ class TestC411ReservedGroups:
         setup = TRACKER_SETUP(config=_config())
         meta = {"tag": "-Dramas.For.Ever", "unattended": True}
         assert asyncio.run(setup.check_banned_group("C411", tracker.banned_groups, meta)) is True
+
+
+# ─── Same-infohash dupe detection ─────────────────────────────
+
+
+class TestProspectiveInfohash:
+    def _base_torrent(self, tmp_path):
+        from torf import Torrent
+
+        uuid = "Movie.2024.1080p.BluRay.REMUX.AVC-GRP"
+        content = tmp_path / "content" / uuid
+        content.mkdir(parents=True)
+        (content / "movie.mkv").write_bytes(b"x" * 2048)
+        t = Torrent(path=str(content), trackers=["https://fake.tracker/announce"], piece_size=16384)
+        t.generate()
+        out = tmp_path / "tmp" / uuid
+        out.mkdir(parents=True)
+        t.write(str(out / "BASE.torrent"))
+        return uuid
+
+    def test_matches_the_source_flagged_clone(self, tmp_path, monkeypatch):
+        from torf import Torrent
+
+        uuid = self._base_torrent(tmp_path)
+        c = C411(_config())
+        monkeypatch.setattr(c, "_get_nfo_files", lambda meta: [])
+        meta = {"base_dir": str(tmp_path), "uuid": uuid}
+        expected = Torrent.read(str(tmp_path / "tmp" / uuid / "BASE.torrent"))
+        expected.metainfo["info"]["source"] = "C411"
+        assert c._prospective_infohash(meta) == str(expected.infohash).lower()
+
+    def test_empty_when_nfo_will_recreate_the_torrent(self, tmp_path, monkeypatch):
+        uuid = self._base_torrent(tmp_path)
+        c = C411(_config())
+        monkeypatch.setattr(c, "_get_nfo_files", lambda meta: ["/release/movie.nfo"])
+        assert c._prospective_infohash({"base_dir": str(tmp_path), "uuid": uuid}) == ""
+
+    def test_empty_without_base_torrent(self, tmp_path):
+        c = C411(_config())
+        assert c._prospective_infohash({"base_dir": str(tmp_path), "uuid": "nope"}) == ""
+
+
+class TestSameInfohashShortCircuit:
+    XML = """<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:torznab="http://torznab.com/schemas/2015/feed">
+  <channel>
+    <item>
+      <title>Totally.Different.Name.1954.MULTI.VFF.2160p.WEB.x265-OTHER</title>
+      <guid>https://c411.org/torrents/222</guid>
+      <link>https://c411.org/torrents/222</link>
+      <size>25237757854</size>
+      <torznab:attr name="infohash" value="AABBCCDDEEFF00112233445566778899AABBCCDD" />
+    </item>
+  </channel>
+</rss>"""
+
+    def test_parser_captures_infohash(self):
+        results = C411._parse_torznab_response(self.XML)
+        assert results[0]["infohash"] == "AABBCCDDEEFF00112233445566778899AABBCCDD"
+
+    def test_same_infohash_is_a_definite_dupe_bypassing_filters(self, monkeypatch):
+        c = C411(_config())
+        meta = _meta_base()
+
+        async def fake_hashless_filters_should_not_matter(*a, **k):
+            raise AssertionError("filters must not run after an infohash match")
+
+        monkeypatch.setattr(c, "_prospective_infohash", lambda m: "aabbccddeeff00112233445566778899aabbccdd")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = self.XML
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_cls.return_value = mock_client
+            dupes = asyncio.run(c.search_existing(meta, "nodisc"))
+
+        # The name would fail every relevance/slot filter (different title,
+        # resolution, group) — the identical infohash still makes it a dupe.
+        assert len(dupes) == 1
+        assert dupes[0]["infohash"] == "AABBCCDDEEFF00112233445566778899AABBCCDD"
+
+
+class TestUploadLosslessClassification:
+    def test_remux_with_lossless_track_is_classified_lossless(self):
+        # Generic meta audio understates the file ("DD 2.0"); the track-based
+        # C411 logic must classify it lossless like the fiche name it creates.
+        c = C411(_config())
+        meta = {
+            "audio": "Dual-Audio DD 2.0",
+            "mediainfo": {
+                "media": {
+                    "track": [
+                        {"@type": "General"},
+                        {"@type": "Audio", "Format": "DTS", "Format_AdditionalFeatures": "XLL X", "Channels": "6", "Language": "en"},
+                        {"@type": "Audio", "Format": "AC-3", "Channels": "2", "Language": "fr"},
+                    ]
+                }
+            },
+        }
+        audio_str = c._get_audio_for_name(meta)
+        assert C411._is_lossless_audio(audio_str), audio_str

--- a/tests/test_c411.py
+++ b/tests/test_c411.py
@@ -3102,3 +3102,58 @@ class TestUploadLosslessClassification:
         }
         audio_str = c._get_audio_for_name(meta)
         assert C411._is_lossless_audio(audio_str), audio_str
+
+
+class TestCoexistenceUsesTrackAudio:
+    """Regression: the lossy/lossless coexistence filter must classify the
+    upload from its MediaInfo tracks (like the C411 fiche name), not from the
+    generic meta audio string."""
+
+    XML = """<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:torznab="http://torznab.com/schemas/2015/feed">
+  <channel>
+    <item>
+      <title>Le.Prenom.2012.MULTI.VFF.1080p.WEB.DTS.HD.MA.5.1.x264-Other</title>
+      <guid>https://c411.org/torrents/301</guid>
+      <link>https://c411.org/torrents/301</link>
+      <size>9000000000</size>
+    </item>
+    <item>
+      <title>Le.Prenom.2012.MULTI.VFF.1080p.WEB.DD.5.1.x264-Other2</title>
+      <guid>https://c411.org/torrents/302</guid>
+      <link>https://c411.org/torrents/302</link>
+      <size>4000000000</size>
+    </item>
+  </channel>
+</rss>"""
+
+    def test_lossless_file_with_lossy_meta_audio_keeps_lossless_dupe(self):
+        c = C411(_config())
+        meta = _meta_base(audio="Dual-Audio DD 2.0", tag="-Other")
+        meta["mediainfo"] = {
+            "media": {
+                "track": [
+                    {"@type": "General"},
+                    {"@type": "Audio", "Format": "DTS", "Format_AdditionalFeatures": "XLL", "Channels": "6", "Language": "en"},
+                    {"@type": "Audio", "Format": "AC-3", "Channels": "2", "Language": "fr"},
+                ]
+            }
+        }
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = self.XML
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_cls.return_value = mock_client
+            dupes = asyncio.run(c.search_existing(meta, "nodisc"))
+
+        names = " ".join(d.get("name", "") for d in dupes)
+        # Track-based classification: the upload is lossless, so the lossless
+        # dupe blocks it and the lossy one is removed (permanent coexistence).
+        assert "DTS.HD.MA" in names
+        assert "DD.5.1" not in names


### PR DESCRIPTION
The dupe search returned the user's own earlier upload but the lossy/lossless coexistence filter dropped it: the generic meta audio string said DD 2.0 while the file carries a lossless track, so the same file was classified opposite to its own fiche name. The coexistence check now uses the track-based _get_audio_for_name logic that names C411 releases. As a backstop, the torznab infohash attribute is parsed and compared to the prospective [C411].torrent infohash (deterministic BASE clone + source flag): an identical infohash is a definite dupe that bypasses every relevance/slot/coexistence filter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate detection by identifying matching torrents through their infohash before applying other upload filters.
  * Preserved infohash details from Torznab results for more reliable duplicate checks.
  * Improved lossless/lossy audio classification using track-level media information when available.
  * Added safeguards for torrents whose metadata changes during NFO embedding.

* **Tests**
  * Expanded coverage for infohash-based duplicate detection, fallback scenarios, Torznab parsing, and audio classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->