### PR TITLE
fix: strip tool signatures with variable names from reused descriptions

### DIFF
--- a/src/bbcode.py
+++ b/src/bbcode.py
@@ -514,7 +514,11 @@ class BBCODE:
         # logo — a ".4HH" stroke and the closing ".JHHL." line — so a real
         # NFO code block that merely shares one stroke survives.
         desc = re.sub(r"\s*\[code\]\[center\][^\[]*\.4HH[^\[]*\.JHHL\.\s*\[/center\]\[/code\]\s*", "\n\n", desc, flags=re.IGNORECASE).strip()
-        desc = re.sub(r"\s*Posted to this fine tracker with seedbrr\.?", "", desc, flags=re.IGNORECASE)
+        # The tool name after "with" varies per uploader (seedbrr, seed-tools, …);
+        # the bounded character class stops before any BBCode bracket.
+        desc = re.sub(r"\s*Posted to this fine tracker with [\w -]{1,40}\.?", "", desc, flags=re.IGNORECASE)
+        # Same family of tool signatures, variable "sponsor" name.
+        desc = re.sub(r"\s*This description is rendered for you via config\.yaml and is sponsored by [\w -]{1,40}\.?", "", desc, flags=re.IGNORECASE)
         # ...and its sample-link spoiler ([b][spoiler=Sample: xyz]url[/spoiler][/b])
         desc = re.sub(r"\s*(\[b\])?\[spoiler=Sample[^\]]*\][\s\S]*?\[/spoiler\](\[/b\])?\s*", "\n\n", desc, flags=re.IGNORECASE).strip()
         desc = re.sub(r"\[center\].*Created by.*Upload Assistant.*\[\/center\]", "", desc, flags=re.IGNORECASE)

--- a/tests/test_bbcode_sp_cleanup.py
+++ b/tests/test_bbcode_sp_cleanup.py
@@ -69,3 +69,26 @@ def test_regular_spoiler_survives() -> None:
     desc = "Summary.\n\n[spoiler=Screens]some content[/spoiler]"
     cleaned, _ = BBCODE().clean_unit3d_description(desc, "https://seedpool.org")
     assert "[spoiler=Screens]some content[/spoiler]" in cleaned
+
+
+def test_seedpool_sentence_with_other_tool_name_is_removed():
+    # The tool name after "with" varies per uploader (seedbrr, seed-tools, …)
+    desc = "[b][size=12][color=#757575]Created with mkbrr, ffmpeg, and mediainfo. Posted to this fine tracker with seed-tools.[/color][/size][/b]"
+    cleaned, _ = BBCODE().clean_unit3d_description(desc, "https://seedpool.org")
+    assert "Posted to this fine tracker" not in cleaned
+    assert "Created with mkbrr, ffmpeg, and mediainfo." in cleaned
+
+
+def test_seedpool_sentence_does_not_eat_following_text():
+    desc = "Posted to this fine tracker with seed-tools. A plot summary that must stay."
+    cleaned, _ = BBCODE().clean_unit3d_description(desc, "https://seedpool.org")
+    assert "A plot summary that must stay." in cleaned
+    assert "Posted to this fine tracker" not in cleaned
+
+
+def test_sponsored_sentence_is_removed() -> None:
+    desc = "Summary kept.\nThis description is rendered for you via config.yaml and is sponsored by Shrek."
+    cleaned, _ = BBCODE().clean_unit3d_description(desc, "https://seedpool.org")
+    assert "sponsored by" not in cleaned
+    assert "rendered for you via config.yaml" not in cleaned
+    assert "Summary kept." in cleaned


### PR DESCRIPTION
The 'Posted to this fine tracker with …' sentence carries a per-uploader tool name (seedbrr, seed-tools, …) — match any bounded name instead of the literal. Also strip the same family's 'This description is rendered for you via config.yaml and is sponsored by …' sentence.