### PR TITLE
fix(c411): pure coexistence

### DIFF
--- a/src/trackers/C411.py
+++ b/src/trackers/C411.py
@@ -1658,6 +1658,16 @@ class C411(FrenchTrackerMixin):
                     meta["_c411_slot_occupied"] = not self._is_corrective_version_meta(meta)
                     return [dupe]
 
+        # ── BONUS releases live in their own world ──
+        # A release tagged BONUS carries only the film's bonus content, not
+        # the film itself: it never competes with a film upload, and a BONUS
+        # upload only competes with other BONUS releases.
+        upload_is_bonus = self._is_bonus_release_meta(meta)
+        before_bonus = len(dupes)
+        dupes = [d for d in dupes if self._name_has_bonus_tag(d.get("name", "")) == upload_is_bonus]
+        if meta.get("debug") and len(dupes) < before_bonus:
+            console.print(f"[cyan]C411: {before_bonus - len(dupes)} BONUS-mismatched release(s) excluded from dupe checking[/cyan]")
+
         # ── Corrective versions: note but still check dupes ──
         # PROPER/REPACK/… may replace the original, but we still need to
         # show the user what currently occupies the slot so they can decide.
@@ -1793,6 +1803,15 @@ class C411(FrenchTrackerMixin):
         meta["_c411_slot_occupied"] = len(final_dupes) > 0 and not is_corrective
 
         return final_dupes
+
+    @staticmethod
+    def _name_has_bonus_tag(name: str) -> bool:
+        """True when a release name carries the BONUS token (bonus-only content)."""
+        n = f".{name.upper().replace('-', '.').replace(' ', '.')}."
+        return ".BONUS." in n
+
+    def _is_bonus_release_meta(self, meta: Meta) -> bool:
+        return any(self._name_has_bonus_tag(str(meta.get(field, ""))) for field in ("uuid", "name", "path", "edition"))
 
     def _prospective_infohash(self, meta: Meta) -> str:
         """Infohash the [C411].torrent will have (BASE clone + source flag).

--- a/src/trackers/C411.py
+++ b/src/trackers/C411.py
@@ -1692,7 +1692,8 @@ class C411(FrenchTrackerMixin):
         if dupes:
             upload_audio = await self._build_audio_string(meta)
             upload_lang = self._detect_lang_tag_from_name(upload_audio)
-            # Check if any existing dupe is VF2 or MULTI.VF2
+            # Check if any existing dupe is VF2 or MULTI.VF2 (per-slot: the
+            # VF2 > VFF+VFQ supersession only applies within the same slot)
             has_unified = any(self._detect_lang_tag_from_name(d.get("name", "")) in ("VF2", "MULTI.VF2") for d in dupes)
             if not has_unified and upload_lang in _FR_TAGS:
                 # VFF/VFI upload: filter out VFQ-only dupes (they coexist)
@@ -1735,13 +1736,16 @@ class C411(FrenchTrackerMixin):
                                 f"[cyan]C411 coexistence: HDR-only upload — {before - len(dupes)} DV-only dupe(s) removed (temporary coexistence, no DV.HDR10 found)[/cyan]"
                             )
 
-        # ── Lossy / Lossless coexistence (permanent) ──
-        # A lossy version and a lossless version can always coexist in the same slot.
+        # ── Lossy / Lossless coexistence (PURE slots only) ──
+        # PURE slots are defined "Lossless (lossy accepté)": a lossy rip and a
+        # lossless one may coexist there. COMPAT/OPTI/HCOPT slots are single
+        # occupancy regardless of audio class — audio is part of the slot
+        # definition, not a sub-slot.
         # Exception: for VOSTFR uploads, always keep FR-audio releases regardless of
         # lossless/lossy — they must reach _check_french_lang_dupes to be flagged as
         # french_lang_supersede. Without this, a MULTI EAC3 release would be silently
         # removed before the language-hierarchy check can see it.
-        if dupes:
+        if dupes and upload_slot and "PURE" in upload_slot:
             # Classify the upload with the same track-based logic that names
             # C411 releases (_get_audio_for_name picks a lossless track when
             # one exists) — the generic meta audio string can understate a

--- a/tests/test_c411.py
+++ b/tests/test_c411.py
@@ -3179,3 +3179,54 @@ class TestCoexistenceUsesTrackAudio:
         names = " ".join(d.get("name", "") for d in dupes)
         assert "AC3.5.1.x264-Other" in names
 
+
+
+class TestBonusReleasesAreExcluded:
+    """BONUS releases carry only the film's bonus content: they never compete
+    with a film upload, and a BONUS upload only competes with other BONUS."""
+
+    XML = """<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:torznab="http://torznab.com/schemas/2015/feed">
+  <channel>
+    <item>
+      <title>Le.Prenom.2012.BONUS.VOSTFR.1080p.WEB.AC3.2.0.x264-Other</title>
+      <guid>https://c411.org/torrents/501</guid>
+      <link>https://c411.org/torrents/501</link>
+      <size>4000000000</size>
+    </item>
+    <item>
+      <title>Le.Prenom.2012.FRENCH.1080p.WEB.AC3.5.1.x264-Other2</title>
+      <guid>https://c411.org/torrents/502</guid>
+      <link>https://c411.org/torrents/502</link>
+      <size>8000000000</size>
+    </item>
+  </channel>
+</rss>"""
+
+    def _search(self, **meta_overrides):
+        c = C411(_config())
+        meta = _meta_base(tag="-Mine", original_language="en", **meta_overrides)
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = self.XML
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_cls.return_value = mock_client
+            return asyncio.run(c.search_existing(meta, "nodisc"))
+
+    def test_film_upload_ignores_bonus_releases(self):
+        dupes = self._search()
+        names = " ".join(d.get("name", "") for d in dupes)
+        assert "BONUS" not in names
+        assert "FRENCH.1080p" in names
+
+    def test_bonus_upload_only_competes_with_bonus(self):
+        dupes = self._search(uuid="Le.Prenom.2012.BONUS.VOSTFR.1080p.WEB.AC3.2.0.x264-Mine")
+        names = " ".join(d.get("name", "") for d in dupes)
+        assert "BONUS" in names
+        assert "FRENCH.1080p.WEB.AC3.5.1" not in names

--- a/tests/test_c411.py
+++ b/tests/test_c411.py
@@ -3105,31 +3105,43 @@ class TestUploadLosslessClassification:
 
 
 class TestCoexistenceUsesTrackAudio:
-    """Regression: the lossy/lossless coexistence filter must classify the
-    upload from its MediaInfo tracks (like the C411 fiche name), not from the
-    generic meta audio string."""
+    """The lossy/lossless coexistence only applies in PURE slots, and must
+    classify the upload from its MediaInfo tracks (like the C411 fiche name),
+    not from the generic meta audio string."""
 
-    XML = """<?xml version="1.0" encoding="UTF-8"?>
+    PURE_XML = """<?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0" xmlns:torznab="http://torznab.com/schemas/2015/feed">
   <channel>
     <item>
-      <title>Le.Prenom.2012.MULTI.VFF.1080p.WEB.DTS.HD.MA.5.1.x264-Other</title>
+      <title>Le.Prenom.2012.MULTI.VFF.1080p.BluRay.Remux.DTS.HD.MA.5.1.AVC-Other</title>
       <guid>https://c411.org/torrents/301</guid>
       <link>https://c411.org/torrents/301</link>
-      <size>9000000000</size>
+      <size>25000000000</size>
     </item>
     <item>
-      <title>Le.Prenom.2012.MULTI.VFF.1080p.WEB.DD.5.1.x264-Other2</title>
+      <title>Le.Prenom.2012.MULTI.VFF.1080p.BluRay.Remux.AC3.5.1.AVC-Other2</title>
       <guid>https://c411.org/torrents/302</guid>
       <link>https://c411.org/torrents/302</link>
+      <size>18000000000</size>
+    </item>
+  </channel>
+</rss>"""
+
+    COMPAT_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:torznab="http://torznab.com/schemas/2015/feed">
+  <channel>
+    <item>
+      <title>Le.Prenom.2012.FRENCH.1080p.WEB.AC3.5.1.x264-Other</title>
+      <guid>https://c411.org/torrents/303</guid>
+      <link>https://c411.org/torrents/303</link>
       <size>4000000000</size>
     </item>
   </channel>
 </rss>"""
 
-    def test_lossless_file_with_lossy_meta_audio_keeps_lossless_dupe(self):
+    def _search(self, xml: str, **meta_overrides):
         c = C411(_config())
-        meta = _meta_base(audio="Dual-Audio DD 2.0", tag="-Other")
+        meta = _meta_base(audio="Dual-Audio DD 2.0", tag="-Other", original_language="en", **meta_overrides)
         meta["mediainfo"] = {
             "media": {
                 "track": [
@@ -3142,7 +3154,7 @@ class TestCoexistenceUsesTrackAudio:
 
         mock_response = MagicMock()
         mock_response.status_code = 200
-        mock_response.text = self.XML
+        mock_response.text = xml
 
         with patch("httpx.AsyncClient") as mock_client_cls:
             mock_client = AsyncMock()
@@ -3150,10 +3162,20 @@ class TestCoexistenceUsesTrackAudio:
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_cls.return_value = mock_client
-            dupes = asyncio.run(c.search_existing(meta, "nodisc"))
+            return asyncio.run(c.search_existing(meta, "nodisc"))
 
+    def test_pure_slot_lossless_upload_keeps_lossless_dupe_only(self):
+        dupes = self._search(self.PURE_XML, type="REMUX", source="BluRay")
         names = " ".join(d.get("name", "") for d in dupes)
         # Track-based classification: the upload is lossless, so the lossless
-        # dupe blocks it and the lossy one is removed (permanent coexistence).
+        # remux blocks it and the lossy remux is removed (PURE coexistence).
         assert "DTS.HD.MA" in names
-        assert "DD.5.1" not in names
+        assert "AC3.5.1" not in names
+
+    def test_compat_slot_has_no_lossy_lossless_coexistence(self):
+        # COMPAT is single occupancy: a lossy occupant blocks even a
+        # lossless-audio upload of the same slot.
+        dupes = self._search(self.COMPAT_XML)
+        names = " ".join(d.get("name", "") for d in dupes)
+        assert "AC3.5.1.x264-Other" in names
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate detection so bonus editions are matched only with corresponding bonus editions.
  * Refined release coexistence handling, allowing lossless and lossy versions together where appropriate while preserving single-version rules elsewhere.
  * Improved language and audio-track checks for more accurate release matching.
  * Clarified subtitle and language precedence behavior when evaluating releases in the same slot.
  * Added regression coverage for bonus editions, audio classification, and coexistence rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->