### PR TITLE
fix(g3mini): pgs encodes

### DIFF
--- a/src/trackers/G3MINI.py
+++ b/src/trackers/G3MINI.py
@@ -1,4 +1,5 @@
 # Upload Assistant © 2025 Audionut &amp; wastaken7 — Licensed under UAPL v1.0
+import os
 import re
 from typing import Any
 
@@ -175,6 +176,91 @@ class G3MINI(FrenchTrackerMixin, UNIT3D):
                             console.print(f"[bold red]{self.tracker}: x264 encode quality is below the 'slow' preset minimum: {', '.join(details)}.[/bold red]")
                         return False
                     break
+
+        # x265 encodes must use at least the "medium" preset. Same inference
+        # approach as x264: medium = subme=2/rd=3, slow = subme=3/rd=4.
+        if not meta.get("is_disc") and "x265" in meta.get("video_encode", "").lower() and meta.get("type") in {"ENCODE", "WEBRIP"}:
+            tracks = meta.get("mediainfo", {}).get("media", {}).get("track", [])
+            for track in tracks:
+                if track.get("@type") == "Video":
+                    encoding_settings = str(track.get("Encoded_Library_Settings", "") or "")
+                    if not encoding_settings or encoding_settings == "{}":
+                        if not meta.get("unattended") or meta.get("debug"):
+                            console.print(
+                                f"[bold red]{self.tracker}: No encoding settings found in mediainfo — cannot verify x265 preset quality (minimum: 'medium').[/bold red]"
+                            )
+                        return False
+                    subme_match = re.search(r"\bsubme\s*=\s*(\d+)", encoding_settings, re.IGNORECASE)
+                    rd_match = re.search(r"\brd\s*=\s*(\d+)", encoding_settings, re.IGNORECASE)
+                    subme = int(subme_match.group(1)) if subme_match else None
+                    rd = int(rd_match.group(1)) if rd_match else None
+                    if (subme is not None and subme < 2) or (rd is not None and rd < 3):
+                        details = []
+                        if subme is not None and subme < 2:
+                            details.append(f"subme={subme} (minimum 2 for 'medium')")
+                        if rd is not None and rd < 3:
+                            details.append(f"rd={rd} (minimum 3 for 'medium')")
+                        if not meta.get("unattended") or meta.get("debug"):
+                            console.print(f"[bold red]{self.tracker}: x265 encode quality is below the 'medium' preset minimum: {', '.join(details)}.[/bold red]")
+                        return False
+                    break
+
+        # AV1 encodes must use preset 4 (slower) or better (lower number).
+        if not meta.get("is_disc") and "av1" in meta.get("video_encode", "").lower() and meta.get("type") in {"ENCODE", "WEBRIP"}:
+            tracks = meta.get("mediainfo", {}).get("media", {}).get("track", [])
+            for track in tracks:
+                if track.get("@type") == "Video":
+                    encoding_settings = str(track.get("Encoded_Library_Settings", "") or "")
+                    preset_match = re.search(r"\bpreset\s*[=:]\s*(\d+)", encoding_settings, re.IGNORECASE)
+                    if not encoding_settings or encoding_settings == "{}" or not preset_match:
+                        if not meta.get("unattended") or meta.get("debug"):
+                            console.print(f"[bold red]{self.tracker}: No encoding settings found in mediainfo — cannot verify AV1 preset (maximum: 4).[/bold red]")
+                        return False
+                    if int(preset_match.group(1)) > 4:
+                        if not meta.get("unattended") or meta.get("debug"):
+                            console.print(f"[bold red]{self.tracker}: AV1 preset {preset_match.group(1)} is above the allowed maximum of 4 (slower).[/bold red]")
+                        return False
+                    break
+
+        # Forbidden audio codecs on encodes: MP3 always, FLAC beyond stereo.
+        if not meta.get("is_disc") and meta.get("type") in {"ENCODE", "WEBRIP"}:
+            for track in meta.get("mediainfo", {}).get("media", {}).get("track", []):
+                if track.get("@type") != "Audio":
+                    continue
+                fmt = str(track.get("Format", "") or "").upper()
+                channels = int(str(track.get("Channels", "0") or "0"))
+                if fmt == "MP3":
+                    if not meta.get("unattended") or meta.get("debug"):
+                        console.print(f"[bold red]{self.tracker}: MP3 audio tracks are forbidden on encodes.[/bold red]")
+                    return False
+                if fmt == "FLAC" and channels > 2:
+                    if not meta.get("unattended") or meta.get("debug"):
+                        console.print(f"[bold red]{self.tracker}: FLAC audio is only allowed for mono/stereo tracks (found {channels} channels).[/bold red]")
+                    return False
+
+        # A MULTi release must carry VO + VF + French subtitles.
+        audio_tag = await self._build_audio_string(meta)
+        if audio_tag.startswith("MULTI") and not self._has_french_subs(meta):
+            if not meta.get("unattended") or meta.get("debug"):
+                console.print(f"[bold red]{self.tracker}: a MULTi release requires French subtitles (VO + VF + subs FR).[/bold red]")
+            return False
+
+        # Subtitles must be muxed into the MKV (no external files) and
+        # archives are forbidden.
+        _external_subs = (".srt", ".ass", ".ssa", ".sub", ".idx", ".vtt")
+        _archives = (".rar", ".zip", ".7z")
+        for path in meta.get("filelist", []) or []:
+            lower = str(path).lower()
+            if lower.endswith(_external_subs):
+                if not meta.get("unattended") or meta.get("debug"):
+                    console.print(
+                        f"[bold red]{self.tracker}: external subtitle files are forbidden — subtitles must be muxed into the MKV ({os.path.basename(str(path))}).[/bold red]"
+                    )
+                return False
+            if lower.endswith(_archives):
+                if not meta.get("unattended") or meta.get("debug"):
+                    console.print(f"[bold red]{self.tracker}: archives are forbidden ({os.path.basename(str(path))}).[/bold red]")
+                return False
 
         # PGS subtitles are forbidden on encodes unless they are additional:
         # a PGS track only passes when a text-based subtitle track of the

--- a/src/trackers/G3MINI.py
+++ b/src/trackers/G3MINI.py
@@ -166,13 +166,14 @@ class G3MINI(FrenchTrackerMixin, UNIT3D):
                     if meta.get("debug", False):
                         console.print(f"[cyan]{self.tracker}: x264 subme={subme}, trellis={trellis}[/cyan]")
 
-                    # Reject if either parameter is at medium level or worse
-                    if (subme is not None and subme < 8) or (trellis is not None and trellis < 2):
-                        details = []
-                        if subme is not None and subme < 8:
-                            details.append(f"subme={subme} (minimum 8 for 'slow')")
-                        if trellis is not None and trellis < 2:
-                            details.append(f"trellis={trellis} (minimum 2 for 'slow')")
+                    # x264 always dumps both parameters; a missing one means the
+                    # settings are unverifiable — reject like a below-minimum value.
+                    details = []
+                    if subme is None or subme < 8:
+                        details.append(f"subme={subme if subme is not None else 'missing'} (minimum 8 for 'slow')")
+                    if trellis is None or trellis < 2:
+                        details.append(f"trellis={trellis if trellis is not None else 'missing'} (minimum 2 for 'slow')")
+                    if details:
                         if not meta.get("unattended") or meta.get("debug"):
                             console.print(f"[bold red]{self.tracker}: x264 encode quality is below the 'slow' preset minimum: {', '.join(details)}.[/bold red]")
                         return False

--- a/src/trackers/G3MINI.py
+++ b/src/trackers/G3MINI.py
@@ -25,7 +25,8 @@ class G3MINI(FrenchTrackerMixin, UNIT3D):
         self.requests_url = f"{self.base_url}/api/requests/filter"
         self.search_url = f"{self.base_url}/api/torrents/filter"
         self.torrent_url = f"{self.base_url}/torrents/"
-        self.banned_groups = ["k0re", "Slay3R", "Fenixx", "KMS.Tools.Portable", "MAXAGENT", "Seyter", "Vansik"]
+        # Site "Teams Interdites" list
+        self.banned_groups = ["k0RE", "Slay3R", "EXTREME", "ShadowKernel", "byPlex", "WebVision", "AgoraQc", "DELiRiUS", "MICKEY"]
         self.source_flag = "G3MINI"
         pass
 

--- a/src/trackers/G3MINI.py
+++ b/src/trackers/G3MINI.py
@@ -176,6 +176,24 @@ class G3MINI(FrenchTrackerMixin, UNIT3D):
                         return False
                     break
 
+        # PGS subtitles are forbidden on encodes unless they are additional:
+        # a PGS track only passes when a text-based subtitle track of the
+        # same language exists alongside it.
+        if not meta.get("is_disc") and meta.get("type") in {"ENCODE", "WEBRIP"}:
+            tracks = meta.get("mediainfo", {}).get("media", {}).get("track", [])
+
+            def _lang(track: dict[str, Any]) -> str:
+                return str(track.get("Language", "") or "").lower().split("-")[0]
+
+            text_sub_langs = {_lang(t) for t in tracks if t.get("@type") == "Text" and "PGS" not in str(t.get("Format", "")).upper()}
+            offending = sorted({_lang(t) or "?" for t in tracks if t.get("@type") == "Text" and "PGS" in str(t.get("Format", "")).upper() and _lang(t) not in text_sub_langs})
+            if offending:
+                if not meta.get("unattended") or meta.get("debug"):
+                    console.print(
+                        f"[bold red]{self.tracker}: PGS subtitles are forbidden on encodes unless additional to a text subtitle track — offending language(s): {', '.join(offending)}.[/bold red]"
+                    )
+                return False
+
         return True
 
     # https://gemini-tracker.org/pages/7

--- a/src/trackers/G3MINI.py
+++ b/src/trackers/G3MINI.py
@@ -195,12 +195,14 @@ class G3MINI(FrenchTrackerMixin, UNIT3D):
                     rd_match = re.search(r"\brd\s*=\s*(\d+)", encoding_settings, re.IGNORECASE)
                     subme = int(subme_match.group(1)) if subme_match else None
                     rd = int(rd_match.group(1)) if rd_match else None
-                    if (subme is not None and subme < 2) or (rd is not None and rd < 3):
-                        details = []
-                        if subme is not None and subme < 2:
-                            details.append(f"subme={subme} (minimum 2 for 'medium')")
-                        if rd is not None and rd < 3:
-                            details.append(f"rd={rd} (minimum 3 for 'medium')")
+                    # x265 always dumps both parameters; a missing one means the
+                    # settings are unverifiable — reject like a below-minimum value.
+                    details = []
+                    if subme is None or subme < 2:
+                        details.append(f"subme={subme if subme is not None else 'missing'} (minimum 2 for 'medium')")
+                    if rd is None or rd < 3:
+                        details.append(f"rd={rd if rd is not None else 'missing'} (minimum 3 for 'medium')")
+                    if details:
                         if not meta.get("unattended") or meta.get("debug"):
                             console.print(f"[bold red]{self.tracker}: x265 encode quality is below the 'medium' preset minimum: {', '.join(details)}.[/bold red]")
                         return False
@@ -241,6 +243,8 @@ class G3MINI(FrenchTrackerMixin, UNIT3D):
 
         # A MULTi release must carry VO + VF + French subtitles.
         audio_tag = await self._build_audio_string(meta)
+        while audio_tag.startswith("AD."):
+            audio_tag = audio_tag[3:]
         if audio_tag.startswith("MULTI") and not self._has_french_subs(meta):
             if not meta.get("unattended") or meta.get("debug"):
                 console.print(f"[bold red]{self.tracker}: a MULTi release requires French subtitles (VO + VF + subs FR).[/bold red]")
@@ -272,7 +276,8 @@ class G3MINI(FrenchTrackerMixin, UNIT3D):
             def _lang(track: dict[str, Any]) -> str:
                 return str(track.get("Language", "") or "").lower().split("-")[0]
 
-            text_sub_langs = {_lang(t) for t in tracks if t.get("@type") == "Text" and "PGS" not in str(t.get("Format", "")).upper()}
+            # Unlabelled text tracks must not vouch for unlabelled PGS tracks
+            text_sub_langs = {_lang(t) for t in tracks if t.get("@type") == "Text" and "PGS" not in str(t.get("Format", "")).upper()} - {""}
             offending = sorted({_lang(t) or "?" for t in tracks if t.get("@type") == "Text" and "PGS" in str(t.get("Format", "")).upper() and _lang(t) not in text_sub_langs})
             if offending:
                 if not meta.get("unattended") or meta.get("debug"):

--- a/tests/test_g3mini.py
+++ b/tests/test_g3mini.py
@@ -1011,3 +1011,112 @@ class TestG3MINIPgsSubtitlesOnEncodes:
     def test_no_pgs_passes(self):
         meta = self._meta([{"@type": "Text", "Format": "UTF-8", "Language": "fr"}])
         assert asyncio.run(self._g3().get_additional_checks(meta)) is True
+
+
+class TestG3MINIEncodingRules:
+    """x265/AV1 preset minimums, forbidden audio codecs, MULTi subtitle
+    requirement, external subs and archives."""
+
+    @staticmethod
+    def _g3() -> G3MINI:
+        return G3MINI(_config())
+
+    def _meta(self, *, video: dict[str, Any] | None = None, audio: list[dict[str, Any]] | None = None, text: list[dict[str, Any]] | None = None, **overrides: Any) -> dict[str, Any]:
+        tracks: list[dict[str, Any]] = [video or {"@type": "Video", "Encoded_Library_Settings": "cabac=1 / subme=8 / trellis=2"}]
+        tracks += audio or [{"@type": "Audio", "Format": "E-AC-3", "Channels": "6", "Language": "fr"}]
+        tracks += text or []
+        m = _meta_base(
+            type="ENCODE",
+            video_codec="AVC",
+            video_encode=" x264",
+            source="BluRay",
+            is_disc=None,
+            mediainfo={"media": {"track": tracks}},
+            audio_languages=["French"],
+            subtitle_languages=[],
+            filelist=["/downloads/Movie.2024.mkv"],
+        )
+        m.update(overrides)
+        return m
+
+    def _run(self, meta: dict[str, Any]) -> bool:
+        return asyncio.run(self._g3().get_additional_checks(meta))
+
+    # ── x265 preset ──
+
+    def test_x265_medium_passes(self):
+        meta = self._meta(video={"@type": "Video", "Encoded_Library_Settings": "cpuid=x / subme=2 / rd=3"}, video_encode=" x265")
+        assert self._run(meta) is True
+
+    def test_x265_below_medium_is_rejected(self):
+        meta = self._meta(video={"@type": "Video", "Encoded_Library_Settings": "cpuid=x / subme=1 / rd=2"}, video_encode=" x265")
+        assert self._run(meta) is False
+
+    def test_x265_without_settings_is_rejected(self):
+        meta = self._meta(video={"@type": "Video"}, video_encode=" x265")
+        assert self._run(meta) is False
+
+    # ── AV1 preset ──
+
+    def test_av1_preset_4_passes(self):
+        meta = self._meta(video={"@type": "Video", "Encoded_Library_Settings": "preset=4 / crf=30"}, video_encode="AV1")
+        assert self._run(meta) is True
+
+    def test_av1_preset_above_4_is_rejected(self):
+        meta = self._meta(video={"@type": "Video", "Encoded_Library_Settings": "preset=8 / crf=30"}, video_encode="AV1")
+        assert self._run(meta) is False
+
+    def test_av1_without_preset_is_rejected(self):
+        meta = self._meta(video={"@type": "Video"}, video_encode="AV1")
+        assert self._run(meta) is False
+
+    # ── forbidden audio codecs ──
+
+    def test_mp3_track_is_rejected(self):
+        meta = self._meta(audio=[{"@type": "Audio", "Format": "MP3", "Channels": "2", "Language": "fr"}])
+        assert self._run(meta) is False
+
+    def test_flac_stereo_passes(self):
+        meta = self._meta(audio=[{"@type": "Audio", "Format": "FLAC", "Channels": "2", "Language": "fr"}])
+        assert self._run(meta) is True
+
+    def test_flac_surround_is_rejected(self):
+        meta = self._meta(audio=[{"@type": "Audio", "Format": "FLAC", "Channels": "6", "Language": "fr"}])
+        assert self._run(meta) is False
+
+    def test_remux_is_exempt_from_codec_rules(self):
+        meta = self._meta(audio=[{"@type": "Audio", "Format": "MP3", "Channels": "2", "Language": "fr"}], type="REMUX")
+        assert self._run(meta) is True
+
+    # ── MULTi requires French subs ──
+
+    def test_multi_without_french_subs_is_rejected(self):
+        meta = self._meta(
+            audio=[
+                {"@type": "Audio", "Format": "E-AC-3", "Channels": "6", "Language": "fr"},
+                {"@type": "Audio", "Format": "E-AC-3", "Channels": "6", "Language": "en"},
+            ],
+            original_language="en",
+        )
+        assert self._run(meta) is False
+
+    def test_multi_with_french_subs_passes(self):
+        meta = self._meta(
+            audio=[
+                {"@type": "Audio", "Format": "E-AC-3", "Channels": "6", "Language": "fr"},
+                {"@type": "Audio", "Format": "E-AC-3", "Channels": "6", "Language": "en"},
+            ],
+            text=[{"@type": "Text", "Format": "UTF-8", "Language": "fr"}],
+            original_language="en",
+        )
+        assert self._run(meta) is True
+
+    # ── external files ──
+
+    def test_external_subtitle_file_is_rejected(self):
+        meta = self._meta(filelist=["/downloads/Movie.2024.mkv", "/downloads/Movie.2024.fr.srt"])
+        assert self._run(meta) is False
+
+    def test_archive_is_rejected(self):
+        meta = self._meta(filelist=["/downloads/Movie.2024.mkv", "/downloads/extras.rar"])
+        assert self._run(meta) is False

--- a/tests/test_g3mini.py
+++ b/tests/test_g3mini.py
@@ -936,3 +936,78 @@ class TestG3MINIEncodeCodecLabel:
         name = self._get_name(meta)
         assert 'H265' in name, f"Untouched WEB-DL keeps H265, got: {name!r}"
         assert 'x265' not in name, f"x265 must not appear for a true WEB-DL, got: {name!r}"
+
+
+class TestG3MINIPgsSubtitlesOnEncodes:
+    """PGS subtitles are forbidden on encodes unless additional to a
+    text-based subtitle track of the same language."""
+
+    GOOD_SETTINGS = "cabac=1 / ref=5 / subme=8 / trellis=2"
+
+    @staticmethod
+    def _g3() -> G3MINI:
+        return G3MINI(_config())
+
+    def _meta(self, subtitle_tracks: list[dict[str, Any]], **overrides: Any) -> dict[str, Any]:
+        m = _meta_base(
+            type="ENCODE",
+            video_codec="AVC",
+            video_encode=" x264",
+            source="BluRay",
+            is_disc=None,
+            mediainfo={
+                "media": {
+                    "track": [
+                        {"@type": "Video", "Encoded_Library_Settings": self.GOOD_SETTINGS},
+                        {"@type": "Audio", "Language": "fr"},
+                        *subtitle_tracks,
+                    ]
+                }
+            },
+            audio_languages=["French"],
+            subtitle_languages=[],
+        )
+        m.update(overrides)
+        return m
+
+    def test_pgs_only_language_is_rejected(self):
+        """A language whose only subtitle is PGS blocks the encode (Lola Rennt case)."""
+        meta = self._meta(
+            [
+                {"@type": "Text", "Format": "UTF-8", "Language": "en"},
+                {"@type": "Text", "Format": "PGS", "Language": "fr"},
+            ]
+        )
+        assert asyncio.run(self._g3().get_additional_checks(meta)) is False
+
+    def test_pgs_additional_to_text_track_passes(self):
+        """PGS is fine when a text subtitle of the same language exists."""
+        meta = self._meta(
+            [
+                {"@type": "Text", "Format": "UTF-8", "Language": "fr"},
+                {"@type": "Text", "Format": "PGS", "Language": "fr", "Title": "SDH"},
+            ]
+        )
+        assert asyncio.run(self._g3().get_additional_checks(meta)) is True
+
+    def test_language_variants_count_as_the_same_language(self):
+        """pt vs pt-BR: the text track covers the PGS variant."""
+        meta = self._meta(
+            [
+                {"@type": "Text", "Format": "UTF-8", "Language": "pt"},
+                {"@type": "Text", "Format": "PGS", "Language": "pt-BR"},
+                {"@type": "Text", "Format": "UTF-8", "Language": "fr"},
+            ]
+        )
+        assert asyncio.run(self._g3().get_additional_checks(meta)) is True
+
+    def test_remux_is_not_subject_to_the_rule(self):
+        meta = self._meta(
+            [{"@type": "Text", "Format": "PGS", "Language": "fr"}],
+            type="REMUX",
+        )
+        assert asyncio.run(self._g3().get_additional_checks(meta)) is True
+
+    def test_no_pgs_passes(self):
+        meta = self._meta([{"@type": "Text", "Format": "UTF-8", "Language": "fr"}])
+        assert asyncio.run(self._g3().get_additional_checks(meta)) is True

--- a/tests/test_g3mini.py
+++ b/tests/test_g3mini.py
@@ -1120,3 +1120,47 @@ class TestG3MINIEncodingRules:
     def test_archive_is_rejected(self):
         meta = self._meta(filelist=["/downloads/Movie.2024.mkv", "/downloads/extras.rar"])
         assert self._run(meta) is False
+
+
+class TestG3MINIReviewRegressions:
+    """Edge cases: partial x265 settings, AD.MULTI tags, unlabelled tracks."""
+
+    @staticmethod
+    def _g3() -> G3MINI:
+        return G3MINI(_config())
+
+    def _meta(self, **kwargs: Any) -> dict[str, Any]:
+        return TestG3MINIEncodingRules()._meta(**kwargs)
+
+    def _run(self, meta: dict[str, Any]) -> bool:
+        return asyncio.run(self._g3().get_additional_checks(meta))
+
+    def test_x265_subme_only_is_rejected(self):
+        meta = self._meta(video={"@type": "Video", "Encoded_Library_Settings": "cpuid=x / subme=3"}, video_encode=" x265")
+        assert self._run(meta) is False
+
+    def test_x265_rd_only_is_rejected(self):
+        meta = self._meta(video={"@type": "Video", "Encoded_Library_Settings": "cpuid=x / rd=4"}, video_encode=" x265")
+        assert self._run(meta) is False
+
+    def test_ad_multi_without_french_subs_is_rejected(self):
+        meta = self._meta(
+            audio=[
+                {"@type": "Audio", "Format": "E-AC-3", "Channels": "6", "Language": "fr"},
+                {"@type": "Audio", "Format": "E-AC-3", "Channels": "6", "Language": "en"},
+                {"@type": "Audio", "Format": "E-AC-3", "Channels": "2", "Language": "fr", "Title": "Audiodescription"},
+            ],
+            original_language="en",
+        )
+        meta["has_audiodesc"] = True
+        assert self._run(meta) is False
+
+    def test_unlabelled_text_track_does_not_vouch_for_unlabelled_pgs(self):
+        meta = self._meta(
+            text=[
+                {"@type": "Text", "Format": "UTF-8"},
+                {"@type": "Text", "Format": "PGS"},
+                {"@type": "Text", "Format": "UTF-8", "Language": "fr"},
+            ]
+        )
+        assert self._run(meta) is False

--- a/tests/test_g3mini.py
+++ b/tests/test_g3mini.py
@@ -1164,3 +1164,17 @@ class TestG3MINIReviewRegressions:
             ]
         )
         assert self._run(meta) is False
+
+
+class TestX264PartialSettings:
+    """x264 settings missing subme or trellis are unverifiable → rejected."""
+
+    def _run(self, encoding_settings: str) -> bool:
+        meta = TestG3MINIAdditionalChecksX264Preset()._meta(encoding_settings=encoding_settings)
+        return asyncio.run(G3MINI(_config()).get_additional_checks(meta))
+
+    def test_subme_only_is_rejected(self):
+        assert self._run("cabac=1 / subme=9") is False
+
+    def test_trellis_only_is_rejected(self):
+        assert self._run("cabac=1 / trellis=2") is False


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added expanded release validation for x265 and AV1 encoding presets.
  * Added checks for forbidden MP3 and multichannel FLAC audio.
  * Added validation for MULTi French subtitle requirements.
  * Added handling for external subtitles, archive files, and standalone PGS subtitles.
  * Updated the list of disallowed release groups.

* **Bug Fixes**
  * REMUX releases are now correctly exempt from applicable encoding checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->