### PR TITLE
feat: strip orphaned screenshot headers from reused descriptions

### DIFF
--- a/src/bbcode.py
+++ b/src/bbcode.py
@@ -539,6 +539,16 @@ class BBCODE:
         desc = re.sub(r"\[img=[\s\S]*?\]", "", desc, flags=re.IGNORECASE)
         # desc = re.sub(r"\[URL=[\s\S]*?\]\[\/URL\]", "", desc, flags=re.IGNORECASE)
 
+        # Screenshot headers are orphaned once their images were extracted
+        # above (no [img] survives at this point): drop short lines that are
+        # just a screenshots keyword, with or without [center]/[b]/[color]/
+        # [size] decoration ("SCREENSHOTS", "Screens", "Captures d'écran :"…).
+        _decor = r"(?:\[/?(?:center|b|i|u|size(?:=[^\]]*)?|color(?:=[^\]]*)?)\]\s*)*"
+        _punct = r"[\s:.\-=─━—~*·•]*"
+        _keyword = r"(?:screen\s?shots?|screens|captures?(?:\s+d['’]?[ée]cran)?)"
+        orphan_header_re = re.compile(rf"^\s*{_decor}{_punct}{_keyword}{_punct}{_decor}\s*$", re.IGNORECASE)
+        desc = "\n".join(line for line in desc.split("\n") if not orphan_header_re.match(line))
+
         # Strip trailing whitespace and newlines:
         desc = desc.rstrip()
 

--- a/tests/test_bbcode_sp_cleanup.py
+++ b/tests/test_bbcode_sp_cleanup.py
@@ -127,3 +127,36 @@ def test_comparison_without_header_is_also_removed() -> None:
     cleaned, _ = BBCODE().clean_unit3d_description(desc, "https://blutopia.cc")
     assert "ptpimg" not in cleaned
     assert "Intro." in cleaned and "Outro." in cleaned
+
+
+def test_orphan_screenshot_headers_are_removed() -> None:
+    desc = (
+        "Notes worth keeping.\n"
+        "[center][b][color=#f7942d]SCREENSHOTS[/color][/b][/center]\n"
+        "[url=https://img.example.invalid/w][img]https://img.example.invalid/a.png[/img][/url]\n"
+    )
+    cleaned, images = BBCODE().clean_unit3d_description(desc, "https://blutopia.cc")
+    assert "SCREENSHOTS" not in cleaned
+    assert "Notes worth keeping." in cleaned
+    assert len(images) == 1
+
+
+def test_orphan_header_variants_are_removed() -> None:
+    variants = [
+        "Screens",
+        "Screenshots:",
+        "[b]Screen shots[/b]",
+        "Captures d'écran :",
+        "[center]— Captures —[/center]",
+    ]
+    for line in variants:
+        desc = f"Kept intro.\n{line}\n[img]https://img.example.invalid/a.png[/img]\nKept outro."
+        cleaned, _ = BBCODE().clean_unit3d_description(desc, "https://blutopia.cc")
+        assert "Kept intro." in cleaned and "Kept outro." in cleaned
+        assert cleaned.count("\n") <= 2, f"header not removed for: {line!r} → {cleaned!r}"
+
+
+def test_sentence_containing_screenshots_is_kept() -> None:
+    desc = "These screenshots show the HDR grading difference.\n[img]https://img.example.invalid/a.png[/img]"
+    cleaned, _ = BBCODE().clean_unit3d_description(desc, "https://blutopia.cc")
+    assert "These screenshots show" in cleaned


### PR DESCRIPTION
Image extraction leaves the header line that introduced the shots ('SCREENSHOTS', 'Screens', 'Captures d'écran'…) orphaned in the text, which then collides with the configured screenshot_header or floats meaninglessly. Short keyword-only lines, with or without center/bold/color/size decoration, are dropped after extraction; sentences containing the words are untouched.