### PR TITLE
feat: source description section

### DIFF
--- a/data/example-config.py
+++ b/data/example-config.py
@@ -524,6 +524,10 @@ config = {
             "announce_url": "https://c411.org/announce/YOUR_PASSKEY",
             # Include screenshots in the upload description (default: False)
             "include_screenshots": False,
+            # Append the reused/base description (cleaned text grabbed from
+            # another tracker, or your custom description) as a
+            # "Notes de la release d'origine" section in the fiche
+            "include_source_description": False,
         },
         "CZ": {
             # Instead of using the tracker acronym for folder name when sym/hard linking, you can use a custom name
@@ -1026,6 +1030,10 @@ config = {
             "anon": False,
             # Include screenshot thumbnails in the description (default True)
             "include_screenshots": True,
+            # Append the reused/base description (cleaned text grabbed from
+            # another tracker, or your custom description) as a
+            # "Notes de la release d'origine" section in the fiche
+            "include_source_description": False,
             "link_dir_name": "",
         },
         "UTP": {

--- a/data/example-config.py
+++ b/data/example-config.py
@@ -1013,6 +1013,11 @@ config = {
             "modq": False,
         },
         "V3X": {
+            # Note: the site displays the .torrent's internal name, so UA
+            # renames the torrent root to the generated release name. Seeding
+            # it therefore needs a qBittorrent or rTorrent client with linking
+            # enabled (the link folder takes the new name); without one, the
+            # rename is skipped and the fiche shows the on-disk name.
             "api_key": "V3X api key (upload scope)",
             # Site credentials — the dupe search browses the catalog through a
             # web session (API keys are upload-only since the 2026-08 update).
@@ -1020,13 +1025,6 @@ config = {
             "username": "",
             "password": "",
             "announce_url": "get from V3X",
-            # The site displays the .torrent's internal name: UA renames the
-            # torrent root to the generated release name (single files are
-            # wrapped in a folder so the inner file keeps its original,
-            # cross-seedable name). The rename only happens with a qBittorrent
-            # client that has linking enabled — the link folder takes the new
-            # name so seeding works without touching the on-disk content
-            # (unless your content path already carries that exact name).
             "anon": False,
             # Include screenshot thumbnails in the description (default True)
             "include_screenshots": True,

--- a/src/trackers/C411.py
+++ b/src/trackers/C411.py
@@ -1081,6 +1081,13 @@ class C411(FrenchTrackerMixin):
 
         parts.append("")
 
+        # ── Notes de la release d'origine (opt-in: include_source_description) ──
+        source_desc = await self._get_source_description(meta)
+        if source_desc:
+            parts.append(f"        [color={C}]Notes de la release d'origine[/color]")
+            parts.append(f"    [font=Verdana][size=14]{source_desc}[/size][/font]")
+            parts.append("")
+
         # ── Captures d'écran  (opt-in via config: include_screenshots) ──
         include_screens = self.config["TRACKERS"].get(self.tracker, {}).get("include_screenshots", False)
         image_list: list[dict[str, Any]] = meta.get("image_list", []) if include_screens else []

--- a/src/trackers/FRENCH.py
+++ b/src/trackers/FRENCH.py
@@ -2215,6 +2215,20 @@ class FrenchTrackerMixin:
 
         return content
 
+    async def _get_source_description(self, meta: Meta) -> str:
+        """Reused/base description text (tmp DESCRIPTION.txt), already cleaned
+        by the description pipeline, for trackers that opt in via the
+        per-tracker ``include_source_description`` config flag.
+        """
+        if not self.config["TRACKERS"].get(self.tracker, {}).get("include_source_description", False):  # type: ignore[attr-defined]
+            return ""
+        path = os.path.join(str(meta.get("base_dir", "")), "tmp", str(meta.get("uuid", "")), "DESCRIPTION.txt")
+        try:
+            async with aiofiles.open(path, encoding="utf-8") as f:
+                return (await f.read()).strip()
+        except OSError:
+            return ""
+
     async def _get_or_generate_nfo(self, meta: Meta) -> Union[str, None]:
         """Pick the NFO to upload: the release's own NFO when present,
         otherwise a MediaInfo file or a generated scene NFO.

--- a/src/trackers/V3X.py
+++ b/src/trackers/V3X.py
@@ -505,6 +505,13 @@ class V3X(FrenchTrackerMixin):
             parts.append(f"[b][color={C}]Groupe :[/color][/b] {group}")
         parts.append("")
 
+        # ── Notes de la release d'origine (opt-in: include_source_description) ──
+        source_desc = await self._get_source_description(meta)
+        if source_desc:
+            parts.append(f"[b][color={C}][size=130]━━━ Notes de la release d'origine ━━━[/size][/color][/b]")
+            parts.append(source_desc)
+            parts.append("")
+
         # ── Screenshots: clickable thumbnails, two per row. The V3X parser
         # only understands a bare [img] tag (no [img=N] sizing), so small
         # renderings depend on the image host providing a thumbnail img_url.

--- a/tests/test_c411.py
+++ b/tests/test_c411.py
@@ -3230,3 +3230,31 @@ class TestBonusReleasesAreExcluded:
         names = " ".join(d.get("name", "") for d in dupes)
         assert "BONUS" in names
         assert "FRENCH.1080p.WEB.AC3.5.1" not in names
+
+
+class TestSourceDescriptionSection:
+    """Optional 'Notes de la release d'origine' section from DESCRIPTION.txt."""
+
+    def _desc(self, tmp_path: Any, *, flag: bool, content: str | None) -> str:
+        config = _config()
+        config["TRACKERS"]["C411"]["include_source_description"] = flag
+        c = C411(config)
+        uuid = "X"
+        if content is not None:
+            import pathlib
+
+            d = pathlib.Path(tmp_path) / "tmp" / uuid
+            d.mkdir(parents=True, exist_ok=True)
+            (d / "DESCRIPTION.txt").write_text(content, encoding="utf-8")
+        meta = _meta_base()
+        meta.update({"base_dir": str(tmp_path), "uuid": uuid})
+        return asyncio.run(c._build_description(meta))
+
+    def test_section_included_when_enabled(self, tmp_path: Any):
+        desc = self._desc(tmp_path, flag=True, content="Encoder notes worth keeping.")
+        assert "Notes de la release d'origine" in desc
+        assert "Encoder notes worth keeping." in desc
+
+    def test_section_absent_by_default(self, tmp_path: Any):
+        desc = self._desc(tmp_path, flag=False, content="Encoder notes worth keeping.")
+        assert "Notes de la release" not in desc

--- a/tests/test_v3x.py
+++ b/tests/test_v3x.py
@@ -1086,3 +1086,48 @@ class TestApprovedImageHosts:
         from src.rehostimages import TRACKERS_WITH_IMAGE_HOST_REQUIREMENTS
 
         assert "V3X" in TRACKERS_WITH_IMAGE_HOST_REQUIREMENTS
+
+
+class TestSourceDescriptionSection:
+    """The reused/base description is appended as an optional fiche section."""
+
+    def _desc(self, monkeypatch: Any, tmp_path: Any, *, flag: bool, content: str | None) -> str:
+        config = _config()
+        config["TRACKERS"]["V3X"]["include_source_description"] = flag
+        tracker = V3X(config)
+
+        async def fake_localized(*args: Any, **kwargs: Any) -> dict[str, Any]:
+            return {}
+
+        async def fake_mi(meta: Any) -> str:
+            return ""
+
+        monkeypatch.setattr(tracker.tmdb_manager, "get_tmdb_localized_data", fake_localized)
+        monkeypatch.setattr(tracker, "_format_audio_bbcode", lambda mi, meta: [])
+        monkeypatch.setattr(tracker, "_format_subtitle_bbcode", lambda mi, meta: [])
+        monkeypatch.setattr(tracker, "_get_mediainfo_text", fake_mi)
+        uuid = "X"
+        if content is not None:
+            (tmp_path / "tmp" / uuid).mkdir(parents=True, exist_ok=True)
+            (tmp_path / "tmp" / uuid / "DESCRIPTION.txt").write_text(content, encoding="utf-8")
+        meta = {"base_dir": str(tmp_path), "uuid": uuid, "title": "Some Movie", "category": "MOVIE"}
+        return asyncio.run(tracker._build_description(meta))
+
+    def test_section_included_when_enabled(self, monkeypatch: Any, tmp_path: Any):
+        desc = self._desc(monkeypatch, tmp_path, flag=True, content="Encoder notes worth keeping.")
+        assert "━━━ Notes de la release d'origine ━━━" in desc
+        assert "Encoder notes worth keeping." in desc
+        # Before the screenshots/end, after the Release section
+        assert desc.index("━━━ Release ━━━") < desc.index("Notes de la release")
+
+    def test_section_absent_by_default(self, monkeypatch: Any, tmp_path: Any):
+        desc = self._desc(monkeypatch, tmp_path, flag=False, content="Encoder notes worth keeping.")
+        assert "Notes de la release" not in desc
+
+    def test_section_absent_without_content(self, monkeypatch: Any, tmp_path: Any):
+        desc = self._desc(monkeypatch, tmp_path, flag=True, content=None)
+        assert "Notes de la release" not in desc
+
+    def test_section_absent_when_file_is_blank(self, monkeypatch: Any, tmp_path: Any):
+        desc = self._desc(monkeypatch, tmp_path, flag=True, content="\n\n  \n")
+        assert "Notes de la release" not in desc


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional setting to include cleaned original release descriptions in C411 and V3X tracker fiches.
  * Included source descriptions under a dedicated “Notes de la release d'origine” section when available.

* **Documentation**
  * Clarified V3X torrent-root renaming, linking requirements, and fallback behavior when linking is unavailable.

* **Bug Fixes**
  * Source descriptions are now safely omitted when disabled, unavailable, unreadable, or blank.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->