### PR TITLE
feat(V3X): send the IMDb link instead of the title field

### DIFF
--- a/src/trackers/V3X.py
+++ b/src/trackers/V3X.py
@@ -11,9 +11,11 @@
 #   POST /api/torrents                  upload — multipart, Authorization: Bearer <api key>
 #                                       (?apikey= also accepted; X-Api-Key is NOT)
 #     required: file (.torrent), categoryId (SUBcategory id), rightsDeclared;
-#               movies/series also require nfo and tmdbId (or tmdbUrl)
-#     accepted: name, description, descriptionFormat, language, title,
+#               movies/series also require nfo and tmdbUrl (or tmdbId)
+#     accepted: name, description, descriptionFormat, language,
 #               posterUrl, backdropUrl, anonymous
+#     (title exists but must be left empty — the IMDb tmdbUrl auto-fills
+#      the fiche title site-side)
 #   Browse routes (/torrents listing & detail) require a web session cookie —
 #   API keys are rejected there since the 2026-08 site update.
 
@@ -633,11 +635,13 @@ class V3X(FrenchTrackerMixin):
         }
         if nfo_text:
             data["nfo"] = nfo_text
-        if int(meta.get("tmdb_id") or 0):
+        # Never send the title field — provide the IMDb link (tmdbUrl)
+        # instead so the site auto-fills the fiche title itself.
+        imdb_digits = re.sub(r"^tt", "", str(meta.get("imdb_id") or ""), flags=re.IGNORECASE)
+        if imdb_digits.isdigit() and int(imdb_digits) > 0:
+            data["tmdbUrl"] = f"https://www.imdb.com/title/tt{imdb_digits.zfill(7)}/"
+        elif int(meta.get("tmdb_id") or 0):
             data["tmdbId"] = str(meta["tmdb_id"])
-        fr_title = str(meta.get("frtitle") or "") or await self._get_french_title(meta)
-        if fr_title:
-            data["title"] = fr_title
         if meta.get("poster"):
             data["posterUrl"] = str(meta["poster"])
         if meta.get("backdrop"):

--- a/tests/test_v3x.py
+++ b/tests/test_v3x.py
@@ -855,17 +855,30 @@ def test_rename_allowed_with_rtorrent_linking(tmp_path: Any):
     assert Torrent.read(str(out / "[V3X].torrent")).name == "Un.Film.2024.VOSTFR.1080p.WEB-GRP"
 
 
-def test_upload_sends_title_and_artwork_fields(monkeypatch: Any, tmp_path: Any):
+def test_upload_sends_imdb_url_and_artwork_fields(monkeypatch: Any, tmp_path: Any):
     name = "Some.Movie.2024.MULTi.VFF.1080p.WEB-GRP"
     tracker, meta = _prep_upload(monkeypatch, tmp_path, name)
-    meta["frtitle"] = "Un Film"
+    meta["imdb_id"] = 47296
     meta["poster"] = "https://image.tmdb.org/t/p/original/poster.jpg"
     meta["backdrop"] = "https://image.tmdb.org/t/p/original/backdrop.jpg"
     asyncio.run(tracker.upload(meta, ""))
     data = _FakeClient.captured["data"]
-    assert data["title"] == "Un Film"
+    # No title field: the IMDb link auto-fills the fiche title site-side
+    assert "title" not in data
+    assert data["tmdbUrl"] == "https://www.imdb.com/title/tt0047296/"
+    assert "tmdbId" not in data
     assert data["posterUrl"] == "https://image.tmdb.org/t/p/original/poster.jpg"
     assert data["backdropUrl"] == "https://image.tmdb.org/t/p/original/backdrop.jpg"
+
+
+def test_upload_falls_back_to_tmdb_id_without_imdb(monkeypatch: Any, tmp_path: Any):
+    tracker, meta = _prep_upload(monkeypatch, tmp_path, "Some.Movie.2024.1080p.WEB-GRP")
+    meta["tmdb_id"] = 693134
+    asyncio.run(tracker.upload(meta, ""))
+    data = _FakeClient.captured["data"]
+    assert data["tmdbId"] == "693134"
+    assert "tmdbUrl" not in data
+    assert "title" not in data
 
 
 def test_upload_omits_artwork_when_absent(monkeypatch: Any, tmp_path: Any):


### PR DESCRIPTION
The title field must stay empty: providing the IMDb URL (tmdbUrl) lets the site auto-fill the fiche title itself. tmdbId remains as the fallback when no IMDb id is known, and the French-title lookup for the upload payload is gone with the field.