### PR TITLE
feat(C411/V3X): prefer the French-localized TMDB poster

### DIFF
--- a/src/trackers/C411.py
+++ b/src/trackers/C411.py
@@ -819,10 +819,15 @@ class C411(FrenchTrackerMixin):
         year = meta.get("year", "")
 
         # ── Header: Title + Year + Poster (centered) ──
-        poster = meta.get("poster", "") or ""
-        poster_w500 = poster
-        if "image.tmdb.org/t/p/" in poster:
-            poster_w500 = re.sub(r"/t/p/[^/]+/", "/t/p/w500/", poster)
+        # Prefer the French-localized poster from the language=fr TMDB response
+        fr_poster_path = str(fr_data.get("poster_path") or "")
+        if fr_poster_path:
+            poster_w500 = f"https://image.tmdb.org/t/p/w500{fr_poster_path}"
+        else:
+            poster = meta.get("poster", "") or ""
+            poster_w500 = poster
+            if "image.tmdb.org/t/p/" in poster:
+                poster_w500 = re.sub(r"/t/p/[^/]+/", "/t/p/w500/", poster)
 
         parts.append(f"[center][b][font=Verdana][color={C}][size=28]{fr_title} ({year})[/size][/color][/font][/b]")
         if poster_w500:

--- a/src/trackers/V3X.py
+++ b/src/trackers/V3X.py
@@ -347,9 +347,16 @@ class V3X(FrenchTrackerMixin):
             parts.append(f"[b][color={C}][size=200]{heading}[/size][/color][/b]")
             parts.append("")
 
-        poster = str(meta.get("poster") or "")
-        if "image.tmdb.org/t/p/" in poster:
-            poster = re.sub(r"/t/p/[^/]+/", "/t/p/w500/", poster)
+        # Prefer the French-localized poster (the language=fr TMDB response
+        # already fetched above localizes poster_path when a FR variant exists)
+        fr_poster_path = str(fr_data.get("poster_path") or "")
+        if fr_poster_path:
+            poster = f"https://image.tmdb.org/t/p/w500{fr_poster_path}"
+            meta["fr_poster"] = f"https://image.tmdb.org/t/p/original{fr_poster_path}"
+        else:
+            poster = str(meta.get("poster") or "")
+            if "image.tmdb.org/t/p/" in poster:
+                poster = re.sub(r"/t/p/[^/]+/", "/t/p/w500/", poster)
         if poster:
             parts.append(f"[img]{poster}[/img]")
             parts.append("")
@@ -638,8 +645,10 @@ class V3X(FrenchTrackerMixin):
         fr_title = str(meta.get("frtitle") or "") or await self._get_french_title(meta)
         if fr_title:
             data["title"] = fr_title
-        if meta.get("poster"):
-            data["posterUrl"] = str(meta["poster"])
+        if meta.get("fr_poster") or meta.get("poster"):
+            # fr_poster is set by _build_description when a French-localized
+            # poster exists on TMDB
+            data["posterUrl"] = str(meta.get("fr_poster") or meta["poster"])
         if meta.get("backdrop"):
             data["backdropUrl"] = str(meta["backdrop"])
         # MediaInfo-based tag first (knows VOF/VOQ/VFB/AD/MUET); fall back

--- a/tests/test_c411.py
+++ b/tests/test_c411.py
@@ -3230,3 +3230,18 @@ class TestBonusReleasesAreExcluded:
         names = " ".join(d.get("name", "") for d in dupes)
         assert "BONUS" in names
         assert "FRENCH.1080p.WEB.AC3.5.1" not in names
+
+
+class TestFrenchPoster:
+    def test_description_prefers_french_poster(self, monkeypatch: Any):
+        c = C411(_config())
+
+        async def fake_localized(*args: Any, **kwargs: Any) -> dict[str, Any]:
+            return {"title": "Un Film", "poster_path": "/frposter.jpg"}
+
+        monkeypatch.setattr(c.tmdb_manager, "get_tmdb_localized_data", fake_localized)
+        meta = _meta_base()
+        meta["poster"] = "https://image.tmdb.org/t/p/original/default.jpg"
+        desc = asyncio.run(c._build_description(meta))
+        assert "https://image.tmdb.org/t/p/w500/frposter.jpg" in desc
+        assert "default.jpg" not in desc

--- a/tests/test_v3x.py
+++ b/tests/test_v3x.py
@@ -1086,3 +1086,43 @@ class TestApprovedImageHosts:
         from src.rehostimages import TRACKERS_WITH_IMAGE_HOST_REQUIREMENTS
 
         assert "V3X" in TRACKERS_WITH_IMAGE_HOST_REQUIREMENTS
+
+
+def test_description_prefers_french_poster(monkeypatch: Any, tmp_path: Any):
+    tracker = V3X(_config())
+
+    async def fake_localized(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        return {"poster_path": "/frposter.jpg"}
+
+    async def fake_mi(meta: Any) -> str:
+        return ""
+
+    monkeypatch.setattr(tracker.tmdb_manager, "get_tmdb_localized_data", fake_localized)
+    monkeypatch.setattr(tracker, "_format_audio_bbcode", lambda mi, meta: [])
+    monkeypatch.setattr(tracker, "_format_subtitle_bbcode", lambda mi, meta: [])
+    monkeypatch.setattr(tracker, "_get_mediainfo_text", fake_mi)
+    meta = {"base_dir": str(tmp_path), "uuid": "X", "title": "Some Movie", "category": "MOVIE", "poster": "https://image.tmdb.org/t/p/original/default.jpg"}
+    desc = asyncio.run(tracker._build_description(meta))
+    assert "[img]https://image.tmdb.org/t/p/w500/frposter.jpg[/img]" in desc
+    assert "default.jpg" not in desc
+    # And the upload field will carry the FR poster too
+    assert meta["fr_poster"] == "https://image.tmdb.org/t/p/original/frposter.jpg"
+
+
+def test_description_falls_back_to_default_poster(monkeypatch: Any, tmp_path: Any):
+    tracker = V3X(_config())
+
+    async def fake_localized(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        return {}
+
+    async def fake_mi(meta: Any) -> str:
+        return ""
+
+    monkeypatch.setattr(tracker.tmdb_manager, "get_tmdb_localized_data", fake_localized)
+    monkeypatch.setattr(tracker, "_format_audio_bbcode", lambda mi, meta: [])
+    monkeypatch.setattr(tracker, "_format_subtitle_bbcode", lambda mi, meta: [])
+    monkeypatch.setattr(tracker, "_get_mediainfo_text", fake_mi)
+    meta = {"base_dir": str(tmp_path), "uuid": "X", "title": "Some Movie", "category": "MOVIE", "poster": "https://image.tmdb.org/t/p/original/default.jpg"}
+    desc = asyncio.run(tracker._build_description(meta))
+    assert "[img]https://image.tmdb.org/t/p/w500/default.jpg[/img]" in desc
+    assert "fr_poster" not in meta


### PR DESCRIPTION
The language=fr TMDB response already fetched for the synopsis localizes poster_path when a French variant exists — use it for the fiche poster on both trackers, and for V3X's posterUrl upload field. Default artwork remains the fallback.