### PR TITLE
fix: rotate to the next approved image host when zero images upload

### DIFF
--- a/src/rehostimages.py
+++ b/src/rehostimages.py
@@ -628,6 +628,18 @@ async def _handle_image_upload(
         )
         if uploaded_images:
             meta[new_images_key] = uploaded_images
+        elif not meta.get(new_images_key):
+            # Zero uploads means this host failed outright (e.g. HTTP 413 on
+            # oversized 4K screenshots). Without this, the empty result sails
+            # through the validation below (all([]) is True) and is returned
+            # as success, so the caller never rotates to the next approved
+            # host. Mark the host failed and ask for a retry instead.
+            current_host = str(meta.get("imghost", "") or "")
+            session_failed = cast(list[str], meta.setdefault("failed_image_hosts", []))
+            if current_host and current_host not in session_failed:
+                session_failed.append(current_host)
+            console.print(f"[yellow]No images uploaded to '{current_host}' — trying the next approved host.[/yellow]")
+            return [], True, images_reuploaded
 
         if meta["debug"]:
             console.print(f"[debug] Updated {new_images_key} with {len(uploaded_images)} images.")

--- a/tests/test_rehost_rotation.py
+++ b/tests/test_rehost_rotation.py
@@ -1,0 +1,54 @@
+"""Regression: a host that uploads zero images must trigger rotation to the
+next approved host instead of returning an empty result as success."""
+
+import asyncio
+import pathlib
+from typing import Any
+
+from src.rehostimages import _handle_image_upload
+
+
+class _Uploader:
+    async def upload_screens(self, *args: Any, **kwargs: Any) -> Any:
+        return [], 0  # host accepts nothing (e.g. HTTP 413 on every file)
+
+
+class _Screens:
+    async def screenshots(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+
+def test_zero_uploads_marks_host_failed_and_requests_retry(tmp_path: pathlib.Path):
+    uuid = "Movie.2024.2160p.Remux-GRP"
+    shots = tmp_path / "tmp" / uuid
+    shots.mkdir(parents=True)
+    (shots / "abc123.png").write_bytes(b"x")
+    meta = {
+        "base_dir": str(tmp_path),
+        "uuid": uuid,
+        "debug": False,
+        "is_disc": None,
+        "filelist": ["/x/movie.mkv"],
+        "image_list": [{"img_url": "https://lostimg.cc/abc123.png", "raw_url": "https://lostimg.cc/abc123.png", "web_url": "https://lostimg.cc/abc123.png"}],
+        "imghost": "pixhost",
+        "title": "Movie",
+        "video": "/x/movie.mkv",
+    }
+    default_config = {"img_host_1": "pixhost", "img_host_2": "imgbb", "screens": "1"}
+
+    result, retry_mode, _reup = asyncio.run(
+        _handle_image_upload(
+            meta,
+            "V3X",
+            {"pixhost.to": "pixhost", "ibb.co": "imgbb"},
+            approved_image_hosts=["pixhost", "imgbb"],
+            img_host_index=1,
+            default_config=default_config,
+            takescreens_manager=_Screens(),
+            uploadscreens_manager=_Uploader(),
+        )
+    )
+
+    assert result == []
+    assert retry_mode is True
+    assert "pixhost" in meta.get("failed_image_hosts", [])


### PR DESCRIPTION
A host that accepts nothing (e.g. pixhost returning HTTP 413 on oversized 4K screenshots) produced an empty upload list that sailed through the validation (all([]) is vacuously true) and was returned as success, so the rotation loop never tried the remaining approved hosts and the description fell back to the unapproved originals. The host is now marked failed for the session and a retry is requested, letting the rotation reach the next configured approved host.