### PR TITLE
feat: strip the Shared-with-Upload-Assistant signature from reused de…

### DIFF
--- a/src/bbcode.py
+++ b/src/bbcode.py
@@ -548,6 +548,7 @@ class BBCODE:
             r"Powered by GG-BOT Upload Assistant(?:\s+v?[\w.]+)?",
             r"Created by Hentai Bot(?:\s+v?[\w.]+)?",
             r"Brought to you by Only-Uploader(?:\s+v?[\w.]+)?",
+            r"Shared with Upload-Assistant(?:\s+v?[\w.]+)?(?:\s+\(fork\))?",
             r"Please PM [\w.\-]{1,40} if you have any issues(?: or need a reseed)?",
         ):
             desc = re.sub(rf"^\s*{_sig_decor}{_sig_marker}\s*[.!]?\s*{_sig_decor}\s*$\n?", "", desc, flags=re.IGNORECASE | re.MULTILINE)

--- a/tests/test_bbcode_sp_cleanup.py
+++ b/tests/test_bbcode_sp_cleanup.py
@@ -300,3 +300,10 @@ def test_h3_wrapped_ornament_header_and_leftover_close_are_removed() -> None:
     matched = "[h3]intro[/h3]\nBody."
     cleaned2, _ = BBCODE().clean_unit3d_description(matched, "https://lst.gg")
     assert "[h3]intro[/h3]" in cleaned2
+
+
+def test_shared_with_upload_assistant_signature_is_removed() -> None:
+    desc = "Kept.\n[right][url=https://github.com/wastaken7/Upload-Assistant][size=4]Shared with Upload-Assistant v3.4 (fork)[/size][/url][/right]\nAlso kept."
+    cleaned, _ = BBCODE().clean_unit3d_description(desc, "https://lst.gg")
+    assert "Upload-Assistant" not in cleaned
+    assert "Kept." in cleaned and "Also kept." in cleaned

--- a/tests/test_bbcode_sp_cleanup.py
+++ b/tests/test_bbcode_sp_cleanup.py
@@ -303,7 +303,13 @@ def test_h3_wrapped_ornament_header_and_leftover_close_are_removed() -> None:
 
 
 def test_shared_with_upload_assistant_signature_is_removed() -> None:
-    desc = "Kept.\n[right][url=https://github.com/wastaken7/Upload-Assistant][size=4]Shared with Upload-Assistant v3.4 (fork)[/size][/url][/right]\nAlso kept."
-    cleaned, _ = BBCODE().clean_unit3d_description(desc, "https://lst.gg")
-    assert "Upload-Assistant" not in cleaned
-    assert "Kept." in cleaned and "Also kept." in cleaned
+    signatures = [
+        "[right][url=https://github.com/wastaken7/Upload-Assistant][size=4]Shared with Upload-Assistant v3.4 (fork)[/size][/url][/right]",
+        "Shared with Upload-Assistant",
+        "Shared with Upload-Assistant v3.4",
+        "Shared with Upload-Assistant (fork)",
+    ]
+    for signature in signatures:
+        desc = f"Kept.\n{signature}\nAlso kept."
+        cleaned, _ = BBCODE().clean_unit3d_description(desc, "https://lst.gg")
+        assert cleaned == "Kept.\nAlso kept.", f"signature not fully removed: {signature!r} → {cleaned!r}"


### PR DESCRIPTION
…scriptions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed standalone “Shared with Upload-Assistant” signature lines from cleaned descriptions, including version and fork variants.
  * Preserved surrounding description content and formatting.
  * Corrected removal of linked, right-aligned signature text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->