### PR TITLE
feat: per-tracker opt-out of reused description text

### DIFF
--- a/data/example-config.py
+++ b/data/example-config.py
@@ -973,6 +973,10 @@ config = {
             "anon": False,
             # Upload with Exclusive flag (team of staff only)
             "exclusive": False,
+            # The tracker requires descriptions written in French, so the
+            # (English) description text reused from other trackers is left
+            # out of uploads; reused images, NFO and templates still apply.
+            "include_reused_description": False,
         },
         "TTG": {
             # Instead of using the tracker acronym for folder name when sym/hard linking, you can use a custom name

--- a/src/get_desc.py
+++ b/src/get_desc.py
@@ -552,8 +552,13 @@ class DescriptionBuilder:
                     desc_parts.append(f"[center][pre]{title}[/pre][/center]\n")
                 desc_parts.append(f"[center][pre]{episode_overview}[/pre][/center]\n")
 
-        # Description that may come from API requests
-        meta_description_value = meta.get("description", "")
+        # Description that may come from API requests. A tracker whose rules
+        # exclude descriptions written in another language can opt out of the
+        # text reused from other trackers with include_reused_description:
+        # False in its config section — images, NFO and templates still apply.
+        tracker_cfg = cast(dict[str, Any], self.config.get("TRACKERS", {}).get(self.tracker, {}) or {})
+        reused_excluded = meta.get("saved_description") and not bool(tracker_cfg.get("include_reused_description", True))
+        meta_description_value = "" if reused_excluded else meta.get("description", "")
         if isinstance(meta_description_value, str):
             meta_description = meta_description_value
         elif meta_description_value is None:

--- a/tests/test_reused_description_optout.py
+++ b/tests/test_reused_description_optout.py
@@ -1,0 +1,59 @@
+# A tracker can opt out of the description text reused from other trackers
+# (include_reused_description: False in its config section); a description
+# the user provided themselves is never affected.
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+from src.get_desc import DescriptionBuilder
+
+
+def _config(include: bool) -> dict:
+    return {
+        "DEFAULT": {"screens": 0, "multiScreens": 0},
+        "TRACKERS": {"TOS": {"include_reused_description": include}},
+    }
+
+
+def _meta(saved: bool) -> dict:
+    return {
+        "base_dir": "/tmp",
+        "uuid": "x",
+        "description": "An English plot summary grabbed elsewhere.",
+        "saved_description": saved,
+        "image_list": [],
+        "language_checked": True,
+        "subtitle_languages": [],
+        "debug": False,
+        "ua_signature": "sig",
+    }
+
+
+def _build(meta: dict, config: dict) -> str:
+    builder = DescriptionBuilder("TOS", config)
+    quiet = AsyncMock(return_value="")
+    with (
+        patch.object(DescriptionBuilder, "get_custom_header", quiet),
+        patch.object(DescriptionBuilder, "get_logo_section", AsyncMock(return_value=("", ""))),
+        patch.object(DescriptionBuilder, "get_bluray_section", AsyncMock(return_value=("", ""))),
+        patch.object(DescriptionBuilder, "get_tv_info", AsyncMock(return_value=("", "", ""))),
+        patch.object(DescriptionBuilder, "get_user_description", quiet),
+        patch.object(DescriptionBuilder, "get_personal_note", quiet),
+        patch.object(DescriptionBuilder, "menu_section", quiet),
+        patch.object(DescriptionBuilder, "get_tonemapped_header", quiet),
+        patch.object(DescriptionBuilder, "_handle_discs_and_screenshots", quiet),
+        patch.object(DescriptionBuilder, "get_custom_signature", quiet),
+    ):
+        return asyncio.run(builder.unit3d_edit_desc(meta))
+
+
+def test_reused_description_is_dropped_when_opted_out() -> None:
+    assert "English plot summary" not in _build(_meta(saved=True), _config(include=False))
+
+
+def test_reused_description_kept_by_default() -> None:
+    assert "English plot summary" in _build(_meta(saved=True), _config(include=True))
+
+
+def test_user_description_survives_the_optout() -> None:
+    assert "English plot summary" in _build(_meta(saved=False), _config(include=False))


### PR DESCRIPTION
include_reused_description: False in a tracker's config section leaves the description text grabbed from other trackers out of that tracker's uploads, while reused images, NFO and templates still apply.