### PR TITLE
fix: send the single-episode MediaInfo when the release NFO is a mult…

### DIFF
--- a/src/nfo_generator.py
+++ b/src/nfo_generator.py
@@ -10,6 +10,21 @@ import aiofiles
 from src.console import console
 
 
+def is_multi_episode_nfo(nfo_path: str) -> bool:
+    """Detect an NFO that concatenates the MediaInfo dump of many episodes.
+
+    Some season packs ship one giant NFO holding the full MediaInfo of every
+    episode. Such a file is not a release NFO and is far too long for a
+    tracker's NFO field; a single MediaInfo dump contains exactly one
+    "Complete name" line, so two or more means a concatenation.
+    """
+    try:
+        with open(nfo_path, encoding="utf-8", errors="replace") as f:
+            return f.read().count("Complete name") >= 2
+    except OSError:
+        return False
+
+
 class SceneNfoGenerator:
     """Generates MediaInfo-based NFO files for releases."""
 

--- a/src/nfo_generator.py
+++ b/src/nfo_generator.py
@@ -10,7 +10,7 @@ import aiofiles
 from src.console import console
 
 
-def is_multi_episode_nfo(nfo_path: str) -> bool:
+async def is_multi_episode_nfo(nfo_path: str) -> bool:
     """Detect an NFO that concatenates the MediaInfo dump of many episodes.
 
     Some season packs ship one giant NFO holding the full MediaInfo of every
@@ -19,8 +19,8 @@ def is_multi_episode_nfo(nfo_path: str) -> bool:
     "Complete name" line, so two or more means a concatenation.
     """
     try:
-        with open(nfo_path, encoding="utf-8", errors="replace") as f:
-            return f.read().count("Complete name") >= 2
+        async with aiofiles.open(nfo_path, encoding="utf-8", errors="replace") as f:
+            return (await f.read()).count("Complete name") >= 2
     except OSError:
         return False
 

--- a/src/trackers/C411.py
+++ b/src/trackers/C411.py
@@ -24,6 +24,7 @@ from unidecode import unidecode
 
 from src.console import console
 from src.get_desc import DescriptionBuilder
+from src.nfo_generator import is_multi_episode_nfo
 from src.rehostimages import RehostImagesManager
 from src.tmdb import TmdbManager
 from src.trackers.COMMON import COMMON
@@ -1336,7 +1337,10 @@ class C411(FrenchTrackerMixin):
         # ── NFO file (required by C411) ──
         nfo_path = await self._get_or_generate_nfo(meta)
         nfo_bytes = b""
-        if nfo_files:
+        # A multi-episode MediaInfo concatenation stays in the torrent (for
+        # cross-seed integrity) but is too long for the API NFO field, where
+        # the generated single-episode MediaInfo NFO is sent instead.
+        if nfo_files and not is_multi_episode_nfo(nfo_files[0]):
             async with aiofiles.open(nfo_files[0], "rb") as f:
                 nfo_bytes = await f.read()
         elif nfo_path and os.path.exists(nfo_path):

--- a/src/trackers/C411.py
+++ b/src/trackers/C411.py
@@ -1340,7 +1340,7 @@ class C411(FrenchTrackerMixin):
         # A multi-episode MediaInfo concatenation stays in the torrent (for
         # cross-seed integrity) but is too long for the API NFO field, where
         # the generated single-episode MediaInfo NFO is sent instead.
-        used_release_nfo = bool(nfo_files) and not is_multi_episode_nfo(nfo_files[0])
+        used_release_nfo = bool(nfo_files) and not await is_multi_episode_nfo(nfo_files[0])
         if used_release_nfo:
             async with aiofiles.open(nfo_files[0], "rb") as f:
                 nfo_bytes = await f.read()

--- a/src/trackers/C411.py
+++ b/src/trackers/C411.py
@@ -1340,7 +1340,8 @@ class C411(FrenchTrackerMixin):
         # A multi-episode MediaInfo concatenation stays in the torrent (for
         # cross-seed integrity) but is too long for the API NFO field, where
         # the generated single-episode MediaInfo NFO is sent instead.
-        if nfo_files and not is_multi_episode_nfo(nfo_files[0]):
+        used_release_nfo = bool(nfo_files) and not is_multi_episode_nfo(nfo_files[0])
+        if used_release_nfo:
             async with aiofiles.open(nfo_files[0], "rb") as f:
                 nfo_bytes = await f.read()
         elif nfo_path and os.path.exists(nfo_path):
@@ -1463,8 +1464,10 @@ class C411(FrenchTrackerMixin):
                                 if mi_append_to_nfo:
                                     async with aiofiles.open(mi_append_to_nfo, "rb") as f:
                                         mi_bytes = await f.read()
-                                    # If the NFO was rejected for being too large or invalid, send only the mediainfo
-                                    if "volumineux" in api_message.lower() or "invalide" in api_message.lower():
+                                    # If the NFO was rejected for being too large or invalid, send only the mediainfo.
+                                    # Same when nfo_bytes already is the MediaInfo dump (no release NFO
+                                    # was used): appending mi_bytes would duplicate it.
+                                    if "volumineux" in api_message.lower() or "invalide" in api_message.lower() or not used_release_nfo:
                                         console.print("[yellow]C411 - NFO rejected (too large or invalid), retrying with mediainfo only[/yellow]")
                                         nfo_bytes = mi_bytes
                                     else:

--- a/src/trackers/FRENCH.py
+++ b/src/trackers/FRENCH.py
@@ -2236,7 +2236,7 @@ class FrenchTrackerMixin:
         Useful for trackers that expect an NFO with every upload (e.g. C411).
         """
         nfo_files = self._get_nfo_files(meta)
-        if nfo_files and not is_multi_episode_nfo(nfo_files[0]):
+        if nfo_files and not await is_multi_episode_nfo(nfo_files[0]):
             return nfo_files[0]
         else:
             return await self._get_or_generate_mediainfo_as_nfo(meta)

--- a/src/trackers/FRENCH.py
+++ b/src/trackers/FRENCH.py
@@ -23,7 +23,7 @@ from unidecode import unidecode
 
 from src.audio import AD_TRACK_RE, codec_info_from_track
 from src.console import console
-from src.nfo_generator import SceneNfoGenerator
+from src.nfo_generator import SceneNfoGenerator, is_multi_episode_nfo
 from src.torrentcreate import TorrentCreator
 from src.trackers.COMMON import COMMON
 
@@ -2236,7 +2236,7 @@ class FrenchTrackerMixin:
         Useful for trackers that expect an NFO with every upload (e.g. C411).
         """
         nfo_files = self._get_nfo_files(meta)
-        if nfo_files:
+        if nfo_files and not is_multi_episode_nfo(nfo_files[0]):
             return nfo_files[0]
         else:
             return await self._get_or_generate_mediainfo_as_nfo(meta)

--- a/src/trackers/UNIT3D.py
+++ b/src/trackers/UNIT3D.py
@@ -447,7 +447,7 @@ class UNIT3D:
         # A multi-episode MediaInfo concatenation stays in the torrent (for
         # cross-seed integrity) but is too long for the API NFO field, where
         # the single-episode MediaInfo dump is sent instead when available.
-        if nfo_files and is_multi_episode_nfo(nfo_files[0]):
+        if nfo_files and await is_multi_episode_nfo(nfo_files[0]):
             mi_fallback = [
                 p
                 for p in (

--- a/src/trackers/UNIT3D.py
+++ b/src/trackers/UNIT3D.py
@@ -13,6 +13,7 @@ from typing_extensions import TypeAlias
 
 from src.console import console
 from src.get_desc import DescriptionBuilder
+from src.nfo_generator import is_multi_episode_nfo
 from src.trackers.COMMON import COMMON
 
 QueryValue: TypeAlias = Union[str, int, float, bool, None]
@@ -442,6 +443,21 @@ class UNIT3D:
         if not nfo_files and meta.get("keep_nfo", False) and (meta.get("keep_folder", False) or meta.get("isdir", False)):
             search_dir = meta["path"] if os.path.isdir(meta["path"]) or meta.get("isdir", False) else os.path.dirname(meta["path"])
             nfo_files = glob.glob(os.path.join(search_dir, "*.nfo"))
+
+        # A multi-episode MediaInfo concatenation stays in the torrent (for
+        # cross-seed integrity) but is too long for the API NFO field, where
+        # the single-episode MediaInfo dump is sent instead when available.
+        if nfo_files and is_multi_episode_nfo(nfo_files[0]):
+            mi_fallback = [
+                p
+                for p in (
+                    os.path.join(base_dir, "tmp", uuid, "MEDIAINFO_CLEANPATH.txt"),
+                    os.path.join(base_dir, "tmp", uuid, "MEDIAINFO.txt"),
+                )
+                if os.path.isfile(p)
+            ]
+            if mi_fallback:
+                nfo_files = mi_fallback[:1]
 
         if nfo_files:
             async with aiofiles.open(nfo_files[0], "rb") as f:

--- a/src/trackers/V3X.py
+++ b/src/trackers/V3X.py
@@ -32,6 +32,7 @@ from unidecode import unidecode
 
 from src.console import console
 from src.get_desc import DescriptionBuilder
+from src.nfo_generator import is_multi_episode_nfo
 from src.rehostimages import RehostImagesManager
 from src.tmdb import TmdbManager
 from src.trackers.COMMON import COMMON
@@ -675,9 +676,12 @@ class V3X(FrenchTrackerMixin):
         # The site rules keep the ORIGINAL release NFO (shipped untouched);
         # otherwise fall back to MediaInfo / a generated scene NFO, with the
         # "Complete name" line patched to the tracker release name.
+        # A multi-episode MediaInfo concatenation stays in the torrent (for
+        # cross-seed integrity) but is too long for the API NFO field.
+        usable_nfo = bool(nfo_files) and not is_multi_episode_nfo(nfo_files[0])
         nfo_text = ""
-        is_scene_nfo = bool(nfo_files)
-        nfo_path = nfo_files[0] if nfo_files else await self._get_or_generate_mediainfo_as_nfo(meta)
+        is_scene_nfo = usable_nfo
+        nfo_path = nfo_files[0] if usable_nfo else await self._get_or_generate_mediainfo_as_nfo(meta)
         if nfo_path:
             try:
                 async with aiofiles.open(nfo_path, "rb") as f:

--- a/src/trackers/V3X.py
+++ b/src/trackers/V3X.py
@@ -678,7 +678,7 @@ class V3X(FrenchTrackerMixin):
         # "Complete name" line patched to the tracker release name.
         # A multi-episode MediaInfo concatenation stays in the torrent (for
         # cross-seed integrity) but is too long for the API NFO field.
-        usable_nfo = bool(nfo_files) and not is_multi_episode_nfo(nfo_files[0])
+        usable_nfo = bool(nfo_files) and not await is_multi_episode_nfo(nfo_files[0])
         nfo_text = ""
         is_scene_nfo = usable_nfo
         nfo_path = nfo_files[0] if usable_nfo else await self._get_or_generate_mediainfo_as_nfo(meta)

--- a/tests/test_multi_episode_nfo.py
+++ b/tests/test_multi_episode_nfo.py
@@ -27,20 +27,26 @@ def _write(tmp_path, content):
     return str(path)
 
 
+def _is_multi(path):
+    import asyncio
+
+    return asyncio.run(is_multi_episode_nfo(path))
+
+
 def test_single_mediainfo_dump_is_not_multi(tmp_path):
-    assert is_multi_episode_nfo(_write(tmp_path, SINGLE_MI)) is False
+    assert _is_multi(_write(tmp_path, SINGLE_MI)) is False
 
 
 def test_scene_nfo_is_not_multi(tmp_path):
-    assert is_multi_episode_nfo(_write(tmp_path, SCENE_NFO)) is False
+    assert _is_multi(_write(tmp_path, SCENE_NFO)) is False
 
 
 def test_concatenated_dumps_are_multi(tmp_path):
-    assert is_multi_episode_nfo(_write(tmp_path, MULTI_MI)) is True
+    assert _is_multi(_write(tmp_path, MULTI_MI)) is True
 
 
 def test_missing_file_is_not_multi(tmp_path):
-    assert is_multi_episode_nfo(str(tmp_path / "absent.nfo")) is False
+    assert _is_multi(str(tmp_path / "absent.nfo")) is False
 
 
 def _unit3d(tmp_path, nfo_content):

--- a/tests/test_multi_episode_nfo.py
+++ b/tests/test_multi_episode_nfo.py
@@ -1,0 +1,67 @@
+# A season pack sometimes ships one giant NFO concatenating the full
+# MediaInfo dump of every episode. That file must stay in the .torrent
+# (cross-seed integrity) but must not be sent as the tracker API NFO field,
+# where the single-episode MediaInfo dump is preferred.
+
+from src.nfo_generator import is_multi_episode_nfo
+
+SINGLE_MI = """General
+Unique ID                                : 123
+Complete name                            : Show.S01E01.1080p.WEB-DL-GRP.mkv
+Format                                   : Matroska
+"""
+
+MULTI_MI = SINGLE_MI + """
+General
+Unique ID                                : 456
+Complete name                            : Show.S01E02.1080p.WEB-DL-GRP.mkv
+Format                                   : Matroska
+"""
+
+SCENE_NFO = "ASCII art release notes, no mediainfo dump here."
+
+
+def _write(tmp_path, content):
+    path = tmp_path / "release.nfo"
+    path.write_text(content, encoding="utf-8")
+    return str(path)
+
+
+def test_single_mediainfo_dump_is_not_multi(tmp_path):
+    assert is_multi_episode_nfo(_write(tmp_path, SINGLE_MI)) is False
+
+
+def test_scene_nfo_is_not_multi(tmp_path):
+    assert is_multi_episode_nfo(_write(tmp_path, SCENE_NFO)) is False
+
+
+def test_concatenated_dumps_are_multi(tmp_path):
+    assert is_multi_episode_nfo(_write(tmp_path, MULTI_MI)) is True
+
+
+def test_missing_file_is_not_multi(tmp_path):
+    assert is_multi_episode_nfo(str(tmp_path / "absent.nfo")) is False
+
+
+def _unit3d(tmp_path, nfo_content):
+    import asyncio
+
+    from src.trackers.UNIT3D import UNIT3D
+
+    tmp_dir = tmp_path / "tmp" / "uuid"
+    tmp_dir.mkdir(parents=True)
+    (tmp_dir / "release.nfo").write_text(nfo_content, encoding="utf-8")
+    (tmp_dir / "MEDIAINFO_CLEANPATH.txt").write_text(SINGLE_MI, encoding="utf-8")
+    tracker = UNIT3D({"TRACKERS": {"XX": {}}}, "XX")
+    meta = {"base_dir": str(tmp_path), "uuid": "uuid", "path": str(tmp_path)}
+    return asyncio.run(tracker.get_additional_files(meta))
+
+
+def test_unit3d_api_field_uses_multi_nfo_replacement(tmp_path):
+    files = _unit3d(tmp_path, MULTI_MI)
+    assert files["nfo"][1].decode("utf-8") == SINGLE_MI
+
+
+def test_unit3d_api_field_keeps_single_nfo(tmp_path):
+    files = _unit3d(tmp_path, SCENE_NFO)
+    assert files["nfo"][1].decode("utf-8") == SCENE_NFO


### PR DESCRIPTION
…i-episode dump

Some season packs ship one giant NFO concatenating the full MediaInfo of every episode. Keep that file in the .torrent for cross-seed integrity, but stop sending it as the tracker API NFO field: detect it (two or more "Complete name" lines) and substitute the single-episode MediaInfo dump in the C411, UNIT3D and V3X upload paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of concatenated multi-episode NFO files during uploads.
  - Prevented unsuitable multi-episode NFO content from being submitted to tracker API fields.
  - Automatically uses suitable single-episode MediaInfo or generated NFO content when needed.
  - Preserves the original NFO inside the torrent for cross-seed compatibility.

- **Tests**
  - Added coverage for multi-episode detection, missing files, scene NFOs, and tracker upload behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->