### PR TITLE
fix: resolve TMDB movie/tv namespace desync in category and id detection

### DIFF
--- a/src/prep.py
+++ b/src/prep.py
@@ -39,7 +39,7 @@ try:
     from src.rehostimages import RehostImagesManager
     from src.sonarr import SonarrManager
     from src.tags import get_tag, tag_override
-    from src.tmdb import TmdbManager
+    from src.tmdb import TmdbManager, verify_tmdb_imdb_agreement
     from src.tvdb import tvdb_data
     from src.tvmaze import tvmaze_manager
     from src.video import video_manager
@@ -922,6 +922,10 @@ class Prep:
         if meta.get("original_language", None) is None:
             no_original_language = True
 
+        # Cross-check the searched TMDB entry against TMDB's own mapping of
+        # the IMDb id before fetching any metadata from it.
+        await verify_tmdb_imdb_agreement(meta, unattended=unattended)
+
         # if we have all of the ids, search everything all at once
         if int(meta.get("imdb_id") or 0) != 0 and int(meta.get("tvdb_id") or 0) != 0 and int(meta.get("tmdb_id") or 0) != 0 and int(meta.get("tvmaze_id") or 0) != 0:
             meta = await self.metadata_searching_manager.all_ids(meta)
@@ -1379,7 +1383,7 @@ class Prep:
 
         return meta
 
-    async def get_cat(self, _video: str, meta: dict[str, Any]) -> Optional[str]:
+    async def get_cat(self, video: str, meta: dict[str, Any]) -> Optional[str]:
         if meta.get("manual_category"):
             manual_category = meta.get("manual_category")
             return manual_category.upper() if isinstance(manual_category, str) else None
@@ -1416,6 +1420,14 @@ class Prep:
                 if meta.get("debug", False):
                     console.print(f"[cyan]Matched TV pattern in filename: {pattern}[/cyan]")
                 return "TV"
+
+        # Season packs sometimes number their episodes E01… without any
+        # season token; none of the name patterns match those, but guessit
+        # recognises the episode numbering on the selected video file.
+        if video and guessit_fn(os.path.basename(video)).get("type") == "episode":
+            if meta.get("debug", False):
+                console.print("[cyan]guessit typed the video file as an episode[/cyan]")
+            return "TV"
 
         if "subsplease" in path.lower() or "subsplease" in uuid.lower():
             anime_pattern = r"(?:\s-\s)?(\d{1,3})\s*\((?:\d+p|480p|480i|576i|576p|720p|1080i|1080p|2160p)\)"

--- a/src/tmdb.py
+++ b/src/tmdb.py
@@ -285,6 +285,84 @@ async def normalize_title(title: str) -> str:
     return title.lower().replace("&", "and").replace("  ", " ").strip()
 
 
+async def _find_by_imdb_id(imdb_id: int) -> dict[str, Any]:
+    """Raw TMDB find() response for an IMDb id (empty dict on failure)."""
+    if not imdb_id:
+        return {}
+    url = f"{TMDB_BASE_URL}/find/tt{imdb_id:07d}"
+    params = {"api_key": tmdb_api_key, "external_source": "imdb_id"}
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.get(url, params=params, timeout=10)
+            response.raise_for_status()
+            return typing_cast(dict[str, Any], response.json())
+    except Exception:
+        return {}
+
+
+async def resolve_tmdb_namespace(tmdb_id: int, imdb_id: int = 0) -> Optional[str]:
+    """Return "MOVIE" or "TV" for a bare TMDB id of unknown namespace.
+
+    A TMDB id is only meaningful with its movie/tv namespace and ids collide
+    between the two. Prefer the IMDb cross-reference (exact key lookup); fall
+    back to plain existence when the id lives in only one namespace.
+    """
+    info = await _find_by_imdb_id(imdb_id)
+    if any(int(r.get("id", 0)) == int(tmdb_id) for r in info.get("tv_results", [])):
+        return "TV"
+    if any(int(r.get("id", 0)) == int(tmdb_id) for r in info.get("movie_results", [])):
+        return "MOVIE"
+
+    async def _exists(namespace: str) -> bool:
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.get(f"{TMDB_BASE_URL}/{namespace}/{tmdb_id}", params={"api_key": tmdb_api_key}, timeout=10)
+                return response.status_code == 200
+        except Exception:
+            return False
+
+    matches = [label for namespace, label in (("movie", "MOVIE"), ("tv", "TV")) if await _exists(namespace)]
+    return matches[0] if len(matches) == 1 else None
+
+
+async def verify_tmdb_imdb_agreement(meta: dict[str, Any], unattended: bool = False) -> None:
+    """Cross-check the (category, tmdb_id) pair against TMDB's own mapping
+    for the known IMDb id, before any metadata is fetched.
+
+    The TMDB and IMDb title searches run independently, so when TMDB's
+    find() maps the IMDb id to a different entry than the title search
+    picked, the find() result is the corroborated one (both databases agree
+    on it). Adopt it in unattended mode, ask in interactive mode.
+    """
+    tmdb_id = int(meta.get("tmdb_id") or 0)
+    imdb_id = int(meta.get("imdb_id") or 0)
+    if not tmdb_id or not imdb_id or int(meta.get("tmdb_manual") or 0) or int(meta.get("imdb_manual") or 0):
+        return
+    info = await _find_by_imdb_id(imdb_id)
+    candidates: list[tuple[str, int]] = [("MOVIE", int(r.get("id", 0))) for r in info.get("movie_results", [])]
+    candidates += [("TV", int(r.get("id", 0))) for r in info.get("tv_results", [])]
+    if not candidates:
+        return  # nothing to corroborate against
+    current = (str(meta.get("category") or ""), tmdb_id)
+    if current in candidates:
+        return
+    # Prefer the candidate matching the current category, else the first
+    category, corroborated_id = next((c for c in candidates if c[0] == current[0]), candidates[0])
+    console.print(
+        f"[yellow]TMDb/IMDb disagree: the title search picked {current[0].lower()}/{current[1]}, "
+        f"but TMDb maps tt{imdb_id:07d} to {category.lower()}/{corroborated_id}.[/yellow]"
+    )
+    use_corroborated = True
+    if not unattended:
+        try:
+            use_corroborated = cli_ui.ask_yes_no(f"Use the corroborated {category.lower()}/{corroborated_id} instead?", default=True)
+        except EOFError:
+            use_corroborated = True
+    if use_corroborated:
+        meta["category"] = category
+        meta["tmdb_id"] = corroborated_id
+
+
 async def get_tmdb_from_imdb(
     imdb_id: Union[str, int],
     tvdb_id: Optional[int] = None,

--- a/src/trackermeta.py
+++ b/src/trackermeta.py
@@ -18,6 +18,7 @@ from src.bbcode import BBCODE
 from src.btnid import BtnIdManager
 from src.console import console
 from src.proxy_env import proxy_for
+from src.tmdb import resolve_tmdb_namespace
 from src.trackers.COMMON import COMMON
 from src.type_utils import to_int
 
@@ -309,14 +310,27 @@ async def update_meta_with_unit3d_data(meta: Meta, tracker_data: Sequence[Any], 
         description_path = Path(meta["base_dir"]) / "tmp" / meta["uuid"] / "DESCRIPTION.txt"
         if len(desc) > 0:
             await asyncio.to_thread(description_path.write_text, (desc or "") + "\n", encoding="utf8")
-    if category and not meta.get("manual_category", None):
+    fiche_category = None
+    if category:
         cat_upper = category.upper()
         if "MOVIE" in cat_upper:
-            meta["category"] = "MOVIE"
+            fiche_category = "MOVIE"
         elif "TV" in cat_upper:
-            meta["category"] = "TV"
-        if meta["debug"]:
-            console.print("set Category:", meta["category"])
+            fiche_category = "TV"
+    if not meta.get("manual_category", None):
+        if fiche_category:
+            meta["category"] = fiche_category
+            if meta["debug"]:
+                console.print("set Category:", meta["category"])
+        elif tmdb:
+            # The tracker supplied a TMDB id but no usable MOVIE/TV category
+            # (e.g. "Anime"). A bare TMDB id is ambiguous — the movie and tv
+            # namespaces collide — so resolve its namespace instead of
+            # keeping the filename-based guess alongside the fiche's id.
+            resolved = await resolve_tmdb_namespace(int(tmdb), int(meta.get("imdb_id") or 0))
+            if resolved and resolved != meta.get("category"):
+                meta["category"] = resolved
+                console.print(f"[yellow]Category set to {resolved} from the TMDB id namespace (tracker category '{category}' was inconclusive)[/yellow]")
 
     imagelist_typed = cast(Optional[list[ImageDict]], imagelist)
     if imagelist_typed:  # Ensure imagelist is not empty before setting

--- a/tests/test_tmdb_category_namespace.py
+++ b/tests/test_tmdb_category_namespace.py
@@ -1,0 +1,114 @@
+# A TMDB id is only meaningful with its movie/tv namespace: ids collide
+# between the two (the same number can be a movie and an unrelated TV show).
+# These tests cover the three defenses against namespace/category desync:
+# episode-numbered packs without a season token, tracker fiches with a
+# category outside MOVIE/TV, and the IMDb<->TMDB corroboration cross-check.
+
+import asyncio
+
+import src.tmdb as tmdb
+import src.trackermeta as trackermeta
+from src.prep import Prep
+
+
+def _get_cat(video, folder):
+    meta = {"path": f"/x/{folder}", "uuid": folder}
+    return asyncio.run(Prep.get_cat(object(), video, meta))
+
+
+def test_get_cat_episode_numbered_pack_is_tv():
+    folder = "Show.Name.MULTi.1080p.BluRay.x264-GRP"
+    video = f"/x/{folder}/Show.Name.E01.MULTi.1080p.BluRay.x264-GRP.mkv"
+    assert _get_cat(video, folder) == "TV"
+
+
+def test_get_cat_movie_file_stays_movie():
+    folder = "Movie.Name.2020.1080p.BluRay.x264-GRP"
+    video = f"/x/{folder}/Movie.Name.2020.1080p.BluRay.x264-GRP.mkv"
+    assert _get_cat(video, folder) == "MOVIE"
+
+
+def test_resolve_namespace_prefers_imdb_cross_reference(monkeypatch):
+    async def fake_find(imdb_id):
+        assert imdb_id == 1910272
+        return {"movie_results": [], "tv_results": [{"id": 42509}]}
+
+    monkeypatch.setattr(tmdb, "_find_by_imdb_id", fake_find)
+    assert asyncio.run(tmdb.resolve_tmdb_namespace(42509, 1910272)) == "TV"
+
+
+def _tracker_data(category):
+    # (tmdb, imdb, tvdb, mal, desc, category, infohash, imagelist, filename)
+    return (42509, 1910272, 0, 0, None, category, None, None, None)
+
+
+def test_unparsed_fiche_category_resolves_namespace(monkeypatch):
+    async def fake_resolve(tmdb_id, imdb_id=0):
+        assert (tmdb_id, imdb_id) == (42509, 1910272)
+        return "TV"
+
+    monkeypatch.setattr(trackermeta, "resolve_tmdb_namespace", fake_resolve)
+    meta = {"debug": False, "unattended": True, "category": "MOVIE"}
+    asyncio.run(trackermeta.update_meta_with_unit3d_data(meta, _tracker_data("Anime"), "XX"))
+    assert meta["category"] == "TV"
+    assert meta["tmdb_id"] == 42509
+
+
+def test_parsed_fiche_category_skips_resolver(monkeypatch):
+    async def boom(*_args, **_kwargs):
+        raise AssertionError("resolver must not run for a MOVIE/TV fiche category")
+
+    monkeypatch.setattr(trackermeta, "resolve_tmdb_namespace", boom)
+    meta = {"debug": False, "unattended": True, "category": "MOVIE"}
+    asyncio.run(trackermeta.update_meta_with_unit3d_data(meta, _tracker_data("TV"), "XX"))
+    assert meta["category"] == "TV"
+
+
+def test_manual_category_is_never_overridden(monkeypatch):
+    async def boom(*_args, **_kwargs):
+        raise AssertionError("resolver must not run with a manual category")
+
+    monkeypatch.setattr(trackermeta, "resolve_tmdb_namespace", boom)
+    meta = {"debug": False, "unattended": True, "category": "MOVIE", "manual_category": "MOVIE"}
+    asyncio.run(trackermeta.update_meta_with_unit3d_data(meta, _tracker_data("Anime"), "XX"))
+    assert meta["category"] == "MOVIE"
+
+
+def test_agreement_check_adopts_corroborated_pair_unattended(monkeypatch):
+    async def fake_find(_imdb_id):
+        return {"movie_results": [], "tv_results": [{"id": 42509}]}
+
+    monkeypatch.setattr(tmdb, "_find_by_imdb_id", fake_find)
+    meta = {"category": "MOVIE", "tmdb_id": 760827, "imdb_id": 1910272}
+    asyncio.run(tmdb.verify_tmdb_imdb_agreement(meta, unattended=True))
+    assert (meta["category"], meta["tmdb_id"]) == ("TV", 42509)
+
+
+def test_agreement_check_keeps_agreeing_pair(monkeypatch):
+    async def fake_find(_imdb_id):
+        return {"movie_results": [{"id": 555}], "tv_results": []}
+
+    monkeypatch.setattr(tmdb, "_find_by_imdb_id", fake_find)
+    meta = {"category": "MOVIE", "tmdb_id": 555, "imdb_id": 42}
+    asyncio.run(tmdb.verify_tmdb_imdb_agreement(meta, unattended=True))
+    assert (meta["category"], meta["tmdb_id"]) == ("MOVIE", 555)
+
+
+def test_agreement_check_no_candidates_is_noop(monkeypatch):
+    async def fake_find(_imdb_id):
+        return {}
+
+    monkeypatch.setattr(tmdb, "_find_by_imdb_id", fake_find)
+    meta = {"category": "MOVIE", "tmdb_id": 555, "imdb_id": 42}
+    asyncio.run(tmdb.verify_tmdb_imdb_agreement(meta, unattended=True))
+    assert (meta["category"], meta["tmdb_id"]) == ("MOVIE", 555)
+
+
+def test_agreement_check_skips_manual_ids(monkeypatch):
+    async def boom(_imdb_id):
+        raise AssertionError("find must not run for manual ids")
+
+    monkeypatch.setattr(tmdb, "_find_by_imdb_id", boom)
+    meta = {"category": "MOVIE", "tmdb_id": 555, "imdb_id": 42, "tmdb_manual": 555}
+    asyncio.run(tmdb.verify_tmdb_imdb_agreement(meta, unattended=True))
+    assert meta["tmdb_id"] == 555


### PR DESCRIPTION
A TMDB id is only meaningful with its movie/tv namespace, and ids collide between the two — a series id fetched through the movie endpoint returns an unrelated film. Three defenses:

- get_cat: packs numbering episodes E01… without a season token matched no TV pattern; guessit on the selected video file now types them.
- update_meta_with_unit3d_data: a fiche category outside MOVIE/TV (e.g. Anime) silently kept the filename-based guess while adopting the fiche's TMDB id; the id's namespace is now resolved via the IMDb cross-reference or single-namespace existence.
- verify_tmdb_imdb_agreement: before fetching metadata, cross-check the (category, tmdb_id) pair against TMDB's find() for the IMDb id — the independent title searches can disagree, and the find() mapping is the pair both databases corroborate. Adopt it unattended, ask otherwise.