### PR TITLE
fix: use a single screenshot set from the shared reuploaded_images.json

### DIFF
--- a/src/rehostimages.py
+++ b/src/rehostimages.py
@@ -229,7 +229,9 @@ async def _check_hosts(
         except Exception as e:
             console.print(f"[red]Failed to load reuploaded images: {e}")
 
-    valid_reuploaded_images: list[dict[str, str]] = []
+    # Every rehost pass appends its own copy of the screenshots, so the file
+    # may hold one set per host; a description only gets one of them.
+    reuploaded_by_host: dict[str, list[dict[str, str]]] = {}
     for image in reuploaded_images:
         raw_url = _as_str(image.get("raw_url"))
         if not raw_url:
@@ -251,10 +253,12 @@ async def _check_hosts(
         if mapped_host:
             mapped_host = url_host_mapping.get(mapped_host, mapped_host)
             if mapped_host in approved_image_hosts:
-                valid_reuploaded_images.append(image)
+                reuploaded_by_host.setdefault(mapped_host, []).append(image)
             elif meta["debug"]:
                 console.print(f"[red]URL '{raw_url}' from reuploaded_images.json is not recognized as an approved host.")
 
+    # Most complete set wins; ties go to the host written first.
+    valid_reuploaded_images = max(reuploaded_by_host.values(), key=len, default=[])
     if valid_reuploaded_images:
         meta[new_images_key] = valid_reuploaded_images
         if tracker == "covers":
@@ -681,8 +685,8 @@ async def _handle_image_upload(
             except Exception:
                 existing_data = []
 
-            updated_data = existing_data + meta[new_images_key]
-            updated_data = [dict(s) for s in {tuple(d.items()) for d in updated_data}]
+            # Dedupe by URL while keeping the screenshot order.
+            updated_data = list({d.get("raw_url", json.dumps(d, sort_keys=True)): d for d in existing_data + meta[new_images_key]}.values())
 
             if tracker == "covers" and "release_url" in meta:
                 for image in updated_data:

--- a/src/rehostimages.py
+++ b/src/rehostimages.py
@@ -71,6 +71,11 @@ def _as_str(value: Any) -> Union[str, None]:
     return value if isinstance(value, str) else None
 
 
+def _dedupe_by_url(records: list[dict[str, str]]) -> list[dict[str, str]]:
+    """Drop duplicate records while keeping the screenshot order."""
+    return list({d.get("raw_url") or json.dumps(d, sort_keys=True): d for d in records}.values())
+
+
 def _safe_remove(path: str) -> bool:
     try:
         if os.path.exists(path):
@@ -685,8 +690,7 @@ async def _handle_image_upload(
             except Exception:
                 existing_data = []
 
-            # Dedupe by URL while keeping the screenshot order.
-            updated_data = list({d.get("raw_url", json.dumps(d, sort_keys=True)): d for d in existing_data + meta[new_images_key]}.values())
+            updated_data = _dedupe_by_url(existing_data + meta[new_images_key])
 
             if tracker == "covers" and "release_url" in meta:
                 for image in updated_data:

--- a/tests/test_rehost_single_host_set.py
+++ b/tests/test_rehost_single_host_set.py
@@ -51,3 +51,12 @@ def test_only_one_host_set_is_used(tmp_path: pathlib.Path):
 def test_most_complete_set_wins(tmp_path: pathlib.Path):
     stored = [_img("ptscreens.com", i) for i in range(3)] + [_img("pixhost.to", i) for i in range(6)]
     assert _run(tmp_path, stored) == [_img("pixhost.to", i) for i in range(6)]
+
+
+def test_dedupe_keeps_order_and_records_without_raw_url():
+    from src.rehostimages import _dedupe_by_url
+
+    a, b = _img("pixhost.to", 1), _img("pixhost.to", 2)
+    blank_1 = {"img_url": "https://x/1.png", "raw_url": ""}
+    blank_2 = {"img_url": "https://x/2.png", "raw_url": None}
+    assert _dedupe_by_url([b, a, b, blank_1, blank_2, blank_1]) == [b, a, blank_1, blank_2]

--- a/tests/test_rehost_single_host_set.py
+++ b/tests/test_rehost_single_host_set.py
@@ -1,0 +1,53 @@
+"""Regression: reuploaded_images.json is shared by every tracker, so two
+trackers rehosting to different hosts leave one screenshot set per host in
+it. A tracker approving both hosts must still pick up a single set."""
+
+import asyncio
+import json
+import pathlib
+from typing import Any
+
+from src.rehostimages import _check_hosts
+
+MAPPING = {"pixhost.to": "pixhost", "ptscreens.com": "ptscreens"}
+
+
+def _img(host: str, i: int) -> dict[str, str]:
+    url = f"https://img.{host}/{i}.png"
+    return {"img_url": url, "raw_url": url, "web_url": url}
+
+
+def _run(tmp_path: pathlib.Path, stored: list[dict[str, str]]) -> list[dict[str, str]]:
+    uuid = "Movie.2024.1080p.WEB-DL-GRP"
+    shots = tmp_path / "tmp" / uuid
+    shots.mkdir(parents=True)
+    (shots / "reuploaded_images.json").write_text(json.dumps(stored), encoding="utf-8")
+    meta: dict[str, Any] = {
+        "base_dir": str(tmp_path),
+        "uuid": uuid,
+        "debug": False,
+        "image_list": [_img("onlyimage.org", i) for i in range(6)],
+    }
+    result, _retry, _reup = asyncio.run(
+        _check_hosts(
+            meta,
+            "V3X",
+            MAPPING,
+            approved_image_hosts=["pixhost", "ptscreens"],
+            default_config={},
+            takescreens_manager=object(),
+            uploadscreens_manager=object(),
+        )
+    )
+    return result
+
+
+def test_only_one_host_set_is_used(tmp_path: pathlib.Path):
+    stored = [_img("ptscreens.com", i) for i in range(6)] + [_img("pixhost.to", i) for i in range(6)]
+    result = _run(tmp_path, stored)
+    assert result == [_img("ptscreens.com", i) for i in range(6)]
+
+
+def test_most_complete_set_wins(tmp_path: pathlib.Path):
+    stored = [_img("ptscreens.com", i) for i in range(3)] + [_img("pixhost.to", i) for i in range(6)]
+    assert _run(tmp_path, stored) == [_img("pixhost.to", i) for i in range(6)]


### PR DESCRIPTION
Every rehost pass appends its uploads to reuploaded_images.json, which is shared by all trackers. Two trackers with different approved hosts leave one copy of the screenshots per host in it, and a tracker approving both hosts then picked up every entry: 12 screenshots (6 pixhost + 6 ptscreens) in one description. The set-based dedupe on write also scrambled the screenshot order.

Group the stored entries by host on read and keep only the most complete set (ties go to the host written first), and dedupe by URL on write while preserving insertion order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reuploaded images are now grouped by hosting provider, with one complete and most comprehensive set selected.
  * Duplicate image entries are removed while preserving their original order.
* **Tests**
  * Added regression coverage for shared image data across multiple hosts.
  * Added verification that the most complete host-specific set is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->