### PR TITLE
feat(C411): lay out screenshots two per row like V3X

### DIFF
--- a/src/trackers/C411.py
+++ b/src/trackers/C411.py
@@ -1131,7 +1131,8 @@ class C411(FrenchTrackerMixin):
                         img_lines.append(f"[img]{thumb}[/img]")
             if img_lines:
                 parts.append("[center]")
-                parts.append("\n".join(img_lines))
+                # Two thumbnails per row, as on V3X.
+                parts.extend(" ".join(img_lines[i : i + 2]) for i in range(0, len(img_lines), 2))
                 parts.append("[/center]")
 
         # ── UA Signature ──

--- a/tests/test_c411.py
+++ b/tests/test_c411.py
@@ -1403,6 +1403,17 @@ class TestDescription:
             '[url=https://img.host/2.png][img]https://img.host/2.md.png[/img][/url]'
         ) in desc
 
+    def test_with_odd_screenshot_count(self):
+        meta = _meta_base(image_list=[
+            {'img_url': f'https://img.host/{i}.md.png', 'raw_url': f'https://img.host/{i}.png', 'web_url': f'https://img.host/view/{i}'}
+            for i in (1, 2, 3)
+        ])
+        c = C411(_config({'include_screenshots': True}))
+        desc = asyncio.run(c._build_description(meta))
+        thumb = '[url=https://img.host/view/{0}][img]https://img.host/{0}.md.png[/img][/url]'
+        # First two share a row, the third starts the next one
+        assert f"{thumb.format(1)} {thumb.format(2)}\n{thumb.format(3)}\n" in desc
+
     def test_with_screenshots_no_thumbnail(self):
         # Hosts without a separate thumbnail fall back to the full-size URL
         meta = _meta_base(image_list=[

--- a/tests/test_c411.py
+++ b/tests/test_c411.py
@@ -1397,8 +1397,11 @@ class TestDescription:
         desc = asyncio.run(c._build_description(meta))
         assert "[color=#3d85c6]Captures d'écran[/color]" in desc
         # Thumbnails are embedded, linked to the full-size image
-        assert '[url=https://img.host/view/1][img]https://img.host/1.md.png[/img][/url]' in desc
-        assert '[url=https://img.host/2.png][img]https://img.host/2.md.png[/img][/url]' in desc
+        # Two thumbnails per row
+        assert (
+            '[url=https://img.host/view/1][img]https://img.host/1.md.png[/img][/url] '
+            '[url=https://img.host/2.png][img]https://img.host/2.md.png[/img][/url]'
+        ) in desc
 
     def test_with_screenshots_no_thumbnail(self):
         # Hosts without a separate thumbnail fall back to the full-size URL


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Screenshot thumbnails in C411 descriptions now display in rows of two for a cleaner, more compact layout.
  * Thumbnail links are separated by spaces when shown together.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->