### PR TITLE
fix(C411): strip [comparison] blocks from the reused description

### DIFF
--- a/src/trackers/C411.py
+++ b/src/trackers/C411.py
@@ -1105,6 +1105,8 @@ class C411(FrenchTrackerMixin):
 
         # ── Notes de la release d'origine (opt-in: include_source_description) ──
         source_desc = await self._get_source_description(meta)
+        # The site parser does not understand [comparison] blocks.
+        source_desc = re.sub(r"\[comparison=[^\]]*\].*?\[/comparison\]", "", source_desc, flags=re.DOTALL | re.IGNORECASE).strip()
         if source_desc:
             parts.append(f"        [color={C}]Notes de la release d'origine[/color]")
             parts.append(f"    [font=Verdana][size=14]{source_desc}[/size][/font]")

--- a/tests/test_c411.py
+++ b/tests/test_c411.py
@@ -3295,6 +3295,7 @@ class TestSourceDescriptionSection:
         assert "Still relevant." in desc
         assert "comparison" not in desc.lower()
         assert "img.host/a.png" not in desc
+        assert "img.host/b.png" not in desc
 
     def test_comparison_only_description_drops_the_section(self, tmp_path: Any):
         desc = self._desc(tmp_path, flag=True, content="[comparison=A, B]\nhttps://img.host/a.png\n[/comparison]")

--- a/tests/test_c411.py
+++ b/tests/test_c411.py
@@ -3284,6 +3284,22 @@ class TestSourceDescriptionSection:
         assert "Notes de la release d'origine" in desc
         assert "Encoder notes worth keeping." in desc
 
+    def test_comparison_blocks_are_stripped(self, tmp_path: Any):
+        content = (
+            "Encoder notes worth keeping.\n"
+            "[comparison=Source, Encode]\nhttps://img.host/a.png\nhttps://img.host/b.png\n[/comparison]\n"
+            "Still relevant."
+        )
+        desc = self._desc(tmp_path, flag=True, content=content)
+        assert "Encoder notes worth keeping." in desc
+        assert "Still relevant." in desc
+        assert "comparison" not in desc.lower()
+        assert "img.host/a.png" not in desc
+
+    def test_comparison_only_description_drops_the_section(self, tmp_path: Any):
+        desc = self._desc(tmp_path, flag=True, content="[comparison=A, B]\nhttps://img.host/a.png\n[/comparison]")
+        assert "Notes de la release" not in desc
+
     def test_section_absent_by_default(self, tmp_path: Any):
         desc = self._desc(tmp_path, flag=False, content="Encoder notes worth keeping.")
         assert "Notes de la release" not in desc


### PR DESCRIPTION
The site parser does not render [comparison] blocks, so they only leave raw tags and bare image URLs in the description.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Comparison-only metadata is now removed from C411 descriptions before source release notes are added.
  - Surrounding release notes remain intact, while empty source-note sections are omitted.

- **Tests**
  - Added coverage for removing comparison blocks and handling descriptions containing only those blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->