### PR TITLE
fix(mkbrr): pass basenames to --include so nested episode files are kept

### DIFF
--- a/src/torrentcreate.py
+++ b/src/torrentcreate.py
@@ -185,6 +185,13 @@ class TorrentCreator:
         exclude_str = ",".join(sorted(exclude_files) + manual_patterns)
         return exclude_str
 
+    @staticmethod
+    def build_mkbrr_include_string(include: Sequence[str]) -> str:
+        # mkbrr matches --include patterns against the file's basename only, so
+        # "Release/Episode.Dir/file.mkv" would never match; keep just the basename.
+        # Unwanted siblings (samples) are still dropped by the --exclude list.
+        return ",".join(sorted({os.path.basename(p) for p in include}))
+
     @classmethod
     async def create_torrent(
         cls,
@@ -353,13 +360,7 @@ class TorrentCreator:
                             exclude_str = cls.build_mkbrr_exclude_string(str(path), meta["filelist"])
                             cmd.extend(["--exclude", exclude_str])
                             if include:
-                                # mkbrr matches --include patterns relative to the input directory,
-                                # not its parent. Strip any leading "FolderName/" prefix so that
-                                # patterns like "FolderName/file.mkv" become just "file.mkv".
-                                folder_prefix = os.path.basename(str(path)) + "/"
-                                mkbrr_include = [p[len(folder_prefix) :] if p.startswith(folder_prefix) else p for p in include]
-                                include_str = ",".join(sorted(mkbrr_include))
-                                cmd.extend(["--include", include_str])
+                                cmd.extend(["--include", cls.build_mkbrr_include_string(include)])
 
                         cmd.extend(["-o", output_path])
                         if meta["debug"]:

--- a/tests/test_mkbrr_include.py
+++ b/tests/test_mkbrr_include.py
@@ -10,3 +10,7 @@ def test_nested_include_paths_are_reduced_to_basenames():
 
 def test_top_level_paths_and_globs_pass_through():
     assert TorrentCreator.build_mkbrr_include_string(["Release/a.mkv", "*.mkv"]) == "*.mkv,a.mkv"
+
+
+def test_same_basename_in_two_folders_is_listed_once():
+    assert TorrentCreator.build_mkbrr_include_string(["Release/CD1/movie.mkv", "Release/CD2/movie.mkv"]) == "movie.mkv"

--- a/tests/test_mkbrr_include.py
+++ b/tests/test_mkbrr_include.py
@@ -1,0 +1,12 @@
+"""mkbrr matches --include against basenames only: nested include paths must be flattened."""
+
+from src.torrentcreate import TorrentCreator
+
+
+def test_nested_include_paths_are_reduced_to_basenames():
+    include = ["Show.S01-GRP/Show.S01E01-GRP/Show.S01E01-GRP.mkv", "Show.S01-GRP/Show.S01E02-GRP/Show.S01E02-GRP.mkv", "*.nfo"]
+    assert TorrentCreator.build_mkbrr_include_string(include) == "*.nfo,Show.S01E01-GRP.mkv,Show.S01E02-GRP.mkv"
+
+
+def test_top_level_paths_and_globs_pass_through():
+    assert TorrentCreator.build_mkbrr_include_string(["Release/a.mkv", "*.mkv"]) == "*.mkv,a.mkv"


### PR DESCRIPTION
mkbrr matches --include patterns against the file basename only, so a season pack whose episodes live in per-episode folders produced a torrent holding only the *.nfo files. Sample files are still dropped by --exclude.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved torrent creation include handling for nested paths.
  * Preserved wildcard patterns and consistently sorted included files and paths.
  * Ensured generated mkbrr commands receive the correct include values.

* **Tests**
  * Added coverage for nested paths, top-level paths, and wildcard patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->