### PR TITLE
fix: ulcx screens and bbcode tld

### DIFF
--- a/src/bbcode.py
+++ b/src/bbcode.py
@@ -423,7 +423,7 @@ class BBCODE:
 
         # Bare mentions only: a host that is part of a URL or a subdomain
         # (cdn.<site>, i.<site>) must keep its TLD or the link breaks.
-        desc = re.sub(rf"(?<![\w./-]){re.escape(site_netloc)}", site_domain, desc)
+        desc = re.sub(rf"(?<![\w./-]){re.escape(site_netloc)}(?![\w-]|\.\w)", site_domain, desc)
 
         # Temporarily hide spoiler tags
         spoilers = re.findall(r"\[spoiler[\s\S]*?\[\/spoiler\]", desc)

--- a/src/bbcode.py
+++ b/src/bbcode.py
@@ -421,7 +421,9 @@ class BBCODE:
                 url_tag_removed = url_tag_removed.replace("[/url]", "")
                 desc = desc.replace(site_url_tag, url_tag_removed)
 
-        desc = desc.replace(site_netloc, site_domain)
+        # Bare mentions only: a host that is part of a URL or a subdomain
+        # (cdn.<site>, i.<site>) must keep its TLD or the link breaks.
+        desc = re.sub(rf"(?<![\w./-]){re.escape(site_netloc)}", site_domain, desc)
 
         # Temporarily hide spoiler tags
         spoilers = re.findall(r"\[spoiler[\s\S]*?\[\/spoiler\]", desc)

--- a/src/trackers/ULCX.py
+++ b/src/trackers/ULCX.py
@@ -156,7 +156,9 @@ class ULCX(UNIT3D):
             if not self._check_audio_tracks(meta):
                 return False
 
-        if len(meta.get("image_list", [])) < 3:
+        # Runs before screenshot generation: reused images may be absent while
+        # the configured screenshot count will still be produced afterwards.
+        if max(len(meta.get("image_list", [])), int(meta.get("screens", 0) or 0)) < 3:
             console.print(f"[bold red]At least 3 screenshots are required, skipping {self.tracker} upload.[/bold red]")
             return False
 

--- a/src/trackers/ULCX.py
+++ b/src/trackers/ULCX.py
@@ -226,6 +226,13 @@ class ULCX(UNIT3D):
     async def get_description(self, meta: Meta) -> dict[str, str]:
         desc = await DescriptionBuilder(self.tracker, self.config).unit3d_edit_desc(meta, comparison=True)
 
+        # Trailers are not allowed in descriptions: drop YouTube links, then
+        # any [b]/[center] wrapper they leave empty.
+        _yt = r"https?://(?:www\.)?(?:youtube\.com|youtu\.be)/\S*"
+        desc = re.sub(rf"\[url={_yt}?\][^\[]*\[/url\]|{_yt}", "", desc, flags=re.IGNORECASE)
+        desc = re.sub(r"\[(b|center)\]\s*\[/\1\]\n?", "", desc, flags=re.IGNORECASE)
+        desc = re.sub(r"\[(b|center)\]\s*\[/\1\]\n?", "", desc, flags=re.IGNORECASE)
+
         if is_adult(meta):
             pattern = r"(\[center\](?:(?!\[/center\]).)*\[/center\])"
 

--- a/src/trackers/ULCX.py
+++ b/src/trackers/ULCX.py
@@ -228,10 +228,11 @@ class ULCX(UNIT3D):
 
         # Trailers are not allowed in descriptions: drop YouTube links, then
         # any [b]/[center] wrapper they leave empty.
-        _yt = r"https?://(?:www\.)?(?:youtube\.com|youtu\.be)/\S*"
-        desc = re.sub(rf"\[url={_yt}?\][^\[]*\[/url\]|{_yt}", "", desc, flags=re.IGNORECASE)
-        desc = re.sub(r"\[(b|center)\]\s*\[/\1\]\n?", "", desc, flags=re.IGNORECASE)
-        desc = re.sub(r"\[(b|center)\]\s*\[/\1\]\n?", "", desc, flags=re.IGNORECASE)
+        _yt = r"https?://(?:www\.)?(?:youtube\.com|youtu\.be)/[^\s\[\]]*"
+        desc = re.sub(rf"\[url={_yt}\](?:(?!\[/url\]).)*\[/url\]|\[url\]{_yt}\[/url\]|{_yt}", "", desc, flags=re.IGNORECASE | re.DOTALL)
+        empty_wrapper = re.compile(r"\[(b|center)\]\s*\[/\1\]\n?", flags=re.IGNORECASE)
+        while (stripped := empty_wrapper.sub("", desc)) != desc:
+            desc = stripped
 
         if is_adult(meta):
             pattern = r"(\[center\](?:(?!\[/center\]).)*\[/center\])"

--- a/tests/test_bbcode_sp_cleanup.py
+++ b/tests/test_bbcode_sp_cleanup.py
@@ -367,3 +367,10 @@ def test_upbrr_signature_is_removed() -> None:
     desc = "Kept.\n[right][url=https://github.com/autobrr/upbrr]Uploaded by upbrr[/url][/right]\nAlso kept."
     cleaned, _ = BBCODE().clean_unit3d_description(desc, "https://lst.gg")
     assert cleaned == "Kept.\nAlso kept."
+
+
+def test_site_anonymisation_keeps_image_and_link_hosts_intact() -> None:
+    desc = "[url=https://seedpool.org/torrents/1][img]https://cdn.seedpool.org/sp.png[/img][/url] [img]https://i.seedpool.org/abc[/img] Mirrored from seedpool.org."
+    cleaned, images = BBCODE().clean_unit3d_description(desc, "https://seedpool.org")
+    assert {i["img_url"] for i in images} == {"https://cdn.seedpool.org/sp.png", "https://i.seedpool.org/abc"}
+    assert "seedpool.org" not in cleaned and "from seedpool." in cleaned

--- a/tests/test_bbcode_sp_cleanup.py
+++ b/tests/test_bbcode_sp_cleanup.py
@@ -372,5 +372,13 @@ def test_upbrr_signature_is_removed() -> None:
 def test_site_anonymisation_keeps_image_and_link_hosts_intact() -> None:
     desc = "[url=https://seedpool.org/torrents/1][img]https://cdn.seedpool.org/sp.png[/img][/url] [img]https://i.seedpool.org/abc[/img] Mirrored from seedpool.org."
     cleaned, images = BBCODE().clean_unit3d_description(desc, "https://seedpool.org")
-    assert {i["img_url"] for i in images} == {"https://cdn.seedpool.org/sp.png", "https://i.seedpool.org/abc"}
+    assert sorted((i["img_url"], i["web_url"]) for i in images) == [
+        ("https://cdn.seedpool.org/sp.png", "https://seedpool.org/torrents/1"),
+        ("https://i.seedpool.org/abc", "https://i.seedpool.org/abc"),
+    ]
     assert "seedpool.org" not in cleaned and "from seedpool." in cleaned
+
+
+def test_site_anonymisation_leaves_longer_hosts_alone() -> None:
+    cleaned, _ = BBCODE().clean_unit3d_description("See seedpool.org.uk or seedpool.org-mirror, not seedpool.org!", "https://seedpool.org")
+    assert cleaned == "See seedpool.org.uk or seedpool.org-mirror, not seedpool!"

--- a/tests/test_ulcx.py
+++ b/tests/test_ulcx.py
@@ -225,3 +225,26 @@ class TestULCXRules:
         # means nothing was reused from a description, not that none will exist.
         assert self._passes(ulcx, image_list=[], screens=6) is True
         assert self._passes(ulcx, image_list=[], screens=2) is False
+
+
+class TestULCXDescription:
+    @pytest.fixture
+    def ulcx(self):
+        return ULCX(config=_config())
+
+    def _desc(self, ulcx, raw: str) -> str:
+        with patch("src.trackers.ULCX.DescriptionBuilder.unit3d_edit_desc", return_value=raw):
+            return _run(ulcx.get_description({"tmdb_id": 1, "keywords": [], "combined_genres": ""}))["description"]
+
+    def test_trailer_links_are_removed(self, ulcx):
+        raw = (
+            "Plot.\n"
+            "[center][b][url=https://www.youtube.com/watch?v=abc123][Trailer on YouTube][/url][/b][/center]\n"
+            "[url=https://youtu.be/abc123]Trailer[/url]\n"
+            "https://www.youtube.com/watch?v=abc123\n"
+            "[center][url=https://example.com/review]Review[/url][/center]"
+        )
+        cleaned = self._desc(ulcx, raw)
+        assert "youtu" not in cleaned
+        assert "[center][b][/b][/center]" not in cleaned and "[center][/center]" not in cleaned
+        assert "Plot." in cleaned and "[url=https://example.com/review]Review[/url]" in cleaned

--- a/tests/test_ulcx.py
+++ b/tests/test_ulcx.py
@@ -240,11 +240,13 @@ class TestULCXDescription:
         raw = (
             "Plot.\n"
             "[center][b][url=https://www.youtube.com/watch?v=abc123][Trailer on YouTube][/url][/b][/center]\n"
-            "[url=https://youtu.be/abc123]Trailer[/url]\n"
+            "[center][url=https://youtu.be/abc123][b]Trailer[/b][/url][/center]\n"
+            "[url]https://youtu.be/abc123[/url] [b]Tagline kept.[/b]\n"
             "https://www.youtube.com/watch?v=abc123\n"
             "[center][url=https://example.com/review]Review[/url][/center]"
         )
         cleaned = self._desc(ulcx, raw)
-        assert "youtu" not in cleaned
-        assert "[center][b][/b][/center]" not in cleaned and "[center][/center]" not in cleaned
-        assert "Plot." in cleaned and "[url=https://example.com/review]Review[/url]" in cleaned
+        assert cleaned == "Plot.\n [b]Tagline kept.[/b]\n\n[center][url=https://example.com/review]Review[/url][/center]"
+
+    def test_nested_empty_wrappers_collapse(self, ulcx):
+        assert self._desc(ulcx, "[center][b][center][b][/b][/center][/b][/center]") == ""

--- a/tests/test_ulcx.py
+++ b/tests/test_ulcx.py
@@ -219,3 +219,9 @@ class TestULCXRules:
         assert self._passes(ulcx, original_language="en", mediainfo=_mi(_text("en", True)), personalrelease=True) is False
         assert self._passes(ulcx, original_language="en", mediainfo=_mi(_text("en", False)), personalrelease=True) is True
         assert self._passes(ulcx, original_language="", mediainfo=_mi(_text("en", True)), personalrelease=True) is True
+
+    def test_empty_image_list_passes_when_screenshots_will_be_generated(self, ulcx):
+        # Pre-upload checks run before screenshot generation: an empty list only
+        # means nothing was reused from a description, not that none will exist.
+        assert self._passes(ulcx, image_list=[], screens=6) is True
+        assert self._passes(ulcx, image_list=[], screens=2) is False


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved site-name anonymisation while preserving image and link URLs.
  * Upload validation now supports items with either existing images or at least three configured screenshots.
  * Removed YouTube trailer links and empty formatting wrappers from generated descriptions.

* **Tests**
  * Added coverage for URL preservation, screenshot requirements, and description cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->