### PR TITLE
fix: postimg tos c411

### DIFF
--- a/src/trackers/C411.py
+++ b/src/trackers/C411.py
@@ -16,6 +16,7 @@ import json
 import os
 import re
 from typing import Any, Union
+from urllib.parse import urlparse
 
 import aiofiles
 import defusedxml.ElementTree as ET
@@ -24,6 +25,7 @@ from unidecode import unidecode
 
 from src.console import console
 from src.get_desc import DescriptionBuilder
+from src.imagehosts import host_slug
 from src.nfo_generator import decode_nfo, is_multi_episode_nfo
 from src.tmdb import TmdbManager
 from src.trackers.COMMON import COMMON
@@ -51,7 +53,7 @@ class C411(FrenchTrackerMixin):
         self.api_key: str = str(self.config["TRACKERS"].get(self.tracker, {}).get("api_key", "")).strip()
         # Hosts verified to actually render on the site; other common hosts
         # (ptscreens, lostimg) come out as dead images there.
-        self.approved_image_hosts = ["pixhost", "imgbb", "onlyimage", "imgbox"]
+        self.approved_image_hosts = ["pixhost", "imgbb", "onlyimage", "imgbox", "postimg"]
         self.tmdb_manager = TmdbManager(config)
         _reserved_note = "Internal C411 group: reserved for the team's own uploads"
         self.banned_groups: list[Any] = ["k0RE"] + [
@@ -1109,12 +1111,15 @@ class C411(FrenchTrackerMixin):
             parts.append(f"        [color={C}]Captures d'écran[/color]")
             parts.append("")
             img_lines: list[str] = []
+            # postimg thumbnails are 180px, too small to judge a capture: embed
+            # the stored image instead, one per row so it does not overflow.
+            per_row = 1 if any(host_slug(urlparse(img.get("img_url") or "").hostname or "") == "postimg" for img in image_list) else 2
             for img in image_list:
                 # Embed the thumbnail, linked to the full-size image: the site
                 # does not scale [img] tags, so a raw screenshot renders full width.
                 raw = img.get("raw_url", "")
                 web = img.get("web_url", "")
-                thumb = img.get("img_url", "") or raw
+                thumb = (img.get("img_url", "") if per_row == 2 else "") or raw
                 link = web or (raw if thumb != raw else "")
                 if thumb:
                     if link:
@@ -1124,7 +1129,7 @@ class C411(FrenchTrackerMixin):
             if img_lines:
                 parts.append("[center]")
                 # Two thumbnails per row, as on V3X.
-                parts.extend(" ".join(img_lines[i : i + 2]) for i in range(0, len(img_lines), 2))
+                parts.extend(" ".join(img_lines[i : i + per_row]) for i in range(0, len(img_lines), per_row))
                 parts.append("[/center]")
 
         # ── UA Signature ──
@@ -1355,6 +1360,9 @@ class C411(FrenchTrackerMixin):
             console.print("[yellow]C411: No NFO available — upload may be rejected[/yellow]")
         # ── Description ──
         description = await self._build_description(meta)
+        desc_path = f"{meta['base_dir']}/tmp/{meta['uuid']}/[{self.tracker}]DESCRIPTION.txt"
+        async with aiofiles.open(desc_path, "w", encoding="utf-8") as f:
+            await f.write(description)
 
         # ── Category / Subcategory ──
         cat_id, subcat_id = self._get_category_subcategory(meta)
@@ -1556,11 +1564,8 @@ class C411(FrenchTrackerMixin):
 
                 return False  # exhausted retries without explicit return
             else:
-                # ── Debug mode — save description & show summary ──
-                desc_path = f"{meta['base_dir']}/tmp/{meta['uuid']}/[{self.tracker}]DESCRIPTION.txt"
-                async with aiofiles.open(desc_path, "w", encoding="utf-8") as f:
-                    await f.write(description)
-                console.print(f"DEBUG: Saving final description to {desc_path}")
+                # ── Debug mode — show summary ──
+                console.print(f"DEBUG: description saved to {desc_path}")
                 console.print("[cyan]C411 Debug — Request data:[/cyan]")
                 console.print(f"  Title:       {title}")
                 console.print(f"  Category:    {cat_id} / Sub: {subcat_id}")

--- a/src/trackers/C411.py
+++ b/src/trackers/C411.py
@@ -1111,15 +1111,16 @@ class C411(FrenchTrackerMixin):
             parts.append(f"        [color={C}]Captures d'écran[/color]")
             parts.append("")
             img_lines: list[str] = []
-            # postimg thumbnails are 180px, too small to judge a capture: embed
-            # the stored image instead, one per row so it does not overflow.
-            per_row = 1 if any(host_slug(urlparse(img.get("img_url") or "").hostname or "") == "postimg" for img in image_list) else 2
             for img in image_list:
                 # Embed the thumbnail, linked to the full-size image: the site
                 # does not scale [img] tags, so a raw screenshot renders full width.
+                # postimg thumbnails are 180px, too small to judge a capture:
+                # embed its stored (already downscaled) image instead.
                 raw = img.get("raw_url", "")
                 web = img.get("web_url", "")
-                thumb = (img.get("img_url", "") if per_row == 2 else "") or raw
+                thumb = img.get("img_url", "") or raw
+                if host_slug(urlparse(thumb).hostname or "") == "postimg":
+                    thumb = raw
                 link = web or (raw if thumb != raw else "")
                 if thumb:
                     if link:
@@ -1129,7 +1130,7 @@ class C411(FrenchTrackerMixin):
             if img_lines:
                 parts.append("[center]")
                 # Two thumbnails per row, as on V3X.
-                parts.extend(" ".join(img_lines[i : i + per_row]) for i in range(0, len(img_lines), per_row))
+                parts.extend(" ".join(img_lines[i : i + 2]) for i in range(0, len(img_lines), 2))
                 parts.append("[/center]")
 
         # ── UA Signature ──

--- a/src/trackers/TOS.py
+++ b/src/trackers/TOS.py
@@ -62,7 +62,7 @@ class TOS(FrenchTrackerMixin, UNIT3D):
         ]
         # Hosts verified to actually render on the site; other common hosts
         # (pixhost, lostimg) come out as dead images there.
-        self.approved_image_hosts = ["ptscreens", "imgbb", "imgbox"]
+        self.approved_image_hosts = ["ptscreens", "imgbb", "imgbox", "postimg"]
         pass
 
     async def get_description(self, meta: dict[str, Any]) -> dict[str, str]:

--- a/src/trackers/V3X.py
+++ b/src/trackers/V3X.py
@@ -661,6 +661,9 @@ class V3X(FrenchTrackerMixin):
             return False
 
         description = await self._build_description(meta)
+        desc_path = f"{meta['base_dir']}/tmp/{meta['uuid']}/[{self.tracker}]DESCRIPTION.txt"
+        async with aiofiles.open(desc_path, "w", encoding="utf-8") as f:
+            await f.write(description)
         # The site rules keep the ORIGINAL release NFO (shipped untouched);
         # otherwise fall back to MediaInfo / a generated scene NFO, with the
         # "Complete name" line patched to the tracker release name.
@@ -711,9 +714,6 @@ class V3X(FrenchTrackerMixin):
         headers = {"Authorization": f"Bearer {self.api_key}", "Accept": "application/json"}
 
         if meta.get("debug"):
-            desc_path = f"{meta['base_dir']}/tmp/{meta['uuid']}/[{self.tracker}]DESCRIPTION.txt"
-            async with aiofiles.open(desc_path, "w", encoding="utf-8") as f:
-                await f.write(description)
             console.print(f"[cyan]{self.tracker} Debug — request data (description saved to {desc_path}):[/cyan]")
             console.print(f"  Name:        {name}")
             console.print(f"  Category:    {data['categoryId']}")

--- a/tests/test_c411.py
+++ b/tests/test_c411.py
@@ -1412,6 +1412,24 @@ class TestDescription:
         assert '[url=https://img.host/view/1][img]https://img.host/1.png[/img][/url]' in desc
         assert '[img]https://img.host/2.png[/img]' in desc
 
+    def test_postimg_screenshots_use_full_size_one_per_row(self):
+        # postimg thumbnails are 180px and the site does not scale [img]:
+        # embed the stored image instead, one per row so none overflows.
+        meta = _meta_base(image_list=[
+            {'img_url': f'https://i.postimg.cc/t{i}/x.png', 'raw_url': f'https://i.postimg.cc/r{i}/x.png', 'web_url': f'https://postimg.cc/p{i}'}
+            for i in (1, 2)
+        ])
+        c = C411(_config({'include_screenshots': True}))
+        desc = asyncio.run(c._build_description(meta))
+        assert (
+            '[url=https://postimg.cc/p1][img]https://i.postimg.cc/r1/x.png[/img][/url]\n'
+            '[url=https://postimg.cc/p2][img]https://i.postimg.cc/r2/x.png[/img][/url]\n'
+        ) in desc
+        assert 'https://i.postimg.cc/t1/x.png' not in desc
+
+    def test_postimg_is_an_approved_host(self):
+        assert 'postimg' in C411(_config()).approved_image_hosts
+
     def test_screenshots_excluded_by_default(self):
         meta = _meta_base(image_list=[
             {'raw_url': 'https://img.host/1.png', 'web_url': 'https://img.host/view/1'},

--- a/tests/test_c411.py
+++ b/tests/test_c411.py
@@ -1412,9 +1412,9 @@ class TestDescription:
         assert '[url=https://img.host/view/1][img]https://img.host/1.png[/img][/url]' in desc
         assert '[img]https://img.host/2.png[/img]' in desc
 
-    def test_postimg_screenshots_use_full_size_one_per_row(self):
+    def test_postimg_screenshots_embed_the_stored_image(self):
         # postimg thumbnails are 180px and the site does not scale [img]:
-        # embed the stored image instead, one per row so none overflows.
+        # embed the stored image instead, still two per row.
         meta = _meta_base(image_list=[
             {'img_url': f'https://i.postimg.cc/t{i}/x.png', 'raw_url': f'https://i.postimg.cc/r{i}/x.png', 'web_url': f'https://postimg.cc/p{i}'}
             for i in (1, 2)
@@ -1422,7 +1422,7 @@ class TestDescription:
         c = C411(_config({'include_screenshots': True}))
         desc = asyncio.run(c._build_description(meta))
         assert (
-            '[url=https://postimg.cc/p1][img]https://i.postimg.cc/r1/x.png[/img][/url]\n'
+            '[url=https://postimg.cc/p1][img]https://i.postimg.cc/r1/x.png[/img][/url] '
             '[url=https://postimg.cc/p2][img]https://i.postimg.cc/r2/x.png[/img][/url]\n'
         ) in desc
         assert 'https://i.postimg.cc/t1/x.png' not in desc

--- a/tests/test_tos.py
+++ b/tests/test_tos.py
@@ -415,3 +415,7 @@ class TestTosTypeId:
         for release_type in ("DISC", "REMUX", "ENCODE", "WEBDL", "WEBRIP", "HDTV", "UNKNOWN"):
             result = _run(t.get_type_id(self._type_meta(release_type)))
             assert result["type_id"] != "5", f"{release_type} produced invalid type_id 5"
+
+
+def test_postimg_is_an_approved_host() -> None:
+    assert "postimg" in TOS(_config()).approved_image_hosts

--- a/tests/test_v3x.py
+++ b/tests/test_v3x.py
@@ -236,6 +236,13 @@ class TestUpload:
         assert sent["files"]["file"][1] == b"fake-torrent"
         assert meta["tracker_status"]["V3X"]["torrent_id"] == "new-uuid"
 
+    def test_upload_saves_the_description(self, monkeypatch: Any, tmp_path: Any):
+        tracker = V3X(_config())
+        self._patch(monkeypatch, tracker, _FakeResponse(201, {"id": "new-uuid"}))
+        meta = self._meta(tmp_path)
+        asyncio.run(tracker.upload(meta, ""))
+        assert (tmp_path / "tmp" / meta["uuid"] / "[V3X]DESCRIPTION.txt").read_text(encoding="utf-8") == "desc"
+
     def test_upload_api_error_is_reported(self, monkeypatch: Any, tmp_path: Any):
         tracker = V3X(_config())
         self._patch(monkeypatch, tracker, _FakeResponse(400, {"error": "invalid_category"}))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Postimg-hosted images during uploads.
  * Full-size Postimg images are now included in descriptions instead of undersized thumbnails.
  * Postimg screenshots maintain a two-image-per-row layout.

* **Bug Fixes**
  * Upload descriptions are now saved consistently before processing continues.
  * Debug mode reuses the saved description without overwriting it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->