### PR TITLE
fix: stc imghost + french decision for en dub

### DIFF
--- a/src/trackers/STC.py
+++ b/src/trackers/STC.py
@@ -22,7 +22,7 @@ class STC(UNIT3D):
         self.search_url = f"{self.base_url}/api/torrents/filter"
         self.torrent_url = f"{self.base_url}/torrents/"
         self.banned_groups = [""]
-        self.approved_image_hosts = ["imgbox", "imgbb"]
+        self.approved_image_hosts = ["imgbox", "imgbb", "ptscreens", "pixhost"]
         pass
 
     skip_nfo: bool = True

--- a/src/trackers/STC.py
+++ b/src/trackers/STC.py
@@ -22,7 +22,7 @@ class STC(UNIT3D):
         self.search_url = f"{self.base_url}/api/torrents/filter"
         self.torrent_url = f"{self.base_url}/torrents/"
         self.banned_groups = [""]
-        self.approved_image_hosts = ["imgbox", "imgbb", "ptscreens", "pixhost"]
+        self.approved_image_hosts = ["imgbox", "imgbb", "ptscreens"]
         pass
 
     skip_nfo: bool = True

--- a/src/trackers/french/rules.py
+++ b/src/trackers/french/rules.py
@@ -68,9 +68,35 @@ class FrenchRulesMixin:
         """The shared French language rule; kwargs tune check_language_requirements per tracker."""
         options: dict[str, Any] = {"languages_to_check": list(FRENCH_LANG_VALUES), "check_audio": True, "check_subtitle": True, "require_both": False}
         options.update(kwargs)
-        if await self.common.check_language_requirements(meta, self.tracker, **options):
+        if not await self.common.check_language_requirements(meta, self.tracker, **options):
+            return self._rule_failed(meta, "french_language", f"Language requirements not met ({self.rule('french_language').summary}).")
+        # The shared check accepts French subtitles on their own; here they
+        # only count alongside an original-language audio track (VOSTFR).
+        # A dub in a third language with French subtitles is neither VF nor
+        # VOSTFR. Unknown original language or audio tracks are not judged.
+        if self._has_audio_in(meta, options["languages_to_check"]) or self._has_original_audio(meta):
             return True
-        return self._rule_failed(meta, "french_language", f"Language requirements not met ({self.rule('french_language').summary}).")
+        return self._rule_failed(
+            meta,
+            "french_language",
+            f"Language requirements not met ({self.rule('french_language').summary}).",
+            ("French subtitles only count with an original-language audio track.",),
+        )
+
+    def _has_audio_in(self, meta: Meta, languages: list[str]) -> bool:
+        wanted = {lang.lower() for lang in languages}
+        return any(lang.lower() in wanted for lang in self.common._coerce_language_values(meta.get("audio_languages", [])))
+
+    def _has_original_audio(self, meta: Meta) -> bool:
+        """True when an audio track is in the original language — or when that cannot be judged."""
+        original = meta.get("original_language") or ""
+        if isinstance(original, list):
+            original = original[0] if original and isinstance(original[0], str) else ""
+        if not original.strip() or meta.get("audio_languages") is None:
+            return True
+        candidates = self.common._expand_language_candidates(original.strip(), self.common._build_language_alias_lookup())
+        audio = {self.common._normalize_language_token(lang) for lang in self.common._coerce_language_values(meta.get("audio_languages", []))}
+        return bool(candidates & audio)
 
     async def get_additional_checks(self, meta: Meta) -> bool:
         """Default French language check for all French trackers.

--- a/tests/test_french_rules.py
+++ b/tests/test_french_rules.py
@@ -1,6 +1,7 @@
 """Contract: French trackers declare their rules as data and only report declared keys."""
 
 import ast
+import asyncio
 import pathlib
 from unittest.mock import patch
 
@@ -54,3 +55,26 @@ def test_dispositions_drive_the_outcome():
         assert ask.call_args.kwargs["default"] is True
     with pytest.raises(KeyError):
         fake._rule_failed({}, "nope", "m")
+
+
+def _config() -> dict:
+    cfg = {"api_key": "k", "announce_url": "https://example.invalid/announce/k"}
+    return {"TRACKERS": {n: dict(cfg) for n in ("C411", "TOS", "V3X", "G3MINI")}, "DEFAULT": {"tmdb_api": "k"}}
+
+
+def _lang_meta(audio: list[str], subs: list[str], original: str = "it") -> dict:
+    return {"audio_languages": audio, "subtitle_languages": subs, "original_language": original, "language_checked": True, "unattended": True, "debug": False}
+
+
+@pytest.mark.parametrize("cls", [C411, TOS, V3X, G3MINI])
+def test_french_subtitles_only_count_with_original_audio(cls):
+    # A dub in a third language with French subtitles is neither VF nor VOSTFR.
+    tracker = cls(config=_config())
+    run = lambda meta: asyncio.run(tracker._check_french_language(meta))  # noqa: E731
+    assert run(_lang_meta(["French"], [])) is True
+    assert run(_lang_meta(["Italian"], ["French"])) is True
+    assert run(_lang_meta(["English"], ["French"])) is False
+    assert run(_lang_meta(["English"], ["French"], original="en")) is True
+    # Unknown original language or audio tracks cannot be judged: not blocked.
+    assert run(_lang_meta(["English"], ["French"], original="")) is True
+    assert run({**_lang_meta([], ["French"]), "audio_languages": None}) is True

--- a/tests/test_stc.py
+++ b/tests/test_stc.py
@@ -103,5 +103,5 @@ class TestSTCEnglishLanguageCheck:
 
 def test_approved_image_hosts() -> None:
     # Rules only ask for lossless thumbnails linking to full-size images;
-    # ptscreens and pixhost keep the PNG intact and are in use on the site.
-    assert STC(config=_config()).approved_image_hosts == ["imgbox", "imgbb", "ptscreens", "pixhost"]
+    # ptscreens keeps the PNG intact and is in use on the site (pixhost is not rendered).
+    assert STC(config=_config()).approved_image_hosts == ["imgbox", "imgbb", "ptscreens"]

--- a/tests/test_stc.py
+++ b/tests/test_stc.py
@@ -99,3 +99,9 @@ class TestSTCEnglishLanguageCheck:
             "combined_genres": "",
         }
         assert _run(stc.get_additional_checks(meta)) is False
+
+
+def test_approved_image_hosts() -> None:
+    # Rules only ask for lossless thumbnails linking to full-size images;
+    # ptscreens and pixhost keep the PNG intact and are in use on the site.
+    assert STC(config=_config()).approved_image_hosts == ["imgbox", "imgbb", "ptscreens", "pixhost"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for images hosted on PTScreens and Pixhost.

* **Bug Fixes**
  * Improved French-language validation to correctly handle French audio, original-language audio with French subtitles, unsupported dubs, and missing metadata.
  * French subtitles alone no longer qualify when audio is in an unrelated language.

* **Tests**
  * Added regression coverage for language classification and approved image hosts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->