### PR TITLE
feat(images): fall back to per-tracker hosts when no common host works

### DIFF
--- a/src/get_tracker_data.py
+++ b/src/get_tracker_data.py
@@ -123,7 +123,6 @@ class TrackerDataManager:
                     "btn": "BTN",
                     "bhd": "BHD",
                     "hdb": "HDB",
-                    "sp": "SP",
                     "rf": "RF",
                     "otw": "OTW",
                     "yus": "YUS",
@@ -134,6 +133,8 @@ class TrackerDataManager:
                     "a4k": "A4K",
                     "stc": "STC",
                     "acm": "ACM",
+                    # SP descriptions often carry noise, consult it late
+                    "sp": "SP",
                     "ptp": "PTP",
                     "tos": "TOS",
                     "g3mini": "G3MINI",

--- a/src/rehostimages.py
+++ b/src/rehostimages.py
@@ -65,6 +65,11 @@ def configured_image_hosts(config: Mapping[str, Any]) -> list[str]:
     return hosts
 
 
+def last_image_host_slot(default_cfg: Mapping[str, Any]) -> int:
+    """Highest populated img_host_N index (slots may be sparse or repeat a host)."""
+    return max((i for i in range(1, 10) if default_cfg.get(f"img_host_{i}")), default=0)
+
+
 def trackers_lacking_images(meta: Mapping[str, Any], trackers: Sequence[str], minimum: int) -> list[str]:
     """Trackers whose per-tracker image list ended up with fewer than `minimum` entries."""
     return [t for t in trackers if len(meta.get(f"{t}_images_key") or []) < minimum]
@@ -312,8 +317,8 @@ async def _check_hosts(
         console.print(f"[yellow]No valid images found for {tracker}, will attempt to reupload...")
 
     images_reuploaded = False
-    # The index walks the configured img_host_N slots, so bound it by those.
-    max_retries = len(configured_image_hosts({"DEFAULT": default_config}))
+    # The index walks the img_host_N slots, so bound it by the last populated one.
+    max_retries = last_image_host_slot(default_config)
 
     while img_host_index <= max_retries:
         image_list, retry_mode, images_reuploaded = await _handle_image_upload(
@@ -616,14 +621,14 @@ async def _handle_image_upload(
         failed_hosts = meta["failed_image_hosts"]
 
         # Add a max retry limit to prevent infinite loop
-        max_retries = len(configured_image_hosts({"DEFAULT": default_config}))
+        max_retries = last_image_host_slot(default_config)
         while img_host_index <= max_retries:
             current_img_host_key = f"img_host_{img_host_index}"
             current_img_host = _as_str(default_config.get(current_img_host_key))
 
             if not current_img_host:
-                console.print("[red]No more image hosts left to try.")
-                return [], True, images_reuploaded
+                img_host_index += 1
+                continue  # sparse slot
 
             if current_img_host not in approved_image_hosts:
                 if meta["debug"]:
@@ -644,6 +649,9 @@ async def _handle_image_upload(
             if meta["debug"]:
                 console.print(f"[green]Uploading to approved host '{current_img_host}'.")
             break
+        else:
+            console.print("[red]No more image hosts left to try.")
+            return [], True, images_reuploaded
 
         uploaded_images, _ = await uploadscreens_manager.upload_screens(
             meta, multi_screens, img_host_index, 0, multi_screens, all_screenshots, {new_images_key: meta[new_images_key]}, retry_mode

--- a/src/rehostimages.py
+++ b/src/rehostimages.py
@@ -65,6 +65,11 @@ def configured_image_hosts(config: Mapping[str, Any]) -> list[str]:
     return hosts
 
 
+def trackers_lacking_images(meta: Mapping[str, Any], trackers: Sequence[str], minimum: int) -> list[str]:
+    """Trackers whose per-tracker image list ended up with fewer than `minimum` entries."""
+    return [t for t in trackers if len(meta.get(f"{t}_images_key") or []) < minimum]
+
+
 def choose_common_host(
     approved_by_tracker: Mapping[str, Any],
     configured_hosts: Sequence[str],
@@ -307,7 +312,8 @@ async def _check_hosts(
         console.print(f"[yellow]No valid images found for {tracker}, will attempt to reupload...")
 
     images_reuploaded = False
-    max_retries = len(approved_image_hosts)
+    # The index walks the configured img_host_N slots, so bound it by those.
+    max_retries = len(configured_image_hosts({"DEFAULT": default_config}))
 
     while img_host_index <= max_retries:
         image_list, retry_mode, images_reuploaded = await _handle_image_upload(
@@ -610,7 +616,7 @@ async def _handle_image_upload(
         failed_hosts = meta["failed_image_hosts"]
 
         # Add a max retry limit to prevent infinite loop
-        max_retries = len(approved_image_hosts)
+        max_retries = len(configured_image_hosts({"DEFAULT": default_config}))
         while img_host_index <= max_retries:
             current_img_host_key = f"img_host_{img_host_index}"
             current_img_host = _as_str(default_config.get(current_img_host_key))

--- a/tests/test_rehost_fallback.py
+++ b/tests/test_rehost_fallback.py
@@ -1,0 +1,74 @@
+"""Per-tracker rehost must be able to reach any configured host slot, and a
+tracker left without enough images on an approved host must be skipped."""
+
+import asyncio
+import pathlib
+from typing import Any
+
+import pytest
+
+from src.rehostimages import _handle_image_upload, trackers_lacking_images
+
+
+class _Uploader:
+    def __init__(self) -> None:
+        self.hosts: list[str] = []
+
+    async def upload_screens(self, meta: dict[str, Any], *args: Any, **kwargs: Any) -> Any:
+        self.hosts.append(meta["imghost"])
+        img = {"img_url": "https://img.ptscreens.com/a.md.png", "raw_url": "https://img.ptscreens.com/a.png", "web_url": "https://ptscreens.com/a"}
+        return [img], 1
+
+
+class _Screens:
+    async def screenshots(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+
+def test_rehost_reaches_an_approved_host_beyond_the_approved_list_size(tmp_path: pathlib.Path):
+    # 4 configured slots, 2 approved hosts: the approved one sits in slot 4.
+    uuid = "Movie.2024.1080p.WEB-GRP"
+    shots = tmp_path / "tmp" / uuid
+    shots.mkdir(parents=True)
+    (shots / "abc123.png").write_bytes(b"x")
+    meta = {
+        "base_dir": str(tmp_path),
+        "uuid": uuid,
+        "debug": False,
+        "is_disc": None,
+        "filelist": ["/x/movie.mkv"],
+        "image_list": [{"img_url": "https://lostimg.cc/abc123.png", "raw_url": "https://lostimg.cc/abc123.png", "web_url": "https://lostimg.cc/abc123.png"}],
+        "imghost": "lostimg",
+        "title": "Movie",
+        "video": "/x/movie.mkv",
+    }
+    default_config = {"img_host_1": "lostimg", "img_host_2": "pixhost", "img_host_3": "postimg", "img_host_4": "ptscreens", "screens": "1"}
+    uploader = _Uploader()
+
+    result, retry_mode, _ = asyncio.run(
+        _handle_image_upload(
+            meta,
+            "STC",
+            approved_image_hosts=["imgbox", "ptscreens"],
+            img_host_index=1,
+            default_config=default_config,
+            takescreens_manager=_Screens(),
+            uploadscreens_manager=uploader,
+        )
+    )
+
+    assert uploader.hosts == ["ptscreens"]
+    assert retry_mode is False
+    assert result and result[0]["raw_url"].startswith("https://img.ptscreens.com/")
+
+
+@pytest.mark.parametrize(
+    ("meta", "expected"),
+    [
+        ({"STC_images_key": [{}] * 4, "C411_images_key": [{}] * 2}, ["C411"]),
+        ({"STC_images_key": [{}] * 4}, ["C411"]),
+        ({"STC_images_key": [{}] * 4, "C411_images_key": [{}] * 4}, []),
+    ],
+)
+def test_trackers_lacking_images(meta: dict[str, Any], expected: list[str]):
+    assert trackers_lacking_images(meta, ["STC", "C411"], minimum=4) == expected

--- a/tests/test_rehost_fallback.py
+++ b/tests/test_rehost_fallback.py
@@ -25,8 +25,16 @@ class _Screens:
         return None
 
 
-def test_rehost_reaches_an_approved_host_beyond_the_approved_list_size(tmp_path: pathlib.Path):
-    # 4 configured slots, 2 approved hosts: the approved one sits in slot 4.
+@pytest.mark.parametrize(
+    "default_config",
+    [
+        # 4 slots, 2 approved hosts: the approved one sits in slot 4.
+        {"img_host_1": "lostimg", "img_host_2": "pixhost", "img_host_3": "postimg", "img_host_4": "ptscreens", "screens": "1"},
+        # Sparse and duplicated slots: the approved host sits beyond the distinct-host count.
+        {"img_host_1": "lostimg", "img_host_3": "lostimg", "img_host_5": "ptscreens", "screens": "1"},
+    ],
+)
+def test_rehost_reaches_an_approved_host_beyond_the_approved_list_size(tmp_path: pathlib.Path, default_config: dict[str, str]):
     uuid = "Movie.2024.1080p.WEB-GRP"
     shots = tmp_path / "tmp" / uuid
     shots.mkdir(parents=True)
@@ -42,7 +50,6 @@ def test_rehost_reaches_an_approved_host_beyond_the_approved_list_size(tmp_path:
         "title": "Movie",
         "video": "/x/movie.mkv",
     }
-    default_config = {"img_host_1": "lostimg", "img_host_2": "pixhost", "img_host_3": "postimg", "img_host_4": "ptscreens", "screens": "1"}
     uploader = _Uploader()
 
     result, retry_mode, _ = asyncio.run(

--- a/tests/test_tracker_id_reuse.py
+++ b/tests/test_tracker_id_reuse.py
@@ -86,8 +86,8 @@ def test_metadata_reuse_consultation_order() -> None:
     tracker_keys_maps = re.findall(r"tracker_keys = (\{[^}]*\})", _source("src/get_tracker_data.py"))
     order = list(ast.literal_eval(tracker_keys_maps[0]))
     preferred = [
-        "aither", "blu", "lst", "ulcx", "oe", "huno", "ant", "btn", "bhd", "hdb", "sp", "rf",
-        "otw", "yus", "dp", "lume", "hhd", "ihd", "a4k", "stc", "acm", "ptp", "tos", "g3mini",
+        "aither", "blu", "lst", "ulcx", "oe", "huno", "ant", "btn", "bhd", "hdb", "rf",
+        "otw", "yus", "dp", "lume", "hhd", "ihd", "a4k", "stc", "acm", "sp", "ptp", "tos", "g3mini",
     ]
     extra = sorted(k for k in NEW_TRACKERS if k not in preferred)
     assert order == preferred + extra

--- a/upload.py
+++ b/upload.py
@@ -46,7 +46,14 @@ from src.nfo_link import NfoLinkManager
 from src.proxy_env import apply_proxy_env
 from src.qbitwait import Wait
 from src.queuemanage import QueueManager
-from src.rehostimages import TRACKERS_WITH_IMAGE_HOST_REQUIREMENTS, check_tracker_image_hosts, choose_common_host, configured_image_hosts, validate_reused_image_hosts
+from src.rehostimages import (
+    TRACKERS_WITH_IMAGE_HOST_REQUIREMENTS,
+    check_tracker_image_hosts,
+    choose_common_host,
+    configured_image_hosts,
+    trackers_lacking_images,
+    validate_reused_image_hosts,
+)
 from src.takescreens import TakeScreensManager
 from src.torrentcreate import TorrentCreator
 from src.trackerhandle import process_trackers
@@ -1186,25 +1193,38 @@ async def process_meta(meta: Meta, base_dir: str, bot: Any = None) -> Optional[b
                             host_order = list(allowed_hosts)
 
                         start_index = host_order.index(current_img_host) if current_img_host in host_order else 0
-                        image_list_count = 0
+                        tried_hosts: list[str] = []
 
-                        for idx in range(start_index, len(host_order)):
-                            if host_order[idx] in (meta.get("failed_image_hosts") or []):
-                                continue  # already exhausted by upload_screens' own fallback chain
-                            meta["imghost"] = host_order[idx]
-                            await uploadscreens_manager.upload_screens(meta, meta["screens"], 1, 0, meta["screens"], [], return_dict=return_dict, allowed_hosts=allowed_hosts)
-                            image_list_count = len(meta.get("image_list", []) or [])
-                            if meta.get("debug"):
-                                console.print(f"[cyan]Image host debug: post-upload_screens image_list={image_list_count}[/cyan]")
+                        async def try_hosts(hosts: list[str], allowed: Optional[list[str]]) -> int:
+                            count = 0
+                            for idx, host in enumerate(hosts):
+                                if host in (meta.get("failed_image_hosts") or []):
+                                    continue  # already exhausted by upload_screens' own fallback chain
+                                tried_hosts.append(host)
+                                meta["imghost"] = host
+                                await uploadscreens_manager.upload_screens(meta, meta["screens"], 1, 0, meta["screens"], [], return_dict=return_dict, allowed_hosts=allowed)
+                                count = len(meta.get("image_list", []) or [])
+                                if meta.get("debug"):
+                                    console.print(f"[cyan]Image host debug: post-upload_screens image_list={count}[/cyan]")
+                                if count >= min_successful_uploads:
+                                    break
+                                if idx + 1 < len(hosts):
+                                    console.print(
+                                        f"[yellow]Only {count} images uploaded; minimum is {min_successful_uploads}. Switching to next host: {hosts[idx + 1]}[/yellow]"
+                                    )
+                            return count
 
-                            if image_list_count >= min_successful_uploads:
-                                break
+                        image_list_count = await try_hosts(host_order[start_index:], allowed_hosts)
 
-                            if idx + 1 < len(host_order):
-                                console.print(
-                                    f"[yellow]Only {image_list_count} images uploaded; minimum is {min_successful_uploads}. "
-                                    f"Switching to next host: {host_order[idx + 1]}[/yellow]"
-                                )
+                        if image_list_count < min_successful_uploads and allowed_hosts:
+                            # No host common to every tracker works: upload to any
+                            # working host, then rehost per tracker below — each
+                            # strict tracker gets a host it approves, or is skipped.
+                            remaining = [h for h in configured_image_hosts(config) if h not in tried_hosts and h not in (meta.get("failed_image_hosts") or [])]
+                            console.print(
+                                f"[yellow]No common image host is working ({', '.join(tried_hosts)}); trying {', '.join(remaining) or 'nothing'} and rehosting per tracker.[/yellow]"
+                            )
+                            image_list_count = await try_hosts(remaining, None)
 
                         if image_list_count < min_successful_uploads:
                             raise Exception(f"Minimum of {min_successful_uploads} successful image uploads required, but only {image_list_count} were uploaded.")
@@ -1223,6 +1243,12 @@ async def process_meta(meta: Meta, base_dir: str, bot: Any = None) -> Optional[b
                                 console.print(
                                     f"[cyan]Image host debug: post-upload after  {tracker_name}.check_image_hosts() image_list={len(meta.get('image_list', []) or [])} {key}={len(meta.get(key, []) or [])}[/cyan]"  # noqa: E501
                                 )
+                        for tracker_name in trackers_lacking_images(meta, relevant_trackers, min_successful_uploads):
+                            approved = getattr(tracker_class_map[tracker_name](config=config), "approved_image_hosts", None) or []
+                            console.print(f"[bold red]{tracker_name}: no working approved image host ({', '.join(approved)}); skipping this tracker.[/bold red]")
+                            tracker_status_entry = cast(dict[str, Any], meta.setdefault("tracker_status", {})).setdefault(tracker_name, {})
+                            tracker_status_entry["upload"] = False
+                            tracker_status_entry["status_message"] = "skipped: no working approved image host"
                     except asyncio.CancelledError:
                         console.print("\n[red]Upload process interrupted! Cancelling tasks...[/red]")
                         return

--- a/upload.py
+++ b/upload.py
@@ -468,6 +468,16 @@ async def validate_tracker_logins(meta: Meta, trackers: Optional[list[str]] = No
         await asyncio.gather(*[validate_single_tracker(tracker) for tracker in valid_trackers])
 
 
+def _skip_trackers_without_approved_images(meta: Meta, config: dict[str, Any], trackers: list[str], minimum: int) -> None:
+    """Disable trackers whose approved-host image list is too short: better skipped than uploaded with broken links."""
+    for tracker_name in trackers_lacking_images(meta, trackers, minimum):
+        approved = getattr(tracker_class_map[tracker_name](config=config), "approved_image_hosts", None) or []
+        console.print(f"[bold red]{tracker_name}: no working approved image host ({', '.join(approved)}); skipping this tracker.[/bold red]")
+        entry = cast(dict[str, Any], meta.setdefault("tracker_status", {})).setdefault(tracker_name, {})
+        entry["upload"] = False
+        entry["status_message"] = "skipped: no working approved image host"
+
+
 async def process_meta(meta: Meta, base_dir: str, bot: Any = None) -> Optional[bool]:
     """Process the metadata for each queued path."""
     if use_discord and bot:
@@ -1243,12 +1253,7 @@ async def process_meta(meta: Meta, base_dir: str, bot: Any = None) -> Optional[b
                                 console.print(
                                     f"[cyan]Image host debug: post-upload after  {tracker_name}.check_image_hosts() image_list={len(meta.get('image_list', []) or [])} {key}={len(meta.get(key, []) or [])}[/cyan]"  # noqa: E501
                                 )
-                        for tracker_name in trackers_lacking_images(meta, relevant_trackers, min_successful_uploads):
-                            approved = getattr(tracker_class_map[tracker_name](config=config), "approved_image_hosts", None) or []
-                            console.print(f"[bold red]{tracker_name}: no working approved image host ({', '.join(approved)}); skipping this tracker.[/bold red]")
-                            tracker_status_entry = cast(dict[str, Any], meta.setdefault("tracker_status", {})).setdefault(tracker_name, {})
-                            tracker_status_entry["upload"] = False
-                            tracker_status_entry["status_message"] = "skipped: no working approved image host"
+                        _skip_trackers_without_approved_images(meta, config, relevant_trackers, min_successful_uploads)
                     except asyncio.CancelledError:
                         console.print("\n[red]Upload process interrupted! Cancelling tasks...[/red]")
                         return
@@ -1265,7 +1270,8 @@ async def process_meta(meta: Meta, base_dir: str, bot: Any = None) -> Optional[b
                     # description) — the screenshot-upload block above was skipped,
                     # but trackers with approved-host requirements still need the
                     # existing images validated and rehosted when necessary.
-                    await validate_reused_image_hosts(meta, config, tracker_class_map)
+                    validated = await validate_reused_image_hosts(meta, config, tracker_class_map)
+                    _skip_trackers_without_approved_images(meta, config, validated, int(config.get("DEFAULT", {}).get("min_successful_image_uploads", 3)))
 
                 elif meta.get("skip_imghost_upload", False) is True and meta.get("image_list", False) is False:
                     meta["image_list"] = []


### PR DESCRIPTION
When every host approved by all trackers fails, screenshots are uploaded to the first working configured host and each strict tracker is rehosted on a host it approves; a tracker left without enough approved images is skipped instead of aborting the whole release. The rehost loop is now bounded by the configured host slots rather than the approved-list size.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Image rehosting now checks additional configured hosts when approved hosts cannot provide enough images.
  - Trackers with insufficient images and no working approved image host are clearly marked as skipped.
- **Bug Fixes**
  - Improved host retry handling ensures later configured image hosts can be used successfully.
  - Updated tracker metadata reuse priorities to include additional supported trackers.
  - Adjusted default tracker preference ordering to place SP after ACM.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->