### PR TITLE
fix(UNIT3D): skip the tracker when the dupe search fails

### DIFF
--- a/src/trackers/UNIT3D.py
+++ b/src/trackers/UNIT3D.py
@@ -160,14 +160,13 @@ class UNIT3D:
                                 result["description"] = attributes.get("description", "")
                             dupes.append(result)
                     else:
-                        console.print(f"[bold red]Failed to search torrents. HTTP Status: {response.status_code}")
+                        self._dupe_search_failed(meta, f"HTTP {response.status_code}")
+                        return []
         except httpx.HTTPStatusError as e:
             if e.response.status_code == 302:
-                meta["tracker_status"][self.tracker]["status_message"] = (
-                    "data error: Redirect (302). This may indicate a problem with authentication. Please verify that your API key is valid."
-                )
+                self._dupe_search_failed(meta, "redirect (302), the API key may be invalid")
             else:
-                meta["tracker_status"][self.tracker]["status_message"] = f"data error: HTTP {e.response.status_code} - {e.response.text}"
+                self._dupe_search_failed(meta, f"HTTP {e.response.status_code} - {e.response.text}")
         except httpx.TimeoutException:
             self._dupe_search_failed(meta, "request timed out after 10 seconds")
         except httpx.RequestError as e:

--- a/src/trackers/UNIT3D.py
+++ b/src/trackers/UNIT3D.py
@@ -169,14 +169,20 @@ class UNIT3D:
             else:
                 meta["tracker_status"][self.tracker]["status_message"] = f"data error: HTTP {e.response.status_code} - {e.response.text}"
         except httpx.TimeoutException:
-            console.print("[bold red]Request timed out after 10 seconds")
+            self._dupe_search_failed(meta, "request timed out after 10 seconds")
         except httpx.RequestError as e:
-            console.print(f"[bold red]Unable to search for existing torrents: {e}")
+            self._dupe_search_failed(meta, str(e))
         except Exception as e:
-            console.print(f"[bold red]Unexpected error: {e}")
+            self._dupe_search_failed(meta, f"unexpected error: {e}")
             await asyncio.sleep(5)
 
         return dupes
+
+    def _dupe_search_failed(self, meta: dict[str, Any], reason: str) -> None:
+        """A failed search is not "no dupes": skip the tracker rather than upload over a possible dupe."""
+        console.print(f"[bold red]{self.tracker}: dupe search failed ({reason}); skipping tracker to avoid a false negative.[/bold red]")
+        meta["tracker_status"][self.tracker]["status_message"] = f"dupe search failed: {reason}"
+        meta["skipping"] = self.tracker
 
     async def get_name(self, meta: dict[str, Any]) -> dict[str, str]:
         return {"name": meta["name"]}

--- a/tests/test_unit3d_search_existing.py
+++ b/tests/test_unit3d_search_existing.py
@@ -46,8 +46,6 @@ def test_site_local_region_ids_override_the_shared_table():
 
 
 def _search_failing(exc: Exception) -> dict[str, Any]:
-    import httpx
-
     tracker = BLU({"TRACKERS": {"BLU": {"api_key": "k", "announce_url": "http://a"}}, "DEFAULT": {}})
     meta: dict[str, Any] = {"category": "MOVIE", "tmdb": 1, "debug": False, "type": "ENCODE", "resolution": "1080p", "uuid": "x", "base_dir": "/tmp"}
     client = AsyncMock()
@@ -59,15 +57,29 @@ def _search_failing(exc: Exception) -> dict[str, Any]:
         patch("src.trackers.UNIT3D.asyncio.sleep", AsyncMock()),
     ):
         assert asyncio.run(tracker.search_existing(meta, None)) == []
-    del httpx
     return meta
 
 
-def test_failed_dupe_search_skips_the_tracker():
-    # A network failure is not "no dupes": fail closed like V3X does.
+def _http_error(status: int) -> Exception:
     import httpx
 
-    for exc in (httpx.ConnectError("[SSL: WRONG_VERSION_NUMBER]"), httpx.ReadTimeout("t"), RuntimeError("boom")):
+    request = httpx.Request("GET", "http://a")
+    return httpx.HTTPStatusError("e", request=request, response=httpx.Response(status, request=request, text="busy"))
+
+
+def test_failed_dupe_search_skips_the_tracker():
+    # A network or HTTP failure is not "no dupes": fail closed like V3X does.
+    import httpx
+
+    cases = [
+        (httpx.ConnectError("[SSL: WRONG_VERSION_NUMBER]"), "WRONG_VERSION_NUMBER"),
+        (httpx.ReadTimeout("t"), "timed out"),
+        (RuntimeError("boom"), "unexpected error: boom"),
+        (_http_error(429), "HTTP 429"),
+        (_http_error(302), "API key"),
+    ]
+    for exc, reason in cases:
         meta = _search_failing(exc)
         assert meta["skipping"] == "BLU", exc
-        assert "dupe search failed" in meta["tracker_status"]["BLU"]["status_message"]
+        assert meta["tracker_status"]["BLU"]["status_message"].startswith("dupe search failed: "), exc
+        assert reason in meta["tracker_status"]["BLU"]["status_message"], exc

--- a/tests/test_unit3d_search_existing.py
+++ b/tests/test_unit3d_search_existing.py
@@ -43,3 +43,31 @@ def test_site_local_region_ids_override_the_shared_table():
     assert _asyncio.run(AITHER(cfg).get_region_id({"region": "FIN"})) == {"region_id": "244"}
     assert _asyncio.run(LST(cfg).get_region_id({"region": "FIN"})) == {"region_id": "245"}
     assert _asyncio.run(LST(cfg).get_region_id({"region": "FRA"})) == {"region_id": "73"}  # shared table still applies
+
+
+def _search_failing(exc: Exception) -> dict[str, Any]:
+    import httpx
+
+    tracker = BLU({"TRACKERS": {"BLU": {"api_key": "k", "announce_url": "http://a"}}, "DEFAULT": {}})
+    meta: dict[str, Any] = {"category": "MOVIE", "tmdb": 1, "debug": False, "type": "ENCODE", "resolution": "1080p", "uuid": "x", "base_dir": "/tmp"}
+    client = AsyncMock()
+    client.get.side_effect = exc
+    client.__aenter__.return_value = client
+    with (
+        patch("src.trackers.UNIT3D.httpx.AsyncClient", return_value=client),
+        patch.object(tracker, "get_additional_checks", AsyncMock(return_value=True)),
+        patch("src.trackers.UNIT3D.asyncio.sleep", AsyncMock()),
+    ):
+        assert asyncio.run(tracker.search_existing(meta, None)) == []
+    del httpx
+    return meta
+
+
+def test_failed_dupe_search_skips_the_tracker():
+    # A network failure is not "no dupes": fail closed like V3X does.
+    import httpx
+
+    for exc in (httpx.ConnectError("[SSL: WRONG_VERSION_NUMBER]"), httpx.ReadTimeout("t"), RuntimeError("boom")):
+        meta = _search_failing(exc)
+        assert meta["skipping"] == "BLU", exc
+        assert "dupe search failed" in meta["tracker_status"]["BLU"]["status_message"]


### PR DESCRIPTION
A network error during the search (timeout, SSL mismatch, proxy error) returned an empty dupe list, so the release was uploaded over an existing one. The message now names the tracker and the tracker is skipped, as V3X already does for incomplete searches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate-search error handling for tracker connections, timeouts, and unexpected failures.
  * Failed duplicate searches now mark the tracker as skipped and prevent uploads based on incomplete results.
  * Added clearer status messages when duplicate checks cannot be completed.

* **Tests**
  * Added coverage for connection, timeout, and unexpected duplicate-search failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->