### PR TITLE
fix(STC,YUS,ACM): stop treating the TMDB 'adult animation' keyword as…

### DIFF
--- a/src/trackers/ACM.py
+++ b/src/trackers/ACM.py
@@ -382,9 +382,7 @@ class ACM:
             if not cli_ui.ask_yes_no("Is this show currently airing?", default=False):
                 return False
 
-        if is_adult(meta, ("hentai", "softcore", "jav", "japanese adult video")) and not ask_to_continue(
-            meta, f"{self.tracker}: Adult, hentai, and JAV content is not permitted."
-        ):
+        if is_adult(meta) and not ask_to_continue(meta, f"{self.tracker}: Adult, hentai, and JAV content is not permitted."):
             return False
 
         # BDMV full-disc structures are allowed (that's the primary Blu-ray format).

--- a/src/trackers/ACM.py
+++ b/src/trackers/ACM.py
@@ -12,7 +12,7 @@ import pycountry
 
 from src.bbcode import BBCODE
 from src.console import console
-from src.trackers.COMMON import COMMON
+from src.trackers.COMMON import COMMON, ask_to_continue, is_adult
 
 
 class ACM:
@@ -382,19 +382,10 @@ class ACM:
             if not cli_ui.ask_yes_no("Is this show currently airing?", default=False):
                 return False
 
-        # ── Adult content (hentai, porn, JAV) ────────────────────────────────────
-        # TMDB keywords are not always reliable, so this is a soft block: the user
-        # can override if the detection is a false positive.
-        genres_combined = f"{meta.get('keywords', '') or ''} {meta.get('combined_genres', '') or ''}".lower()
-        adult_keywords = ["hentai", "xxx", "porn", "erotic", "softcore", "orgy", "jav", "japanese adult video"]
-        if any(re.search(rf"(^|[,\s]){re.escape(kw)}([,\s]|$)", genres_combined) for kw in adult_keywords):
-            if not bool(meta.get("unattended")) or (bool(meta.get("unattended")) and meta.get("unattended_confirm", False)):
-                console.print(f"[bold red]{self.tracker}: Adult, hentai, and JAV content is not permitted.[/bold red]")
-                console.print("[yellow]Note: TMDB keywords may not be reliable — override if this is a false positive.[/yellow]")
-                if not cli_ui.ask_yes_no("Do you want to upload anyway?", default=False):
-                    return False
-            else:
-                return False
+        if is_adult(meta, ("hentai", "softcore", "jav", "japanese adult video")) and not ask_to_continue(
+            meta, f"{self.tracker}: Adult, hentai, and JAV content is not permitted."
+        ):
+            return False
 
         # BDMV full-disc structures are allowed (that's the primary Blu-ray format).
         # Only raw ISOs are restricted to 3D/MGVC, but UA never uploads ISOs — it

--- a/src/trackers/ACM.py
+++ b/src/trackers/ACM.py
@@ -386,7 +386,7 @@ class ACM:
         # TMDB keywords are not always reliable, so this is a soft block: the user
         # can override if the detection is a false positive.
         genres_combined = f"{meta.get('keywords', '') or ''} {meta.get('combined_genres', '') or ''}".lower()
-        adult_keywords = ["hentai", "xxx", "porn", "erotic", "adult animation", "softcore", "orgy", "jav", "japanese adult video"]
+        adult_keywords = ["hentai", "xxx", "porn", "erotic", "softcore", "orgy", "jav", "japanese adult video"]
         if any(re.search(rf"(^|[,\s]){re.escape(kw)}([,\s]|$)", genres_combined) for kw in adult_keywords):
             if not bool(meta.get("unattended")) or (bool(meta.get("unattended")) and meta.get("unattended_confirm", False)):
                 console.print(f"[bold red]{self.tracker}: Adult, hentai, and JAV content is not permitted.[/bold red]")

--- a/src/trackers/COMMON.py
+++ b/src/trackers/COMMON.py
@@ -24,7 +24,7 @@ from src.console import console
 from src.exportmi import exportInfo
 from src.languages import languages_manager
 
-ADULT_KEYWORDS: tuple[str, ...] = ("xxx", "erotic", "porn", "orgy", "hentai", "softcore", "jav", "japanese adult video")
+ADULT_KEYWORDS: tuple[str, ...] = ("xxx", "erotic", "erotica", "porn", "orgy", "hentai", "softcore", "jav", "japanese adult video")
 
 
 def ask_to_continue(meta: dict[str, Any], msg: str, question: str = "Do you want to upload anyway?", default: bool = False) -> bool:

--- a/src/trackers/COMMON.py
+++ b/src/trackers/COMMON.py
@@ -24,7 +24,7 @@ from src.console import console
 from src.exportmi import exportInfo
 from src.languages import languages_manager
 
-ADULT_KEYWORDS: tuple[str, ...] = ("xxx", "erotic", "porn", "orgy")
+ADULT_KEYWORDS: tuple[str, ...] = ("xxx", "erotic", "porn", "orgy", "hentai", "softcore", "jav", "japanese adult video")
 
 
 def ask_to_continue(meta: dict[str, Any], msg: str, question: str = "Do you want to upload anyway?", default: bool = False) -> bool:

--- a/src/trackers/COMMON.py
+++ b/src/trackers/COMMON.py
@@ -24,7 +24,7 @@ from src.console import console
 from src.exportmi import exportInfo
 from src.languages import languages_manager
 
-ADULT_KEYWORDS: tuple[str, ...] = ("xxx", "erotic", "porn", "adult", "orgy")
+ADULT_KEYWORDS: tuple[str, ...] = ("xxx", "erotic", "porn", "orgy")
 
 
 def ask_to_continue(meta: dict[str, Any], msg: str, question: str = "Do you want to upload anyway?", default: bool = False) -> bool:
@@ -37,9 +37,9 @@ def ask_to_continue(meta: dict[str, Any], msg: str, question: str = "Do you want
 
 
 def is_adult(meta: dict[str, Any], extra_keywords: tuple[str, ...] = ()) -> bool:
-    """True when TMDb keywords/genres contain an adult-content marker."""
+    """True when a TMDb keyword/genre contains an adult-content marker as a whole word ("gay porn" counts, "adulthood" does not)."""
     genres = f"{meta.get('keywords', '')}, {meta.get('combined_genres', '')}"
-    return any(re.search(rf"(^|,\s*){re.escape(k)}(\s*,|$)", genres, re.IGNORECASE) for k in (*ADULT_KEYWORDS, *extra_keywords))
+    return any(re.search(rf"\b{re.escape(k)}\b", genres, re.IGNORECASE) for k in (*ADULT_KEYWORDS, *extra_keywords))
 
 
 def mi_tracks(meta: dict[str, Any], track_type: str) -> list[dict[str, Any]]:

--- a/src/trackers/OTW.py
+++ b/src/trackers/OTW.py
@@ -107,7 +107,7 @@ class OTW(UNIT3D):
         keywords = ", ".join(cast(list[str], keywords_value)) if isinstance(keywords_value, list) else str(keywords_value)
         combined_genres_text = ", ".join(combined_genres)
         genres = f"{keywords}, {combined_genres_text}"
-        if is_adult(meta, ("hentai", "adult animation", "softcore")) and not ask_to_continue(meta, "Adult animation not allowed at OTW."):
+        if is_adult(meta, ("adult animation",)) and not ask_to_continue(meta, "Adult animation not allowed at OTW."):
             return False
 
         game_show_keywords = ["reality", "game show", "game-show", "reality tv", "reality television"]

--- a/src/trackers/SP.py
+++ b/src/trackers/SP.py
@@ -114,7 +114,7 @@ class SP(UNIT3D):
             else:
                 return False
 
-        if is_adult(meta, ("erotica",)) and not ask_to_continue(meta, f"Porn/xxx is not allowed at {self.tracker}."):
+        if is_adult(meta) and not ask_to_continue(meta, f"Porn/xxx is not allowed at {self.tracker}."):
             return False
 
         return should_continue

--- a/src/trackers/STC.py
+++ b/src/trackers/STC.py
@@ -53,7 +53,7 @@ class STC(UNIT3D):
                 console.print(f"[bold red]Only TV uploads allowed at {self.tracker}.[/bold red]")
             return False
 
-        if is_adult(meta, ("hentai", "softcore")) and not ask_to_continue(meta, f"Porn is not allowed at {self.tracker}."):
+        if is_adult(meta) and not ask_to_continue(meta, f"Porn is not allowed at {self.tracker}."):
             return False
 
         if meta.get("is_disc") not in ["BDMV", "DVD"] and not await self.common.check_language_requirements(

--- a/src/trackers/STC.py
+++ b/src/trackers/STC.py
@@ -53,7 +53,7 @@ class STC(UNIT3D):
                 console.print(f"[bold red]Only TV uploads allowed at {self.tracker}.[/bold red]")
             return False
 
-        if is_adult(meta, ("hentai", "adult animation", "softcore")) and not ask_to_continue(meta, f"Porn is not allowed at {self.tracker}."):
+        if is_adult(meta, ("hentai", "softcore")) and not ask_to_continue(meta, f"Porn is not allowed at {self.tracker}."):
             return False
 
         if meta.get("is_disc") not in ["BDMV", "DVD"] and not await self.common.check_language_requirements(

--- a/src/trackers/YUS.py
+++ b/src/trackers/YUS.py
@@ -73,7 +73,7 @@ class YUS(UNIT3D):
     async def get_additional_checks(self, meta: Meta) -> bool:
         should_continue = True
 
-        if is_adult(meta, ("hentai", "softcore")) and not ask_to_continue(meta, "Porn/xxx is not allowed at YUS."):
+        if is_adult(meta) and not ask_to_continue(meta, "Porn/xxx is not allowed at YUS."):
             return False
 
         tag_group = str(meta.get("tag", "")).strip("-").strip().lower()

--- a/src/trackers/YUS.py
+++ b/src/trackers/YUS.py
@@ -73,7 +73,7 @@ class YUS(UNIT3D):
     async def get_additional_checks(self, meta: Meta) -> bool:
         should_continue = True
 
-        if is_adult(meta, ("hentai", "adult animation", "softcore")) and not ask_to_continue(meta, "Porn/xxx is not allowed at YUS."):
+        if is_adult(meta, ("hentai", "softcore")) and not ask_to_continue(meta, "Porn/xxx is not allowed at YUS."):
             return False
 
         tag_group = str(meta.get("tag", "")).strip("-").strip().lower()

--- a/tests/test_acm.py
+++ b/tests/test_acm.py
@@ -863,6 +863,12 @@ class TestAdditionalChecksAdultContent:
         meta = _checks_meta(combined_genres="Drama", keywords="jav")
         assert _run(acm.get_additional_checks(meta)) is False
 
+    def test_adult_animation_keyword_is_not_rejected(self):
+        """TMDB tags mainstream adult cartoons 'adult animation'; only hentai/porn markers block."""
+        acm = ACM(_config())
+        meta = _checks_meta(combined_genres="Animation, Comedy", keywords="adult animation, satire")
+        assert _run(acm.get_additional_checks(meta)) is True
+
     def test_normal_animation_is_not_rejected(self):
         """The word 'animation' alone must not trigger the adult-content check."""
         acm = ACM(_config())

--- a/tests/test_common_helpers.py
+++ b/tests/test_common_helpers.py
@@ -18,6 +18,8 @@ def test_is_adult_matches_whole_keywords_only():
     assert is_adult({"keywords": "drama", "combined_genres": "Erotic, Thriller"}) is True  # first genre
     assert is_adult({"keywords": "xxx", "combined_genres": ""}) is True  # lone keyword
     assert is_adult({"keywords": "adulthood", "combined_genres": "Drama"}) is False
+    assert is_adult({"keywords": "gay porn, drama", "combined_genres": ""}) is True  # marker inside a compound keyword
+    assert is_adult({"keywords": "adult animation, adult humor", "combined_genres": "Animation"}) is False
     assert is_adult({"keywords": "", "combined_genres": "Drama, Hentai"}) is False
     assert is_adult({"keywords": "", "combined_genres": "Drama, Hentai"}, ("hentai",)) is True
 

--- a/tests/test_common_helpers.py
+++ b/tests/test_common_helpers.py
@@ -20,8 +20,8 @@ def test_is_adult_matches_whole_keywords_only():
     assert is_adult({"keywords": "adulthood", "combined_genres": "Drama"}) is False
     assert is_adult({"keywords": "gay porn, drama", "combined_genres": ""}) is True  # marker inside a compound keyword
     assert is_adult({"keywords": "adult animation, adult humor", "combined_genres": "Animation"}) is False
-    assert is_adult({"keywords": "", "combined_genres": "Drama, Hentai"}) is False
-    assert is_adult({"keywords": "", "combined_genres": "Drama, Hentai"}, ("hentai",)) is True
+    assert is_adult({"keywords": "", "combined_genres": "Drama, Hentai"}) is True  # base list covers hentai/JAV
+    assert is_adult({"keywords": "", "combined_genres": "Drama"}, ("drama",)) is True  # tracker extras
 
 
 def test_mi_tracks_and_lossless():

--- a/tests/test_stc.py
+++ b/tests/test_stc.py
@@ -100,6 +100,37 @@ class TestSTCEnglishLanguageCheck:
         }
         assert _run(stc.get_additional_checks(meta)) is False
 
+    def test_adult_animation_keyword_passes(self, stc):
+        """TMDB tags mainstream adult cartoons 'adult animation'; only hentai/porn markers block."""
+        meta = {
+            "category": "TV",
+            "audio_languages": ["English"],
+            "subtitle_languages": [],
+            "is_disc": None,
+            "type": "WEBDL",
+            "debug": False,
+            "unattended": True,
+            "keywords": "adult animation, satire",
+            "combined_genres": "Animation, Comedy",
+        }
+        with patch("src.trackers.COMMON.languages_manager") as mock_lm:
+            mock_lm.process_desc_language = AsyncMock()
+            assert _run(stc.get_additional_checks(meta)) is True
+
+    def test_hentai_keyword_fails(self, stc):
+        meta = {
+            "category": "TV",
+            "audio_languages": ["English"],
+            "subtitle_languages": [],
+            "is_disc": None,
+            "type": "WEBDL",
+            "debug": False,
+            "unattended": True,
+            "keywords": "hentai, adult animation",
+            "combined_genres": "Animation",
+        }
+        assert _run(stc.get_additional_checks(meta)) is False
+
 
 def test_approved_image_hosts() -> None:
     # Rules only ask for lossless thumbnails linking to full-size images;

--- a/tests/test_yus.py
+++ b/tests/test_yus.py
@@ -51,6 +51,18 @@ def _meta(**overrides: Any) -> dict[str, Any]:
 # ═══════════════════════════════════════════════════════════════
 
 
+class TestYUSAdultCheck:
+    """TMDB tags mainstream adult cartoons 'adult animation'; only hentai/porn markers block."""
+
+    def test_adult_animation_keyword_passes(self):
+        meta = _meta(keywords="adult animation, satire", combined_genres="Animation, Comedy")
+        assert _run(YUS(_config()).get_additional_checks(meta)) is True
+
+    def test_hentai_keyword_is_rejected(self):
+        meta = _meta(keywords="hentai, adult animation", combined_genres="Animation")
+        assert _run(YUS(_config()).get_additional_checks(meta)) is False
+
+
 class TestYUSNogroupRejection:
     """YUS has no policy for untagged releases — they must be rejected.
 


### PR DESCRIPTION
… porn

TMDB tags mainstream adult cartoons with 'adult animation', which made these trackers skip them unattended. Hentai/softcore/erotic markers still block. OTW keeps the keyword on purpose.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adult animation content is no longer incorrectly flagged as adult content by ACM, STC, and YUS validations.
  * Existing detection for hentai, softcore, porn, and JAV markers remains unchanged.

* **Tests**
  * Added coverage confirming adult animation is accepted where appropriate.
  * Added regression checks ensuring explicitly adult categories continue to be rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->