### PR TITLE
fix(TOS): transliterate accents in the release name instead of droppi…

### DIFF
--- a/src/trackers/TOS.py
+++ b/src/trackers/TOS.py
@@ -439,13 +439,8 @@ class TOS(FrenchTrackerMixin, UNIT3D):
         name = " ".join(name.split()) + tag
         # Normalise special codec notations before stripping
         name = name.replace("DTS:X", "DTS-X")
-        # Substitute known Unicode separators with ASCII hyphens
-        # (e.g. WALL·E → WALL-E, Spider‑Man → Spider-Man)
-        _TOS_CHAR_MAP = {**FrenchTrackerMixin._TITLE_CHAR_MAP, "\u00b7": "-", "\u2022": "-"}
-        for char, repl in _TOS_CHAR_MAP.items():
-            name = name.replace(char, repl)
-        # Allow alphanumeric, spaces, dots, hyphens, colons, and + (for DD+, HDR10+)
-        name = re.sub(r"[^a-zA-Z0-9 .+\-]", "", name)
+        # TOS keeps title-internal hyphens (WALL·E → WALL-E); the shared cleaning transliterates accents.
+        name = self._fr_clean(name.replace("\u00b7", "-").replace("\u2022", "-"))
         name = name.replace(" ", ".")
         name = re.sub(r"\.(-\.)+", ".", name)
         name = re.sub(r"\.{2,}", ".", name)

--- a/tests/test_tos.py
+++ b/tests/test_tos.py
@@ -332,6 +332,11 @@ class TestNogroupWebDL:
         name = self._get_name(_meta_nogroup(title='Bon Appétit, Votre Majesté', tag='-GRP'))
         assert name.startswith('Bon.Appetit.Votre.Majeste.'), name
 
+    def test_middle_dot_and_bullet_become_hyphen(self):
+        for title in ('WALL\u00b7E', 'WALL\u2022E'):
+            name = self._get_name(_meta_nogroup(title=title, tag='-GRP'))
+            assert name.startswith('WALL-E.'), name
+
     def test_real_group_preserved(self):
         """A real group tag must not be replaced by the notag label."""
         name = self._get_name(_meta_nogroup(tag='-FRiENDS'))

--- a/tests/test_tos.py
+++ b/tests/test_tos.py
@@ -327,6 +327,11 @@ class TestNogroupWebDL:
             f"Audio token 'AAC' duplicated in name: {name!r}."
         )
 
+    def test_accents_are_transliterated(self):
+        """Accented letters map to ASCII instead of being dropped (Appétit → Appetit)."""
+        name = self._get_name(_meta_nogroup(title='Bon Appétit, Votre Majesté', tag='-GRP'))
+        assert name.startswith('Bon.Appetit.Votre.Majeste.'), name
+
     def test_real_group_preserved(self):
         """A real group tag must not be replaced by the notag label."""
         name = self._get_name(_meta_nogroup(tag='-FRiENDS'))


### PR DESCRIPTION
…ng them

Reuses the French mixin's _fr_clean, as G3MINI does, so 'Appétit' becomes 'Appetit' rather than 'Apptit'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TOS release name handling by consistently converting accented characters to ASCII.
  * Standardized separator handling for more reliable generated names.

* **Tests**
  * Added coverage to verify accented characters are correctly transliterated in TOS release titles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->