### PR TITLE
fix: abort the uploads when the torrent client went offline mid-run

### DIFF
--- a/src/clients.py
+++ b/src/clients.py
@@ -192,23 +192,11 @@ class Clients(QbittorrentClientMixin, RtorrentClientMixin, DelugeClientMixin, Tr
 
         return tracker_ids
 
-    async def add_to_client(self, meta: dict[str, Any], tracker: str, cross: bool = False) -> None:
-        if cross:
-            torrent_path = f"{meta['base_dir']}/tmp/{meta['uuid']}/[{tracker}_cross].torrent"
-        elif meta["debug"]:
-            torrent_path = f"{meta['base_dir']}/tmp/{meta['uuid']}/[{tracker}_DEBUG].torrent"
-        else:
-            torrent_path = f"{meta['base_dir']}/tmp/{meta['uuid']}/[{tracker}].torrent"
-        if meta.get("no_seed", False) is True:
-            console.print("[bold red]--no-seed was passed, so the torrent will not be added to the client")
-            console.print("[bold yellow]Add torrent manually to the client")
-            return
-        if os.path.exists(torrent_path):
-            torrent = Torrent.read(torrent_path)
-        else:
-            console.print(f"[bold red]Torrent file {torrent_path} does not exist, cannot add to client")
-            return
+    def _inject_client_names(self, meta: dict[str, Any]) -> Optional[list[str]]:
+        """Client names a torrent gets injected into (meta client → injecting_client_list → default).
 
+        None means "meta client is 'none'": nothing to inject anywhere.
+        """
         inject_clients: list[str] = []
         client_value = meta.get("client")
         if isinstance(client_value, str) and client_value != "none":
@@ -218,7 +206,7 @@ class Clients(QbittorrentClientMixin, RtorrentClientMixin, DelugeClientMixin, Tr
         elif client_value == "none":
             if meta["debug"]:
                 console.print("[cyan]DEBUG: meta client is 'none', skipping adding to client[/cyan]")
-            return
+            return None
         else:
             try:
                 inject_clients_config = self.config["DEFAULT"].get("injecting_client_list")
@@ -253,6 +241,45 @@ class Clients(QbittorrentClientMixin, RtorrentClientMixin, DelugeClientMixin, Tr
         if meta["debug"]:
             console.print(f"[cyan]DEBUG: Clients to inject into: {inject_clients}[/cyan]")
 
+        return inject_clients
+
+    async def injection_clients_online(self, meta: dict[str, Any]) -> bool:
+        """Fresh (uncached) reachability probe of every qBittorrent client the upload will inject into.
+
+        The per-process health cache is filled at the start of the run; a client that
+        dies during screenshots would otherwise pass that cache and leave a live
+        tracker upload with nothing seeding it.
+        """
+        if meta.get("no_seed", False):
+            return True
+        for client_name in self._inject_client_names(meta) or []:
+            client = self.config["TORRENT_CLIENTS"].get(client_name)
+            if not client or client.get("torrent_client") != "qbit":
+                continue
+            if not await self._check_qbit_reachable(client):
+                return False
+        return True
+
+    async def add_to_client(self, meta: dict[str, Any], tracker: str, cross: bool = False) -> None:
+        if cross:
+            torrent_path = f"{meta['base_dir']}/tmp/{meta['uuid']}/[{tracker}_cross].torrent"
+        elif meta["debug"]:
+            torrent_path = f"{meta['base_dir']}/tmp/{meta['uuid']}/[{tracker}_DEBUG].torrent"
+        else:
+            torrent_path = f"{meta['base_dir']}/tmp/{meta['uuid']}/[{tracker}].torrent"
+        if meta.get("no_seed", False) is True:
+            console.print("[bold red]--no-seed was passed, so the torrent will not be added to the client")
+            console.print("[bold yellow]Add torrent manually to the client")
+            return
+        if os.path.exists(torrent_path):
+            torrent = Torrent.read(torrent_path)
+        else:
+            console.print(f"[bold red]Torrent file {torrent_path} does not exist, cannot add to client")
+            return
+
+        inject_clients = self._inject_client_names(meta)
+        if inject_clients is None:
+            return
         for client_name in inject_clients:
             if client_name == "none" or not client_name:
                 continue

--- a/tests/test_clients_injection_probe.py
+++ b/tests/test_clients_injection_probe.py
@@ -1,0 +1,52 @@
+"""Pre-upload client probe: a qBittorrent that died mid-run must block the uploads."""
+
+import asyncio
+from typing import Any
+
+from src.clients import Clients
+
+
+def _config(**defaults: Any) -> dict[str, Any]:
+    return {
+        "DEFAULT": {"default_torrent_client": "qbt", **defaults},
+        "TORRENT_CLIENTS": {
+            "qbt": {"torrent_client": "qbit", "qbit_url": "http://127.0.0.1", "qbit_port": 8080},
+            "rt": {"torrent_client": "rtorrent"},
+        },
+    }
+
+
+def _probe(clients: Clients, meta: dict[str, Any], reachable: bool) -> tuple[bool, list[str]]:
+    probed: list[str] = []
+
+    async def fake_check(client: dict[str, Any], **kwargs: Any) -> bool:
+        probed.append(client["torrent_client"])
+        return reachable
+
+    clients._check_qbit_reachable = fake_check  # type: ignore[method-assign]
+    return asyncio.run(clients.injection_clients_online(meta)), probed
+
+
+def test_inject_client_names_falls_back_to_default() -> None:
+    assert Clients(_config())._inject_client_names({"debug": False}) == ["qbt"]
+    assert Clients(_config(injecting_client_list=["rt", "qbt"]))._inject_client_names({"debug": False}) == ["rt", "qbt"]
+    assert Clients(_config())._inject_client_names({"debug": False, "client": "rt"}) == ["rt"]
+    assert Clients(_config())._inject_client_names({"debug": False, "client": "none"}) is None
+
+
+def test_offline_qbit_blocks_the_upload() -> None:
+    online, probed = _probe(Clients(_config()), {"debug": False}, reachable=False)
+    assert online is False
+    assert probed == ["qbit"]
+
+
+def test_only_qbit_clients_are_probed() -> None:
+    online, probed = _probe(Clients(_config(injecting_client_list=["rt"])), {"debug": False}, reachable=False)
+    assert online is True
+    assert probed == []
+
+
+def test_no_seed_skips_the_probe() -> None:
+    online, probed = _probe(Clients(_config()), {"debug": False, "no_seed": True}, reachable=False)
+    assert online is True
+    assert probed == []

--- a/upload.py
+++ b/upload.py
@@ -1971,6 +1971,13 @@ async def do_the_thing(base_dir: str) -> None:
             else:
                 meta = cast(Meta, meta)
                 console.print()
+                # A client that died since the start-of-run health check would leave
+                # live tracker uploads with nothing seeding them: re-probe right before uploading.
+                if not meta.get("debug") and not await client.injection_clients_online(meta):
+                    console.print("[bold red]qBittorrent went offline before the uploads started.")
+                    if meta.get("unattended") or not await asyncio.to_thread(cli_ui.ask_yes_no, "Upload anyway (torrents will not be seeded)?", default=False):
+                        console.print("[bold red]Upload process aborted: qBittorrent is offline.")
+                        return
                 console.print("[yellow]Processing uploads to trackers.....")
                 if meta.get("were_trumping", False):
                     trump_trackers = [t for t in cast(list[Any], meta.get("trackers", [])) if isinstance(t, str)]


### PR DESCRIPTION
The start-of-run health check is cached per process, so a qBittorrent that dies during screenshots still passed it and the run uploaded to the trackers, then failed every injection with 502 — live torrents with nothing seeding them. Re-probe the injecting qBittorrent clients right before the upload loop; unattended runs abort, interactive ones are asked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a pre-upload check for qBittorrent availability.
  * Uploads now respect configured injection clients and per-upload client settings.
  * Seeding-disabled uploads bypass client availability checks.

* **Bug Fixes**
  * Prevented unattended uploads from starting when the required qBittorrent client is offline.
  * Attended uploads now ask for confirmation before continuing without seeding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->