### PR TITLE
fix(bbcode): derive the pixhost thumbnail/full-size pair for reused i…

### DIFF
--- a/src/bbcode.py
+++ b/src/bbcode.py
@@ -36,6 +36,29 @@ from src.console import console
 # INDENT - Probably not an issue, but maybe just remove tags
 
 
+_PIXHOST_FULL = re.compile(r"^https?://img(\d+)\.pixhost\.to/images/")
+_PIXHOST_THUMB = re.compile(r"^https?://t(\d+)\.pixhost\.to/thumbs/")
+
+
+def image_entry(img_url: str, web_url: str = "") -> dict[str, str]:
+    """Image dict for a URL found in a description, with the host's thumbnail/full-size pair derived.
+
+    Descriptions often embed the full-size image; sites that do not scale [img]
+    (C411, V3X) then render it full width — or not at all. Only imgbox and pixhost
+    expose both forms through a predictable URL rewrite.
+    """
+    img_url = img_url.strip()
+    raw_url = img_url
+    host = urllib.parse.urlparse(img_url).hostname or ""
+    if host == "thumbs2.imgbox.com":
+        raw_url = img_url.replace("thumbs2.imgbox.com", "images2.imgbox.com").replace("_t.png", "_o.png")
+    elif _PIXHOST_FULL.match(img_url):
+        img_url = _PIXHOST_FULL.sub(r"https://t\1.pixhost.to/thumbs/", img_url)
+    elif _PIXHOST_THUMB.match(img_url):
+        raw_url = _PIXHOST_THUMB.sub(r"https://img\1.pixhost.to/images/", img_url)
+    return {"img_url": img_url, "raw_url": raw_url, "web_url": web_url.strip() or raw_url}
+
+
 class BBCODE:
     def __init__(self) -> None:
         pass
@@ -116,13 +139,7 @@ class BBCODE:
                 desc = desc.replace(f"[url={web_url}][img]{img_url}[/img][/url]", "")
                 continue
 
-            raw_url = img_url
-            if img_host == "thumbs2.imgbox.com":
-                raw_url = img_url.replace("thumbs2.imgbox.com", "images2.imgbox.com")
-                raw_url = raw_url.replace("_t.png", "_o.png")
-
-            image_dict = {"img_url": img_url, "raw_url": raw_url, "web_url": web_url}
-            imagelist.append(image_dict)
+            imagelist.append(image_entry(img_url, web_url))
             desc = desc.replace(f"[url={web_url}][img]{img_url}[/img][/url]", "")
 
         description = desc.strip()
@@ -163,8 +180,7 @@ class BBCODE:
         # Extract loose images and add to imagelist as dictionaries
         loose_images = re.findall(r"(https?:\/\/[^\s\[\]]+\.(?:png|jpg))", desc, flags=re.IGNORECASE)
         for img_url in loose_images:
-            image_dict = {"img_url": img_url, "raw_url": img_url, "web_url": img_url}
-            imagelist.append(image_dict)
+            imagelist.append(image_entry(img_url))
             desc = desc.replace(img_url, "")
 
         # Now, remove matching URLs from [URL] tags
@@ -376,8 +392,7 @@ class BBCODE:
         loose_images = re.findall(r"(https?:\/\/[^\s\[\]]+\.(?:png|jpg))", nocomp, flags=re.IGNORECASE)
         for img_url in loose_images:
             if img_url not in excluded_urls:  # Only include URLs not part of excluded sections
-                image_dict = {"img_url": img_url, "raw_url": img_url, "web_url": img_url}
-                imagelist.append(image_dict)
+                imagelist.append(image_entry(img_url))
                 desc = desc.replace(img_url, "")
 
         # Re-place comparisons
@@ -441,12 +456,7 @@ class BBCODE:
         url_img_pattern = r"\[url=(https?://[^\]]+)\]\[img[^\]]*\](.*?)\[/img\]\[/url\]"
         url_img_matches = re.findall(url_img_pattern, desc, flags=re.IGNORECASE)
         for web_url, img_url in url_img_matches:
-            image_dict = {
-                "img_url": img_url.strip(),
-                "raw_url": img_url.strip(),
-                "web_url": web_url.strip(),
-            }
-            imagelist.append(image_dict)
+            imagelist.append(image_entry(img_url, web_url))
             # Remove the entire [url=...][img]...[/img][/url] structure
             desc = re.sub(rf"\[url={re.escape(web_url)}\]\[img[^\]]*\]{re.escape(img_url)}\[/img\]\[/url\]", "", desc, flags=re.IGNORECASE)
 
@@ -456,13 +466,8 @@ class BBCODE:
             for img_url in img_tags:
                 img_url = img_url.strip()
                 # Check if this image was already added (wrapped in URL)
-                if not any(img["img_url"] == img_url for img in imagelist):
-                    image_dict = {
-                        "img_url": img_url,
-                        "raw_url": img_url,
-                        "web_url": img_url,
-                    }
-                    imagelist.append(image_dict)
+                if not any(img_url in (img["img_url"], img["raw_url"]) for img in imagelist):
+                    imagelist.append(image_entry(img_url))
                 # Remove the [img] tag
                 desc = re.sub(rf"\[img[^\]]*\]{re.escape(img_url)}\[/img\]", "", desc, flags=re.IGNORECASE)
 
@@ -474,7 +479,8 @@ class BBCODE:
             "https://ptpimg.me/606tk4.png",
             # Add any other known bot image URLs here
         ]
-        imagelist = [img for img in imagelist if img["img_url"] not in bot_image_urls and not re.search(r"thumbs", img["img_url"], re.IGNORECASE)]
+        # A thumbnail with no full-size counterpart cannot be reused as a screenshot.
+        imagelist = [img for img in imagelist if img["img_url"] not in bot_image_urls and not re.search(r"thumbs", img["raw_url"], re.IGNORECASE)]
         # ptpimg.me is dead: its images (flags, icons, screenshots) must not
         # be reused as if they were live screenshots
         imagelist = [img for img in imagelist if "ptpimg.me" not in str(img.get("raw_url", ""))]

--- a/tests/test_bbcode_image_entry.py
+++ b/tests/test_bbcode_image_entry.py
@@ -1,0 +1,31 @@
+"""Images reused from an existing description carry a thumbnail/full-size pair when the host allows deriving it."""
+
+from src.bbcode import BBCODE, image_entry
+
+FULL = "https://img90.pixhost.to/images/376/1_file.png"
+THUMB = "https://t90.pixhost.to/thumbs/376/1_file.png"
+PAGE = "https://pixhost.to/show/376/1_file.png"
+
+
+def test_pixhost_full_size_gets_its_thumbnail() -> None:
+    assert image_entry(FULL, PAGE) == {"img_url": THUMB, "raw_url": FULL, "web_url": PAGE}
+
+
+def test_pixhost_thumbnail_gets_its_full_size() -> None:
+    assert image_entry(THUMB, PAGE) == {"img_url": THUMB, "raw_url": FULL, "web_url": PAGE}
+
+
+def test_imgbox_thumbnail_gets_its_full_size() -> None:
+    entry = image_entry("https://thumbs2.imgbox.com/ab/cd/XXXX_t.png", "https://imgbox.com/XXXX")
+    assert entry["raw_url"] == "https://images2.imgbox.com/ab/cd/XXXX_o.png"
+
+
+def test_unknown_host_is_left_alone() -> None:
+    url = "https://example.org/shot.png"
+    assert image_entry(url) == {"img_url": url, "raw_url": url, "web_url": url}
+
+
+def test_unit3d_description_keeps_pixhost_pairs_and_drops_bare_thumbnails() -> None:
+    desc = f"[url={PAGE}][img]{FULL}[/img][/url] [url=https://other.host/x][img]https://other.host/thumbs/x_t.png[/img][/url]"
+    _, images = BBCODE().clean_unit3d_description(desc, "https://example-tracker.org")
+    assert images == [{"img_url": THUMB, "raw_url": FULL, "web_url": PAGE}]


### PR DESCRIPTION
…mages

Descriptions grabbed from other trackers often embed the full-size img*.pixhost.to URL; it was kept as img_url, so C411 (which filters such sources) showed nothing and V3X rendered it full width. A single image_entry() helper now builds every image dict, deriving the pixhost thumbnail from the full size (and vice versa) like the existing imgbox rewrite. The thumbnail filter checks raw_url so derived pairs survive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image handling for Pixhost and Imgbox links by pairing thumbnails with full-size images.
  * Prevented unsupported bare thumbnails from appearing in extracted image results.
  * Improved duplicate detection and filtering across supported image hosts.

* **Tests**
  * Added coverage for image URL normalization, thumbnail/full-size pairing, unknown hosts, and Unit3D image extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->