### PR TITLE
fix(COMMON): retry the post-upload .torrent download

### DIFF
--- a/src/trackers/COMMON.py
+++ b/src/trackers/COMMON.py
@@ -222,15 +222,27 @@ class COMMON:
         path = f"{meta['base_dir']}/tmp/{meta['uuid']}/[{tracker}_cross].torrent" if cross else f"{meta['base_dir']}/tmp/{meta['uuid']}/[{tracker}].torrent"
         if downurl:
             try:
-                async with httpx.AsyncClient(headers=headers, params=params, timeout=30.0, follow_redirects=True) as session, session.stream("GET", downurl) as r:
-                    r.raise_for_status()
-                    content_type = r.headers.get("content-type", "")
-                    if "text/html" in content_type:
-                        console.print("[yellow]Warning: Torrent download returned HTML instead of a torrent file (possible auth/redirect issue).[/yellow]")
-                        return None
-                    async with aiofiles.open(path, "wb") as f:
-                        async for chunk in r.aiter_bytes():
-                            await f.write(chunk)
+                # The upload already went through: a transient network failure here
+                # would leave a live torrent with nothing seeding it, so retry a few
+                # times with enough spacing to outlast a short connectivity blip.
+                for attempt in range(4):
+                    if attempt:
+                        console.print(f"[yellow]Torrent download failed, retrying in 10s… (attempt {attempt + 1}/4)[/yellow]")
+                        await asyncio.sleep(10)
+                    try:
+                        async with httpx.AsyncClient(headers=headers, params=params, timeout=30.0, follow_redirects=True) as session, session.stream("GET", downurl) as r:
+                            r.raise_for_status()
+                            content_type = r.headers.get("content-type", "")
+                            if "text/html" in content_type:
+                                console.print("[yellow]Warning: Torrent download returned HTML instead of a torrent file (possible auth/redirect issue).[/yellow]")
+                                return None
+                            async with aiofiles.open(path, "wb") as f:
+                                async for chunk in r.aiter_bytes():
+                                    await f.write(chunk)
+                        break
+                    except (httpx.TransportError, httpx.HTTPStatusError):
+                        if attempt == 3:
+                            raise
 
                 if cross:
                     return None

--- a/tests/test_torrent_download_retry.py
+++ b/tests/test_torrent_download_retry.py
@@ -1,0 +1,69 @@
+"""The post-upload .torrent download survives a short network window instead of leaving an orphan upload."""
+
+import asyncio
+from typing import Any
+
+import httpx
+import pytest
+
+import src.trackers.COMMON as common_module
+from src.trackers.COMMON import COMMON
+
+
+def _common(monkeypatch: Any, responses: list[Any]) -> tuple[COMMON, list[int]]:
+    calls: list[int] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(1)
+        outcome = responses[len(calls) - 1]
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+    real_client = httpx.AsyncClient
+
+    def client(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+        kwargs.pop("transport", None)
+        return real_client(*args, transport=httpx.MockTransport(handler), **kwargs)
+
+    async def no_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(common_module.httpx, "AsyncClient", client)
+    monkeypatch.setattr(common_module.asyncio, "sleep", no_sleep)
+    return COMMON(config={"DEFAULT": {}, "TRACKERS": {}}), calls
+
+
+def _meta(tmp_path: Any) -> dict[str, Any]:
+    (tmp_path / "tmp" / "x").mkdir(parents=True)
+    return {"base_dir": str(tmp_path), "uuid": "x"}
+
+
+def test_transient_failure_is_retried(monkeypatch: Any, tmp_path: Any) -> None:
+    ok = httpx.Response(200, content=b"d8:announce0:e", headers={"content-type": "application/x-bittorrent"})
+    common, calls = _common(monkeypatch, [httpx.ConnectError("wrong version number"), httpx.ConnectError("wrong version number"), ok])
+    asyncio.run(common.download_tracker_torrent(_meta(tmp_path), "GRP", downurl="https://example-tracker.org/download/1"))
+    assert len(calls) == 3
+    assert (tmp_path / "tmp" / "x" / "[GRP].torrent").read_bytes() == b"d8:announce0:e"
+
+
+def test_persistent_failure_gives_up_after_four_attempts(monkeypatch: Any, tmp_path: Any) -> None:
+    common, calls = _common(monkeypatch, [httpx.ConnectError("down")] * 4)
+    assert asyncio.run(common.download_tracker_torrent(_meta(tmp_path), "GRP", downurl="https://example-tracker.org/download/1")) is None
+    assert len(calls) == 4
+    assert not (tmp_path / "tmp" / "x" / "[GRP].torrent").exists()
+
+
+def test_html_answer_is_not_retried(monkeypatch: Any, tmp_path: Any) -> None:
+    html = httpx.Response(200, content=b"<html>login</html>", headers={"content-type": "text/html"})
+    common, calls = _common(monkeypatch, [html])
+    assert asyncio.run(common.download_tracker_torrent(_meta(tmp_path), "GRP", downurl="https://example-tracker.org/download/1")) is None
+    assert len(calls) == 1
+
+
+@pytest.mark.parametrize("status", [500, 502])
+def test_server_errors_are_retried(monkeypatch: Any, tmp_path: Any, status: int) -> None:
+    ok = httpx.Response(200, content=b"d8:announce0:e", headers={"content-type": "application/x-bittorrent"})
+    common, calls = _common(monkeypatch, [httpx.Response(status), ok])
+    asyncio.run(common.download_tracker_torrent(_meta(tmp_path), "GRP", downurl="https://example-tracker.org/download/1"))
+    assert len(calls) == 2


### PR DESCRIPTION
A transient network failure here leaves a live tracker upload with nothing seeding it. Retry up to four times, 10 s apart, on transport and HTTP errors; an HTML answer (auth/redirect) still fails at once.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Torrent downloads now automatically retry up to four times after connection failures or server errors.
  * Downloads wait briefly between retry attempts and stop retrying after the final failure.
  * Invalid HTML responses continue to be rejected without unnecessary retries.

* **Tests**
  * Added coverage for transient failures, persistent failures, server errors, and invalid responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->