### PR TITLE
fix(C411): only approve image hosts the site's hostname whitelist alw…

### DIFF
--- a/src/trackers/C411.py
+++ b/src/trackers/C411.py
@@ -51,9 +51,13 @@ class C411(FrenchTrackerMixin):
         self.upload_url: str = "https://c411.org/api/torrents"
         self.torrent_url: str = "https://c411.org/torrents/"
         self.api_key: str = str(self.config["TRACKERS"].get(self.tracker, {}).get("api_key", "")).strip()
-        # Hosts verified to actually render on the site; other common hosts
-        # (ptscreens, lostimg) come out as dead images there.
-        self.approved_image_hosts = ["pixhost", "imgbb", "onlyimage", "imgbox", "postimg"]
+        # The site's front-end only renders images from a fixed hostname
+        # whitelist. pixhost is whitelisted for servers 0-3 only while pixhost
+        # picks the storage server per upload, and imgbox thumbnail hostnames
+        # are not whitelisted at all, so both randomly come out as dead
+        # images; keep only hosts whose hostnames are always whitelisted
+        # (i.ibb.co, img.onlyimage.org, i.postimg.cc).
+        self.approved_image_hosts = ["imgbb", "onlyimage", "postimg"]
         self.tmdb_manager = TmdbManager(config)
         _reserved_note = "Internal C411 group: reserved for the team's own uploads"
         self.banned_groups: list[Any] = ["k0RE"] + [

--- a/tests/test_c411.py
+++ b/tests/test_c411.py
@@ -1430,6 +1430,12 @@ class TestDescription:
     def test_postimg_is_an_approved_host(self):
         assert 'postimg' in C411(_config()).approved_image_hosts
 
+    def test_approved_hosts_match_site_hostname_whitelist(self):
+        # The site whitelists exact hostnames: pixhost only on servers 0-3
+        # and imgbox thumbnails not at all, so neither may be approved.
+        approved = C411(_config()).approved_image_hosts
+        assert approved == ['imgbb', 'onlyimage', 'postimg']
+
     def test_screenshots_excluded_by_default(self):
         meta = _meta_base(image_list=[
             {'raw_url': 'https://img.host/1.png', 'web_url': 'https://img.host/view/1'},


### PR DESCRIPTION
…ays renders

The site's front-end renders images from a fixed hostname whitelist: pixhost is whitelisted for servers 0-3 only while pixhost picks the storage server per upload, and imgbox thumbnail hostnames are not whitelisted at all, so reused or freshly uploaded images on those hosts passed the slug-level approval check yet randomly rendered as dead images. Keep only imgbb, onlyimage and postimg, whose hostnames are always whitelisted; non-approved reused images now get rehosted by the existing per-tracker validation flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Restricted approved image hosts to Imgbb, OnlyImage, and Postimg.
  - Removed Pixhost and Imgbox from the approved host list.

- **Tests**
  - Added regression coverage to verify the approved image-host list remains accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->