### PR TITLE
fix(V3X): embed full-size postimg images instead of 180px thumbnails

### DIFF
--- a/src/trackers/V3X.py
+++ b/src/trackers/V3X.py
@@ -29,6 +29,7 @@ import contextlib
 import os
 import re
 from typing import Any, Optional
+from urllib.parse import urlparse
 
 import aiofiles
 import defusedxml.ElementTree as ET
@@ -38,6 +39,7 @@ from unidecode import unidecode
 
 from src.console import console
 from src.get_desc import DescriptionBuilder
+from src.imagehosts import host_slug
 from src.nfo_generator import decode_nfo, is_multi_episode_nfo
 from src.tmdb import TmdbManager
 from src.trackers.COMMON import COMMON
@@ -542,11 +544,16 @@ class V3X(FrenchTrackerMixin):
         image_list = meta.get(f"{self.tracker}_images_key") or meta.get("image_list") or []
         if image_list and self.config["TRACKERS"].get(self.tracker, {}).get("include_screenshots", True):
             parts.append(f"[b][color={C}][size=130]━━━ Captures d'écran ━━━[/size][/color][/b]")
-            thumbs = [
-                f"[url={img.get('web_url') or img.get('raw_url', '')}][img]{img.get('img_url') or img.get('raw_url', '')}[/img][/url]"
-                for img in image_list
-                if img.get("img_url") or img.get("raw_url")
-            ]
+            thumbs: list[str] = []
+            for img in image_list:
+                thumb = img.get("img_url") or img.get("raw_url", "")
+                if not thumb:
+                    continue
+                # postimg thumbnails are 180px, too small to judge a capture:
+                # embed its stored (already downscaled) image instead.
+                if host_slug(urlparse(thumb).hostname or "") == "postimg":
+                    thumb = img.get("raw_url", "") or thumb
+                thumbs.append(f"[url={img.get('web_url') or img.get('raw_url', '')}][img]{thumb}[/img][/url]")
             parts.extend(" ".join(thumbs[i : i + 2]) for i in range(0, len(thumbs), 2))
 
         parts.append("[/center]")

--- a/tests/test_v3x.py
+++ b/tests/test_v3x.py
@@ -389,6 +389,21 @@ class TestDescription:
         assert desc.index("━━━ Release ━━━") < desc.index("━━━ Captures d'écran ━━━")
         assert "[url=https://github.com/yippee0903/Upload-Assistant]" in desc  # linked signature
 
+    def test_postimg_screenshots_embed_full_size(self, monkeypatch: Any, tmp_path: Any):
+        # postimg thumbnails are 180px: the stored full-size image is embedded instead
+        tracker = self._tracker(monkeypatch, localized=None)
+        meta = {
+            "base_dir": str(tmp_path),
+            "uuid": "Some.Movie.2024.2160p.WEB-GRP",
+            "overview": "Fallback.",
+            "image_list": [
+                {"img_url": "https://i.postimg.cc/t1/x.png", "raw_url": "https://i.postimg.cc/r1/x.png", "web_url": "https://postimg.cc/p1"},
+            ],
+        }
+        desc = asyncio.run(tracker._build_description(meta))
+        assert "[url=https://postimg.cc/p1][img]https://i.postimg.cc/r1/x.png[/img][/url]" in desc
+        assert "https://i.postimg.cc/t1/x.png" not in desc
+
     def test_description_survives_missing_data(self, monkeypatch: Any, tmp_path: Any):
         tracker = self._tracker(monkeypatch, localized=None)
         desc = asyncio.run(tracker._build_description({"base_dir": str(tmp_path), "uuid": "x", "overview": "Fallback only."}))


### PR DESCRIPTION
The V3X parser only understands a bare [img] tag, so the rendered size is whatever the embedded URL serves. postimg thumbnails are 180px, too small to judge a capture; mirror the existing C411 special case and embed postimg's stored (already downscaled) image instead.